### PR TITLE
Remove nox-automation uninstall from build.sh

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -21,15 +21,8 @@ cd github/synthtool
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 
-# Remove old nox.
-python3 -m pip uninstall --yes --quiet nox-automation
-
-# Install nox.
-python3 -m pip install --upgrade --quiet nox
-python3 -m nox --version
-
 # Run tests
-python3 -m nox -s lint test
+nox -s lint test
 
 # remove all files, preventing kokoro from trying to sync them.
 rm -rf *


### PR DESCRIPTION
The correct nox is now installed in the python docker image.