### PR TITLE
fix(node): remove define_artifacts from Node.js's Windows kokoro build

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/presubmit/windows/common.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/presubmit/windows/common.cfg
@@ -1,9 +1,2 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Build logs will be here
-action {
-  define_artifacts {
-    regex: "**/*sponge_log.xml"
-  }
-}
-


### PR DESCRIPTION
We are not dumping test results to `sponge.xml` and it was causing issues when Kokoro tries to pull it from the VM.