### PR TITLE
Lazily clone googleapis{-private}

### DIFF
--- a/synthtool/__main__.py
+++ b/synthtool/__main__.py
@@ -36,5 +36,5 @@ def main(synthfile):
         log.exception(f"{synth_file} not found.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/synthtool/__main__.py
+++ b/synthtool/__main__.py
@@ -34,3 +34,7 @@ def main(synthfile):
         spec.loader.exec_module(synth_module)
     else:
         log.exception(f"{synth_file} not found.")
+
+
+if __name__ == '__main__':
+    main()

--- a/synthtool/gcp/gapic_generator.py
+++ b/synthtool/gcp/gapic_generator.py
@@ -14,6 +14,7 @@
 
 import os
 from pathlib import Path
+from typing import Optional
 
 from synthtool import _tracked_paths
 from synthtool import log
@@ -22,7 +23,7 @@ from synthtool.sources import git
 
 GOOGLEAPIS_URL: str = git.make_repo_clone_url("googleapis/googleapis")
 GOOGLEAPIS_PRIVATE_URL: str = git.make_repo_clone_url("googleapis/googleapis-private")
-LOCAL_GOOGLEAPIS: str = os.environ.get("SYNTHTOOL_GOOGLEAPIS")
+LOCAL_GOOGLEAPIS: Optional[str] = os.environ.get("SYNTHTOOL_GOOGLEAPIS")
 
 
 class GAPICGenerator:

--- a/synthtool/gcp/gapic_generator.py
+++ b/synthtool/gcp/gapic_generator.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import subprocess
 from pathlib import Path
 
 from synthtool import _tracked_paths
@@ -151,7 +150,9 @@ class GAPICGenerator:
 
         if self.local_googleapis:
             self._googleapis_private = Path(LOCAL_GOOGLEAPIS).expanduser()
-            log.debug(f"Using local googleapis at {self._googleapis_private} for googleapis-private")
+            log.debug(
+                f"Using local googleapis at {self._googleapis_private} for googleapis-private"
+            )
 
         else:
             log.debug("Cloning googleapis-private.")


### PR DESCRIPTION
This has two benefits:

1. speeds things up a bit if googleapis-private isn't used.
2. makes the metadata file only contain googleapis-private if it's actually used.