### PR TITLE
Enforce black in noxfile, broaden to generated code

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -23,23 +23,6 @@ import nox
 LOCAL_DEPS = (os.path.join("..", "api_core"), os.path.join("..", "core"))
 
 @nox.session(python="3.7")
-def blacken(session):
-    """Run black.
-
-    Format code to uniform standard.
-    """
-    session.install("black")
-    session.run(
-        "black",
-        "google",
-        "tests",
-        "docs",
-        "--exclude",
-        ".*/proto/.*|.*/gapic/.*|.*/.*_pb2.py",
-    )
-
-
-@nox.session(python="3.7")
 def lint(session):
     """Run linters.
 
@@ -53,10 +36,23 @@ def lint(session):
         "google",
         "tests",
         "docs",
-        "--exclude",
-        ".*/proto/.*|.*/gapic/.*|.*/.*_pb2.py",
     )
     session.run("flake8", "google", "tests")
+
+
+@nox.session(python="3.7")
+def blacken(session):
+    """Run black.
+
+    Format code to uniform standard.
+    """
+    session.install("black")
+    session.run(
+        "black",
+        "google",
+        "tests",
+        "docs",
+    )
 
 
 @nox.session(python="3.7")


### PR DESCRIPTION
- Reorder noxfile steps (linting before auto blackening so on CI unblacked code fails)
- Open up linting and black to generated code.