### PR TITLE
Update python templates

### DIFF
--- a/synthtool/gcp/templates/python_library/.coveragerc
+++ b/synthtool/gcp/templates/python_library/.coveragerc
@@ -1,0 +1,17 @@
+[run]
+branch = True
+
+[report]
+fail_under = 100
+show_missing = True
+exclude_lines =
+    # Re-enable the standard pragma
+    pragma: NO COVER
+    # Ignore debug-only repr
+    def __repr__
+    # Ignore abstract methods
+    raise NotImplementedError
+omit =
+  */gapic/*.py
+  */proto/*.py
+

--- a/synthtool/gcp/templates/python_library/.coveragerc
+++ b/synthtool/gcp/templates/python_library/.coveragerc
@@ -14,4 +14,4 @@ exclude_lines =
 omit =
   */gapic/*.py
   */proto/*.py
-
+  */google-cloud-python/core/google/cloud/*.py

--- a/synthtool/gcp/templates/python_library/.coveragerc
+++ b/synthtool/gcp/templates/python_library/.coveragerc
@@ -14,4 +14,5 @@ exclude_lines =
 omit =
   */gapic/*.py
   */proto/*.py
-  */google-cloud-python/core/google/cloud/*.py
+  */google-cloud-python/core/*.py
+  */site-packages/*.py

--- a/synthtool/gcp/templates/python_library/.flake8
+++ b/synthtool/gcp/templates/python_library/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+ignore = E203, E266, E501, W503
 exclude =
   # Exclude generated code.
   **/proto/**

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -47,7 +47,6 @@ def lint(session):
     serious code quality issues.
     """
     session.install("flake8", "black", *LOCAL_DEPS)
-    session.install(".")
     session.run(
         "black",
         "--check",

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -22,6 +22,50 @@ import nox
 
 LOCAL_DEPS = (os.path.join("..", "api_core"), os.path.join("..", "core"))
 
+@nox.session(python="3.7")
+def blacken(session):
+    """Run black.
+
+    Format code to uniform standard.
+    """
+    session.install("black")
+    session.run(
+        "black",
+        "google",
+        "tests",
+        "docs",
+        "--exclude",
+        ".*/proto/.*|.*/gapic/.*|.*/.*_pb2.py",
+    )
+
+
+@nox.session(python="3.7")
+def lint(session):
+    """Run linters.
+
+    Returns a failure if the linters find linting errors or sufficiently
+    serious code quality issues.
+    """
+    session.install("flake8", "black", *LOCAL_DEPS)
+    session.install(".")
+    session.run(
+        "black",
+        "--check",
+        "google",
+        "tests",
+        "docs",
+        "--exclude",
+        ".*/proto/.*|.*/gapic/.*|.*/.*_pb2.py",
+    )
+    session.run("flake8", "google", "tests")
+
+
+@nox.session(python="3.7")
+def lint_setup_py(session):
+    """Verify that setup.py is valid (including RST check)."""
+    session.install("docutils", "pygments")
+    session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
+
 
 def default(session):
     # Install all test dependencies, then install this package in-place.
@@ -82,51 +126,6 @@ def system(session):
         session.run("py.test", "--quiet", system_test_path, *session.posargs)
     if system_test_folder_exists:
         session.run("py.test", "--quiet", system_test_folder_path, *session.posargs)
-
-
-@nox.session(python="3.7")
-def blacken(session):
-    """Run black.
-
-    Format code to uniform standard.
-    """
-    session.install("black")
-    session.run(
-        "black",
-        "google",
-        "tests",
-        "docs",
-        "--exclude",
-        ".*/proto/.*|.*/gapic/.*|.*/.*_pb2.py",
-    )
-
-
-@nox.session(python="3.7")
-def lint(session):
-    """Run linters.
-
-    Returns a failure if the linters find linting errors or sufficiently
-    serious code quality issues.
-    """
-    session.install("flake8", "black", *LOCAL_DEPS)
-    session.install(".")
-    session.run(
-        "black",
-        "--check",
-        "google",
-        "tests",
-        "docs",
-        "--exclude",
-        ".*/proto/.*|.*/gapic/.*|.*/.*_pb2.py",
-    )
-    session.run("flake8", "google", "tests")
-
-
-@nox.session(python="3.7")
-def lint_setup_py(session):
-    """Verify that setup.py is valid (including RST check)."""
-    session.install("docutils", "pygments")
-    session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
 
 
 @nox.session(python="3.7")

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -20,10 +20,7 @@ import os
 import nox
 
 
-LOCAL_DEPS = (
-    os.path.join("..", "api_core"),
-    os.path.join("..", "core"),
-)
+LOCAL_DEPS = (os.path.join("..", "api_core"), os.path.join("..", "core"))
 
 
 def default(session):
@@ -58,11 +55,15 @@ def unit(session):
 def system(session):
     """Run the system test suite."""
     system_test_path = os.path.join("tests", "system.py")
+    system_test_folder_path = os.path.join("tests", "system")
     # Sanity check: Only run tests if the environment variable is set.
     if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", ""):
         session.skip("Credentials must be set via environment variable")
+
+    system_test_exists = os.path.exists(system_test_path)
+    system_test_folder_exists = os.path.exists(system_test_folder_path)
     # Sanity check: only run tests if found.
-    if not os.path.exists(system_test_path):
+    if not system_test_exists and not system_test_folder_exists:
         session.skip("System tests were not found")
 
     # Use pre-release gRPC for system tests.
@@ -77,7 +78,10 @@ def system(session):
     session.install("-e", ".")
 
     # Run py.test against the system tests.
-    session.run("py.test", "--quiet", system_test_path, *session.posargs)
+    if system_test_exists:
+        session.run("py.test", "--quiet", system_test_path, *session.posargs)
+    if system_test_folder_exists:
+        session.run("py.test", "--quiet", system_test_folder_path, *session.posargs)
 
 
 @nox.session(python="3.7")

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -71,7 +71,8 @@ def default(session):
     session.install("mock", "pytest", "pytest-cov")
     for local_dep in LOCAL_DEPS:
         session.install("-e", local_dep)
-    session.install("-e", ".")
+    session.install("-e", "."){% for dependency in unit_test_dependencies %}
+    session.install("-e", "{{dependency}}"){% endfor %}
 
     # Run py.test against the unit tests.
     session.run(
@@ -117,7 +118,8 @@ def system(session):
     session.install("mock", "pytest")
     for local_dep in LOCAL_DEPS:
         session.install("-e", local_dep)
-    session.install("-e", "../test_utils/")
+    session.install("-e", "../test_utils/"){% for dependency in system_test_dependencies %}
+    session.install("-e", "{{dependency}}"){% endfor %}
     session.install("-e", ".")
 
     # Run py.test against the system tests.

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -20,7 +20,10 @@ import os
 import nox
 
 
-LOCAL_DEPS = (os.path.join("..", "api_core"),)
+LOCAL_DEPS = (
+    os.path.join("..", "api_core"),
+    os.path.join("..", "core"),
+)
 
 
 def default(session):


### PR DESCRIPTION
Copy black flake8 ignore elements to not conflict with black formatting. 
A good number of our libraries require core as part of their tests. Add this to localdep in noxfile.