### PR TITLE
Show stdout for docker pull

### DIFF
--- a/synthtool/gcp/artman.py
+++ b/synthtool/gcp/artman.py
@@ -93,4 +93,6 @@ class Artman:
 
     def _install_artman(self):
         log.debug("Pulling artman image.")
-        shell.run(["docker", "pull", f"googleapis/artman:{ARTMAN_VERSION}"])
+        shell.run(
+            ["docker", "pull", f"googleapis/artman:{ARTMAN_VERSION}"], hide_output=False
+        )

--- a/synthtool/shell.py
+++ b/synthtool/shell.py
@@ -17,11 +17,16 @@ import subprocess
 from synthtool import log
 
 
-def run(args, *, cwd=None, check=True):
+def run(args, *, cwd=None, check=True, hide_output=True):
+    if hide_output:
+        stdout = subprocess.PIPE
+    else:
+        stdout = None
+
     try:
         return subprocess.run(
             args,
-            stdout=subprocess.PIPE,
+            stdout=stdout,
             stderr=subprocess.STDOUT,
             cwd=cwd,
             check=check,


### PR DESCRIPTION
Closes #118. 

I wasn't sure whether to show `stdout` for _only_ docker pull or every time the `run` function is called.