### PR TITLE
feat(node): allow pre-samples-test.sh hook

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
@@ -24,6 +24,11 @@ export GCLOUD_PROJECT=long-door-651
 
 cd $(dirname $0)/..
 
+# Run a pre-test hook, if a pre-samples-test.sh is in the project
+if [ -f .kokoro/pre-samples-test.sh ]; then
+    . .kokoro/pre-samples-test.sh
+fi
+
 npm install
 
 # Install and link samples


### PR DESCRIPTION
We are already adopting this pattern on system-tests and now we want to set up some environment variables before samples tests are run for DLP.