### PR TITLE
Warn when running the synthesis script directly

### DIFF
--- a/synthtool/__init__.py
+++ b/synthtool/__init__.py
@@ -14,6 +14,8 @@
 
 """Synthtool synthesizes libraries from disparate sources."""
 
+import sys
+
 from synthtool.transforms import move, replace
 from synthtool import log
 from synthtool import update_check
@@ -21,6 +23,14 @@ from synthtool import update_check
 copy = move
 
 __all__ = ["copy", "move", "replace"]
+
+# Make sure that synthtool is being used instead of running the synth file
+# directly
+_main_module = sys.modules["__main__"]
+if hasattr(_main_module, "__file__") and "synthtool" not in _main_module.__file__:
+    log.critical(
+        "You are running the synthesis script directly, this will be disabled in a future release of Synthtool. Please use python3 -m synthtool instead."
+    )
 
 # check for updates, if needed.
 update_check.check_for_updates("gcp-synthtool", print=log.critical)


### PR DESCRIPTION
Towards #130.

We can't outright disable this yet, as autosynth uses the direct execution method and the elixir and java apiary client expect to have access to `sys.argv`.