### PR TITLE
Report gapic generation to metadata

### DIFF
--- a/synthtool/gcp/gapic_generator.py
+++ b/synthtool/gcp/gapic_generator.py
@@ -18,6 +18,7 @@ from typing import Optional
 
 from synthtool import _tracked_paths
 from synthtool import log
+from synthtool import metadata
 from synthtool.gcp import artman
 from synthtool.sources import git
 
@@ -127,6 +128,15 @@ class GAPICGenerator:
             )
 
         log.success(f"Generated code into {genfiles}.")
+
+        metadata.add_client_destination(
+            source="googleapis" if not private else "googleapis-private",
+            api_name=service,
+            api_version=version,
+            language=language,
+            generator="gapic",
+            config=str(config_path),
+        )
 
         _tracked_paths.add(genfiles)
         return genfiles

--- a/synthtool/metadata.py
+++ b/synthtool/metadata.py
@@ -49,6 +49,11 @@ def add_template_source(**kwargs) -> None:
     _metadata.sources.add(template=metadata_pb2.TemplateSource(**kwargs))
 
 
+def add_client_destination(**kwargs) -> None:
+    """Adds a client library destination to the current metadata."""
+    _metadata.destinations.add(client=metadata_pb2.ClientDestination(**kwargs))
+
+
 def write(outfile: str = "synth.metadata") -> None:
     """Writes out the metadata to a file."""
     jsonified = google.protobuf.json_format.MessageToJson(_metadata)

--- a/synthtool/protos/metadata.proto
+++ b/synthtool/protos/metadata.proto
@@ -64,12 +64,17 @@ message Destination {
 }
 
 message ClientDestination {
-    string api_name = 1;
-    string api_version = 2;
-    string generator = 3;
-    string source = 4;
+    string source = 1;
+    string api_name = 2;
+    string api_version = 3;
+    string language = 4;
+    string generator = 5;
+    string config = 6;
 }
 
+// Currently unused as storing all file destination options will likely cause
+// the metadata file to be too large and may cause autosynth trashing. We'll
+// investigate using this in the future.
 message FileSetDestination {
     string source = 1;
     repeated string files = 2;

--- a/synthtool/protos/metadata_pb2.py
+++ b/synthtool/protos/metadata_pb2.py
@@ -23,7 +23,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     syntax="proto3",
     serialized_options=None,
     serialized_pb=_b(
-        '\n\x0emetadata.proto\x12\x14yoshi.synth.metadata\x1a\x1fgoogle/protobuf/timestamp.proto"\xa3\x01\n\x08Metadata\x12/\n\x0bupdate_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\x07sources\x18\x02 \x03(\x0b\x32\x1c.yoshi.synth.metadata.Source\x12\x37\n\x0c\x64\x65stinations\x18\x03 \x03(\x0b\x32!.yoshi.synth.metadata.Destination"\xb8\x01\n\x06Source\x12.\n\x03git\x18\x01 \x01(\x0b\x32\x1f.yoshi.synth.metadata.GitSourceH\x00\x12:\n\tgenerator\x18\x02 \x01(\x0b\x32%.yoshi.synth.metadata.GeneratorSourceH\x00\x12\x38\n\x08template\x18\x03 \x01(\x0b\x32$.yoshi.synth.metadata.TemplateSourceH\x00\x42\x08\n\x06source"L\n\tGitSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06remote\x18\x02 \x01(\t\x12\x0b\n\x03sha\x18\x03 \x01(\t\x12\x14\n\x0cinternal_ref\x18\x04 \x01(\t"F\n\x0fGeneratorSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x14\n\x0c\x64ocker_image\x18\x03 \x01(\t"?\n\x0eTemplateSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06origin\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t"\x94\x01\n\x0b\x44\x65stination\x12\x39\n\x06\x63lient\x18\x01 \x01(\x0b\x32\'.yoshi.synth.metadata.ClientDestinationH\x00\x12;\n\x07\x66ileset\x18\x02 \x01(\x0b\x32(.yoshi.synth.metadata.FileSetDestinationH\x00\x42\r\n\x0b\x44\x65stination"]\n\x11\x43lientDestination\x12\x10\n\x08\x61pi_name\x18\x01 \x01(\t\x12\x13\n\x0b\x61pi_version\x18\x02 \x01(\t\x12\x11\n\tgenerator\x18\x03 \x01(\t\x12\x0e\n\x06source\x18\x04 \x01(\t"3\n\x12\x46ileSetDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\r\n\x05\x66iles\x18\x02 \x03(\tb\x06proto3'
+        '\n\x0emetadata.proto\x12\x14yoshi.synth.metadata\x1a\x1fgoogle/protobuf/timestamp.proto"\xa3\x01\n\x08Metadata\x12/\n\x0bupdate_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\x07sources\x18\x02 \x03(\x0b\x32\x1c.yoshi.synth.metadata.Source\x12\x37\n\x0c\x64\x65stinations\x18\x03 \x03(\x0b\x32!.yoshi.synth.metadata.Destination"\xb8\x01\n\x06Source\x12.\n\x03git\x18\x01 \x01(\x0b\x32\x1f.yoshi.synth.metadata.GitSourceH\x00\x12:\n\tgenerator\x18\x02 \x01(\x0b\x32%.yoshi.synth.metadata.GeneratorSourceH\x00\x12\x38\n\x08template\x18\x03 \x01(\x0b\x32$.yoshi.synth.metadata.TemplateSourceH\x00\x42\x08\n\x06source"L\n\tGitSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06remote\x18\x02 \x01(\t\x12\x0b\n\x03sha\x18\x03 \x01(\t\x12\x14\n\x0cinternal_ref\x18\x04 \x01(\t"F\n\x0fGeneratorSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x14\n\x0c\x64ocker_image\x18\x03 \x01(\t"?\n\x0eTemplateSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06origin\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t"\x94\x01\n\x0b\x44\x65stination\x12\x39\n\x06\x63lient\x18\x01 \x01(\x0b\x32\'.yoshi.synth.metadata.ClientDestinationH\x00\x12;\n\x07\x66ileset\x18\x02 \x01(\x0b\x32(.yoshi.synth.metadata.FileSetDestinationH\x00\x42\r\n\x0b\x44\x65stination"\x7f\n\x11\x43lientDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x10\n\x08\x61pi_name\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_version\x18\x03 \x01(\t\x12\x10\n\x08language\x18\x04 \x01(\t\x12\x11\n\tgenerator\x18\x05 \x01(\t\x12\x0e\n\x06\x63onfig\x18\x06 \x01(\t"3\n\x12\x46ileSetDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\r\n\x05\x66iles\x18\x02 \x03(\tb\x06proto3'
     ),
     dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR],
 )
@@ -503,8 +503,8 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
     containing_type=None,
     fields=[
         _descriptor.FieldDescriptor(
-            name="api_name",
-            full_name="yoshi.synth.metadata.ClientDestination.api_name",
+            name="source",
+            full_name="yoshi.synth.metadata.ClientDestination.source",
             index=0,
             number=1,
             type=9,
@@ -521,8 +521,8 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
-            name="api_version",
-            full_name="yoshi.synth.metadata.ClientDestination.api_version",
+            name="api_name",
+            full_name="yoshi.synth.metadata.ClientDestination.api_name",
             index=1,
             number=2,
             type=9,
@@ -539,8 +539,8 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
-            name="generator",
-            full_name="yoshi.synth.metadata.ClientDestination.generator",
+            name="api_version",
+            full_name="yoshi.synth.metadata.ClientDestination.api_version",
             index=2,
             number=3,
             type=9,
@@ -557,10 +557,46 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
-            name="source",
-            full_name="yoshi.synth.metadata.ClientDestination.source",
+            name="language",
+            full_name="yoshi.synth.metadata.ClientDestination.language",
             index=3,
             number=4,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="generator",
+            full_name="yoshi.synth.metadata.ClientDestination.generator",
+            index=4,
+            number=5,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="config",
+            full_name="yoshi.synth.metadata.ClientDestination.config",
+            index=5,
+            number=6,
             type=9,
             cpp_type=9,
             label=1,
@@ -584,7 +620,7 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
     extension_ranges=[],
     oneofs=[],
     serialized_start=792,
-    serialized_end=885,
+    serialized_end=919,
 )
 
 
@@ -640,8 +676,8 @@ _FILESETDESTINATION = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=887,
-    serialized_end=938,
+    serialized_start=921,
+    serialized_end=972,
 )
 
 _METADATA.fields_by_name[

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -40,6 +40,39 @@ def test_add_generator_source():
     assert current.sources[0].generator.version == "1.2.3"
 
 
+def test_add_template_source():
+    metadata.reset()
+
+    metadata.add_template_source(name="name", version="1.2.3")
+
+    current = metadata.get()
+
+    assert current.sources[0].template.name == "name"
+    assert current.sources[0].template.version == "1.2.3"
+
+
+def test_add_client_destination():
+    metadata.reset()
+
+    metadata.add_client_destination(
+        source="source",
+        api_name="api",
+        api_version="v1",
+        language="py",
+        generator="gen",
+        config="config",
+    )
+
+    current = metadata.get()
+
+    assert current.destinations[0].client.source == "source"
+    assert current.destinations[0].client.api_name == "api"
+    assert current.destinations[0].client.api_version == "v1"
+    assert current.destinations[0].client.language == "py"
+    assert current.destinations[0].client.generator == "gen"
+    assert current.destinations[0].client.config == "config"
+
+
 def test_write(tmpdir):
     metadata.reset()
 


### PR DESCRIPTION
Metadata now looks like this:

```
{
  "sources": [
    {
      "generator": {
        "name": "artman",
        "version": "0.16.2",
        "dockerImage": "googleapis/artman@sha256:2f6b261ee7fe1aedf238991c93a20b3820de37a343d0cacf3e3e9555c2aaf2ea"
      }
    },
    {
      "template": {
        "name": "python_library",
        "origin": "synthtool.gcp",
        "version": "2018.11.28"
      }
    },
    {
      "git": {
        "name": "googleapis",
        "remote": "https://github.com/googleapis/googleapis.git",
        "sha": "58249308b9c7bd64ba18ce99100751397e5184a7",
        "internalRef": "223077517"
      }
    }
  ],
  "destinations": [
    {
      "client": {
        "source": "googleapis",
        "apiName": "vision",
        "apiVersion": "v1",
        "language": "python",
        "generator": "gapic",
        "config": "google/cloud/vision/artman_vision_v1.yaml"
      }
    }
  ]
}
```