### PR TITLE
fix: make npm link work for system tests

### DIFF
--- a/synthtool/gcp/templates/node_library/.circleci/config.yml
+++ b/synthtool/gcp/templates/node_library/.circleci/config.yml
@@ -159,7 +159,8 @@ jobs:
           command: npm run system-test
           environment:
             GCLOUD_PROJECT: {{ test_project or 'long-door-651' }}
-            GOOGLE_APPLICATION_CREDENTIALS: .circleci/key.json
+            GOOGLE_APPLICATION_CREDENTIALS: /home/node/project/.circleci/key.json
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
           name: Remove unencrypted key.
           command: |


### PR DESCRIPTION
I need `npm link` in system tests for gax. It does not change any behavior for other libraries.
Context: https://github.com/googleapis/gax-nodejs/pull/334