### PR TITLE
Update readme to latest instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ to author a synth.py script. You can grab one from another package
 
 We run synthtool as follows:
 ```
-python synth.py
+python -m synthtool
 ```
 
 Once you run synthtool without errors:
@@ -88,8 +88,8 @@ export SYNTHTOOL_ARTMAN_VERSION=0.16.2
 ```
 
 ### Local Googleapis
-Synthtool supports generation from a local copy of googleapis. Specify the path to`googleapis` in the environment variable `SYNTHTOOL_LOCAL_GOOGLEAPIS`.
+Synthtool supports generation from a local copy of googleapis. Specify the path to`googleapis` in the environment variable `SYNTHTOOL_GOOGLEAPIS`.
 
 ```
-export SYNTHTOOL_LOCAL_GOOGLEAPIS=path/to/local/googleapis
+export SYNTHTOOL_GOOGLEAPIS=path/to/local/googleapis
 ```


### PR DESCRIPTION
Per https://github.com/googleapis/synthtool/blob/8e95a2333f4c5fc5e12a319b33664d75b06ae620/synthtool/gcp/gapic_generator.py#L27 the environment variable is `SYNTHTOOL_GOOGLEAPIS`.

I get a warning when I run `python synth.py`.