### PR TITLE
fix: pass -md option to openssl

### DIFF
--- a/synthtool/gcp/templates/node_library/.circleci/config.yml
+++ b/synthtool/gcp/templates/node_library/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
           name: Decrypt credentials.
           command: |
             if ! [[ -z "${SYSTEM_TESTS_ENCRYPTION_KEY}" ]]; then
-              openssl aes-256-cbc -d -in .circleci/key.json.enc \
+              openssl aes-256-cbc -d -md md5 -in .circleci/key.json.enc \
                 -out .circleci/key.json \
                 -k "${SYSTEM_TESTS_ENCRYPTION_KEY}"
             fi
@@ -148,7 +148,7 @@ jobs:
           command: |
             if ! [[ -z "${SYSTEM_TESTS_ENCRYPTION_KEY}" ]]; then
               for encrypted_key in .circleci/*.json.enc; do
-                openssl aes-256-cbc -d -in $encrypted_key \
+                openssl aes-256-cbc -d -md md5 -in $encrypted_key \
                   -out $(echo $encrypted_key | sed 's/\.enc//') \
                   -k "${SYSTEM_TESTS_ENCRYPTION_KEY}"
               done


### PR DESCRIPTION
Openssl got upgraded (probably to v1.1.0) in the Docker image used by CircleCI, and it now changed the default algorithm used for decryption, which made all our encrypted keys incompatible. Adding the `-md md5` to `openssl -d` (following [this advice](https://wiki.archlinux.org/index.php/OpenSSL#%22bad_decrypt%22_while_decrypting)) helps ([example workflow](https://circleci.com/workflow-run/2ed13275-1ecf-476d-8644-2435e6394c8b)).