### PR TITLE
node(kokoro): Fetch credentials for magic github proxy

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/release/publish.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/release/publish.cfg
@@ -18,6 +18,26 @@ before_action {
   }
 }
 
+# Fetch magictoken to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "releasetool-magictoken"
+    }
+  }
+}
+
+# Fetch api key to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "magic-github-proxy-api-key"
+    }
+  }
+}
+
 # Download trampoline resources.
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 


### PR DESCRIPTION
Releasetool reporter will go through the magic github proxy to make requests to the GitHub API.