### PR TITLE
Update java formatting version to 1.7

### DIFF
--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -21,7 +21,7 @@ from synthtool import shell
 from pathlib import Path
 
 JAR_DOWNLOAD_URL = "https://github.com/google/google-java-format/releases/download/google-java-format-{version}/google-java-format-{version}-all-deps.jar"
-DEFAULT_FORMAT_VERSION = "1.6"
+DEFAULT_FORMAT_VERSION = "1.7"
 
 
 def format_code(


### PR DESCRIPTION
Our presubmit code format build has been upgraded to 1.7. We'll need to upgrade here as well to prevent conflicts with our generated autosynth PRs.

For reference: https://github.com/googleapis/google-cloud-java/issues/4438

As this is my first PR in this codebase, please let me know if there are any additional changes required. Thanks!