### PR TITLE
Add initial python templates

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -25,7 +25,7 @@ class CommonTemplates:
     def __init__(self):
         self._templates = templates.Templates(_TEMPLATES_DIR)
 
-    def py_library(self) -> Path:
+    def py_library(self, **kwargs) -> Path:
         t = templates.TemplateGroup(_TEMPLATES_DIR / "python_library")
         result = t.render(**kwargs)
         _tracked_paths.add(result)

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -26,7 +26,10 @@ class CommonTemplates:
         self._templates = templates.Templates(_TEMPLATES_DIR)
 
     def py_library(self) -> Path:
-        raise NotImplementedError()
+        t = templates.TemplateGroup(_TEMPLATES_DIR / "python_library")
+        result = t.render(**kwargs)
+        _tracked_paths.add(result)
+        return result
 
     def node_library(self, **kwargs) -> Path:
         kwargs["metadata"] = node.read_metadata()

--- a/synthtool/gcp/templates/python_library/.flake8
+++ b/synthtool/gcp/templates/python_library/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+exclude =
+  # Exclude generated code.
+  **/proto/**
+  **/gapic/**
+  *_pb2.py
+
+  # Standard linting exemptions.
+  __pycache__,
+  .git,
+  *.pyc,
+  conf.py

--- a/synthtool/gcp/templates/python_library/MANIFEST.in
+++ b/synthtool/gcp/templates/python_library/MANIFEST.in
@@ -1,0 +1,5 @@
+include README.rst LICENSE
+recursive-include google *.json *.proto
+recursive-include tests *
+global-exclude *.py[co]
+global-exclude __pycache__

--- a/synthtool/gcp/templates/python_library/setup.cfg
+++ b/synthtool/gcp/templates/python_library/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
See #94 

* The .flake8 files look like the template here, with the exception of [api_core](https://github.com/googleapis/google-cloud-python/blob/0e2c54ce54909467b202a73f04fc3aa4a29a749b/api_core/.flake8) and [core](https://github.com/googleapis/google-cloud-python/blob/0e2c54ce54909467b202a73f04fc3aa4a29a749b/core/.flake8).
* The _majority_ of `MANIFEST.in` files look like the template. These are the exceptions.
  * [api_core/MANIFEST.in](https://github.com/googleapis/google-cloud-python/blob/0e2c54ce54909467b202a73f04fc3aa4a29a749b/api_core/MANIFEST.in)
  * [core/MANIFEST.in](https://github.com/googleapis/google-cloud-python/blob/0e2c54ce54909467b202a73f04fc3aa4a29a749b/core/MANIFEST.in)
   * [bigquery/MANIFEST.in](https://github.com/googleapis/google-cloud-python/blob/0e2c54ce54909467b202a73f04fc3aa4a29a749b/bigquery/MANIFEST.in)
   * [spanner/MANIFEST.in ](https://github.com/googleapis/google-cloud-python/blob/55d11b97f44079ec590c5805952f0735452c6ce8/spanner/MANIFEST.in)
* The `setup.cfg` files look like the template here, with the exception of [api_core](https://github.com/googleapis/google-cloud-python/blob/65d6ebae84aa8f92f1730a08929b029cf12e63b8/api_core/setup.cfg)
