### PR TITLE
Add ability to format java code with a custom google-java-format version

### DIFF
--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -39,7 +39,7 @@ def format_code(path: str, version: str = DEFAULT_FORMAT_VERSION) -> None:
 
     # Run the formatter as a jar file
     log.info("Running java formatter on {} files".format(len(files)))
-    shell.run(["java", "-jar", jar, "--replace"] + files)
+    shell.run(["java", "-jar", str(jar), "--replace"] + files)
 
 
 def _download_formatter(version: str, dest: Path) -> None:

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -1,0 +1,48 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from synthtool import cache
+from synthtool import log
+from synthtool import shell
+from pathlib import Path
+from typing import List
+
+def format_code(path: str, version: str = "1.6") -> None:
+    """
+    Runs the google-java-format jar against all .java files found within the
+    provided path.
+    """
+    jar_name = f"google-java-format-{version}.jar"
+    jar = cache.get_cache_dir() / jar_name
+    if not jar.exists():
+        _download_formatter(version, jar)
+
+    # Find all .java files in path and run the formatter on them
+    files = _find_files(path)
+
+    # Run the formatter as a jar file
+    log.info("Running java formatter on {} files".format(len(files)))
+    shell.run(["java", "-jar", jar, "--replace"] + files)
+
+def _download_formatter(version: str, dest: Path) -> None:
+    url = f"https://github.com/google/google-java-format/releases/download/google-java-format-{version}/google-java-format-{version}-all-deps.jar"
+    log.info("Downloading java formatter")
+    shell.run(["curl", "-L", "-o", dest, url], hide_output=False)
+
+def _find_files(basedir: str, suffix: str = ".java") -> List[str]:
+    return [os.path.join(root, name)
+            for root, _dirs, files in os.walk(basedir)
+            for name in files
+            if name.endswith(suffix)]

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
 import os
 from synthtool import cache
 from synthtool import log
 from synthtool import shell
 from pathlib import Path
-from typing import List
 
 
 def format_code(path: str, version: str = "1.6") -> None:
@@ -31,7 +31,8 @@ def format_code(path: str, version: str = "1.6") -> None:
         _download_formatter(version, jar)
 
     # Find all .java files in path and run the formatter on them
-    files = _find_files(path)
+    log.info("Looking for java files in {}".format(os.path.join(path, "**/*.java")))
+    files = list(glob.iglob(os.path.join(path, "**/*.java"), recursive=True))
 
     # Run the formatter as a jar file
     log.info("Running java formatter on {} files".format(len(files)))
@@ -42,12 +43,3 @@ def _download_formatter(version: str, dest: Path) -> None:
     url = f"https://github.com/google/google-java-format/releases/download/google-java-format-{version}/google-java-format-{version}-all-deps.jar"
     log.info("Downloading java formatter")
     shell.run(["curl", "-L", "-o", dest, url], hide_output=False)
-
-
-def _find_files(basedir: str, suffix: str = ".java") -> List[str]:
-    return [
-        os.path.join(root, name)
-        for root, _dirs, files in os.walk(basedir)
-        for name in files
-        if name.endswith(suffix)
-    ]

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -19,6 +19,7 @@ from synthtool import shell
 from pathlib import Path
 from typing import List
 
+
 def format_code(path: str, version: str = "1.6") -> None:
     """
     Runs the google-java-format jar against all .java files found within the
@@ -36,13 +37,17 @@ def format_code(path: str, version: str = "1.6") -> None:
     log.info("Running java formatter on {} files".format(len(files)))
     shell.run(["java", "-jar", jar, "--replace"] + files)
 
+
 def _download_formatter(version: str, dest: Path) -> None:
     url = f"https://github.com/google/google-java-format/releases/download/google-java-format-{version}/google-java-format-{version}-all-deps.jar"
     log.info("Downloading java formatter")
     shell.run(["curl", "-L", "-o", dest, url], hide_output=False)
 
+
 def _find_files(basedir: str, suffix: str = ".java") -> List[str]:
-    return [os.path.join(root, name)
-            for root, _dirs, files in os.walk(basedir)
-            for name in files
-            if name.endswith(suffix)]
+    return [
+        os.path.join(root, name)
+        for root, _dirs, files in os.walk(basedir)
+        for name in files
+        if name.endswith(suffix)
+    ]

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -14,6 +14,7 @@
 
 import glob
 import os
+import requests
 from synthtool import cache
 from synthtool import log
 from synthtool import shell
@@ -40,6 +41,9 @@ def format_code(path: str, version: str = "1.6") -> None:
 
 
 def _download_formatter(version: str, dest: Path) -> None:
-    url = f"https://github.com/google/google-java-format/releases/download/google-java-format-{version}/google-java-format-{version}-all-deps.jar"
     log.info("Downloading java formatter")
-    shell.run(["curl", "-L", "-o", dest, url], hide_output=False)
+    url = f"https://github.com/google/google-java-format/releases/download/google-java-format-{version}/google-java-format-{version}-all-deps.jar"
+    response = requests.get(url)
+    response.raise_for_status()
+    with open(dest, "wb") as fh:
+        fh.write(response.content)

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -20,8 +20,11 @@ from synthtool import log
 from synthtool import shell
 from pathlib import Path
 
+JAR_DOWNLOAD_URL = "https://github.com/google/google-java-format/releases/download/google-java-format-{version}/google-java-format-{version}-all-deps.jar"
+DEFAULT_FORMAT_VERSION = "1.6"
 
-def format_code(path: str, version: str = "1.6") -> None:
+
+def format_code(path: str, version: str = DEFAULT_FORMAT_VERSION) -> None:
     """
     Runs the google-java-format jar against all .java files found within the
     provided path.
@@ -32,7 +35,6 @@ def format_code(path: str, version: str = "1.6") -> None:
         _download_formatter(version, jar)
 
     # Find all .java files in path and run the formatter on them
-    log.info("Looking for java files in {}".format(os.path.join(path, "**/*.java")))
     files = list(glob.iglob(os.path.join(path, "**/*.java"), recursive=True))
 
     # Run the formatter as a jar file
@@ -42,7 +44,7 @@ def format_code(path: str, version: str = "1.6") -> None:
 
 def _download_formatter(version: str, dest: Path) -> None:
     log.info("Downloading java formatter")
-    url = f"https://github.com/google/google-java-format/releases/download/google-java-format-{version}/google-java-format-{version}-all-deps.jar"
+    url = JAR_DOWNLOAD_URL.format(version=version)
     response = requests.get(url)
     response.raise_for_status()
     with open(dest, "wb") as fh:


### PR DESCRIPTION
Usage would be something like:

```python
import synthtool.languages.java as java

# ... do some codegen into ./src
java.format_code("./src")
```

Note the gapic-generator does run version 1.1 of the Google java formatter and this one defaults to 1.6 (most up to date). We can update the one in gapic, but we'd also like the ability to run this on our apiary libraries too.