### PR TITLE
feat: porting README generation from nodejs-repo-tools

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -26,7 +26,7 @@ from synthtool import metadata
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 _RE_SAMPLE_COMMENT_START = r"\[START \w+_quickstart]"
-_RE_SAMPLE_COMMENT_STOP = r"\[END \w+_quickstart]"
+_RE_SAMPLE_COMMENT_END = r"\[END \w+_quickstart]"
 
 
 class CommonTemplates:
@@ -92,7 +92,7 @@ class CommonTemplates:
                         )
 
     #
-    # quickstart is a special case, it should be loaded and displayed
+    # quickstart is a special case, it should be read from disk and displayed
     # in README.md rather than pushed into samples array.
     #
     def _read_quickstart(self, samples_dir):
@@ -102,7 +102,7 @@ class CommonTemplates:
         with open(samples_dir / "quickstart.js") as f:
             while True:
                 line = f.readline()
-                if not line or re.search(_RE_SAMPLE_COMMENT_STOP, line):
+                if not line or re.search(_RE_SAMPLE_COMMENT_END, line):
                     break
                 if reading:
                     quickstart += line

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -20,6 +20,9 @@ from synthtool import __main__
 from synthtool import _tracked_paths
 from synthtool import metadata
 
+import json
+import os
+
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 
 
@@ -28,6 +31,7 @@ class CommonTemplates:
         self._templates = templates.Templates(_TEMPLATES_DIR)
 
     def _generic_library(self, directory: str, **kwargs) -> Path:
+        self._load_generic_metadata(kwargs["metadata"])
         t = templates.TemplateGroup(_TEMPLATES_DIR / directory)
         result = t.render(**kwargs)
         _tracked_paths.add(result)
@@ -49,3 +53,20 @@ class CommonTemplates:
 
     def render(self, template_name: str, **kwargs) -> Path:
         return self._templates.render(template_name, **kwargs)
+
+    # 
+    # loads additional meta information from:
+    #
+    # .cloud-repo-tools.json: which contains information that helps generate
+    #  README files.
+    #
+    # .repo-metadata.json: which contains general meta-info about git repo.
+    # 
+    def _load_generic_metadata(self, metadata):
+        if os.path.exists("./.cloud-repo-tools.json"):
+            with open("./.cloud-repo-tools.json") as f:
+                metadata["samples"] = json.load(f)
+
+        if os.path.exists("./.repo-metadata.json"):
+            with open("./.repo-metadata.json") as f:
+                metadata["repo"] = json.load(f)

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -54,14 +54,14 @@ class CommonTemplates:
     def render(self, template_name: str, **kwargs) -> Path:
         return self._templates.render(template_name, **kwargs)
 
-    # 
+    #
     # loads additional meta information from:
     #
     # .cloud-repo-tools.json: which contains information that helps generate
-    #  README files.
+    #  README files with samples.
     #
     # .repo-metadata.json: which contains general meta-info about git repo.
-    # 
+    #
     def _load_generic_metadata(self, metadata):
         if os.path.exists("./.cloud-repo-tools.json"):
             with open("./.cloud-repo-tools.json") as f:

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -63,9 +63,14 @@ class CommonTemplates:
     # .repo-metadata.json: which contains general meta-info about git repo.
     #
     def _load_generic_metadata(self, metadata):
+        # TODO: replace with loading from samples folder.
+        metadata["samples"] = {}
+
         if os.path.exists("./.cloud-repo-tools.json"):
             with open("./.cloud-repo-tools.json") as f:
                 metadata["samples"] = json.load(f)
+
+        metadata["repo"] = {}
 
         if os.path.exists("./.repo-metadata.json"):
             with open("./.repo-metadata.json") as f:

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
 from pathlib import Path
 
 from synthtool.languages import node
@@ -20,8 +22,6 @@ from synthtool import __main__
 from synthtool import _tracked_paths
 from synthtool import metadata
 
-import json
-import os
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -61,7 +61,6 @@ class CommonTemplates:
     # loads additional meta information from .repo-metadata.json.
     #
     def _load_generic_metadata(self, metadata):
-        # TODO: replace with loading from samples folder.
         self._load_samples(metadata)
 
         metadata["repo"] = {}

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -1,0 +1,117 @@
+[//]: # "This README.md file is auto-generated, all changes to this file will be lost."
+[//]: # "To regenerate it, use `python -m synthtool`."
+<img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
+
+# [{{ metadata['repo']['name_pretty'] }}: {{ metadata['repo']['language']|language_pretty }} Client](https://github.com/{{ metadata['repo']['repo'] }})
+
+{{ metadata['repo']['release_quality']|release_quality_badge }}
+[![npm version](https://img.shields.io/npm/v/{{ metadata['name'] }}.svg)](https://www.npmjs.org/package/{{ metadata['name'] }})
+[![codecov](https://img.shields.io/codecov/c/github/{{ metadata['repo']['repo'] }}/master.svg?style=flat)](https://codecov.io/gh/{{ metadata['repo']['repo'] }})
+
+{{ metadata['description'] }}
+{% if metadata['deprecated'] %}
+| :warning: Deprecated Module |
+| --- |
+| This library is **deprecated**. {{ metadata['deprecated'] }} |
+{% endif %}
+* [Using the client library](#using-the-client-library){% if metadata['samples']['samples']|length %}
+* [Samples](#samples){% endif %}
+* [Versioning](#versioning)
+* [Contributing](#contributing)
+* [License](#license)
+
+## Using the client library
+
+1.  [Select or create a Cloud Platform project][projects].{% if not metadata['samples']['suppress_billing'] %}
+1.  [Enable billing for your project][billing].{% endif %}{% if metadata['samples']['api_id'] %}
+1.  [Enable the {{ metadata['repo']['name_pretty'] }} API][enable_api].{% endif %}
+1.  [Set up authentication with a service account][auth] so you can access the
+    API from your local workstation.
+
+1. Install the client library:
+
+        {{ metadata['lib_install_cmd'] }}
+
+{% if  metadata['quickstart'] %}
+1. Try an example:
+
+```{{ metadata['syntax_highlighting_ext'] }}
+{{ metadata['quickstart'] }}
+```
+{% endif %}
+
+{% if metadata['samples']['samples']|length %}
+## Samples
+
+Samples are in the [`samples/`](https://github.com/{{  metadata['repo']['repo'] }}/tree/master/samples) directory. The samples' `README.md`
+has instructions for running the samples.
+
+| Sample                      | Source Code                       | Try it |
+| --------------------------- | --------------------------------- | ------ |
+{% for sample in metadata['samples']['samples'] %}| {{ sample.name }} | [source code](https://github.com/{{ metadata['repo']['repo']  }}/blob/master/samples/{{ sample.file }}) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/{{ metadata['repo']['repo'] }}&page=editor&open_in_editor=samples/{{ sample.file }},samples/README.md) |
+{% endfor %}
+{% endif %}
+
+The [{{ metadata['repo']['name_pretty'] }} {{ metadata['repo']['language']|language_pretty }} Client API Reference][client-docs] documentation
+also contains samples.
+
+## Versioning
+
+This library follows [Semantic Versioning](http://semver.org/).
+
+{% if metadata['release_quality'] == 'ga' %}
+This library is considered to be **General Availability (GA)**. This means it
+is stable; the code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **GA** libraries
+are addressed with the highest priority.
+{% endif %}
+{% if metadata['release_quality'] == 'beta' %}
+This library is considered to be in **beta**. This means it is expected to be
+mostly stable while we work toward a general availability release; however,
+complete stability is not guaranteed. We will address issues and requests
+against beta libraries with a high priority.
+{% endif %}
+{% if metadata['release_quality'] == 'alpha' %}
+This library is considered to be in **alpha**. This means it is still a
+work-in-progress and under active development. Any release is subject to
+backwards-incompatible changes at any time.
+{% endif %}
+{% if metadata['release_quality'] == 'deprecated' %}
+This library is **deprecated**. This means that it is no longer being
+actively maintained and the only updates the library will receive will
+be for critical security issues. {% if metadata['deprecated'] %}{{ metadata['deprecated'] }}{% endif %}
+{% endif %}
+
+More Information: [Google Cloud Platform Launch Stages][launch_stages]
+
+[launch_stages]: https://cloud.google.com/terms/launch-stages
+
+## Contributing
+
+Contributions welcome! See the [Contributing Guide](https://github.com/{{ metadata['repository_name'] }}/blob/master/.github/CONTRIBUTING.md).
+
+## License
+
+Apache Version 2.0
+
+See [LICENSE](https://github.com/{{ metadata['repository_name'] }}/blob/master/LICENSE)
+
+## What's Next
+
+* [{{ metadata['repo']['name_pretty'] }} Documentation][product-docs]
+* [{{ metadata['repo']['name_pretty'] }} {{ metadata['repo']['language']|language_pretty }} Client API Reference][client-docs]
+* [github.com/{{ metadata['repository_name'] }}](https://github.com{{repoPath}})
+
+Read more about the client libraries for Cloud APIs, including the older
+Google APIs Client Libraries, in [Client Libraries Explained][explained].
+
+[explained]: https://cloud.google.com/apis/docs/client-libraries-explained
+
+[client-docs]: {{ metadata['repo']['client_documentation'] }}
+[product-docs]: {{ metadata['repo']['product_documentation'] }}
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
+[projects]: https://console.cloud.google.com/project
+[billing]: https://support.google.com/cloud/answer/6293499#enable-billing
+[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['api_id'] }}
+[auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -22,8 +22,8 @@
 
 ## Using the client library
 
-1.  [Select or create a Cloud Platform project][projects].
-1.  [Enable billing for your project][billing].
+1.  [Select or create a Cloud Platform project][projects].{% if metadata['repo']['requires_billing'] %}
+1.  [Enable billing for your project][billing].{% endif %}
 1.  [Enable the {{ metadata['repo']['name_pretty'] }} API][enable_api].
 1.  [Set up authentication with a service account][auth] so you can access the
     API from your local workstation.

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -4,7 +4,7 @@
 
 # [{{ metadata['repo']['name_pretty'] }}: {{ metadata['repo']['language']|language_pretty }} Client](https://github.com/{{ metadata['repo']['repo'] }})
 
-{{ metadata['repo']['release_quality']|release_quality_badge }}
+{{ metadata['repo']['release_level']|release_quality_badge }}
 [![npm version](https://img.shields.io/npm/v/{{ metadata['name'] }}.svg)](https://www.npmjs.org/package/{{ metadata['name'] }})
 [![codecov](https://img.shields.io/codecov/c/github/{{ metadata['repo']['repo'] }}/master.svg?style=flat)](https://codecov.io/gh/{{ metadata['repo']['repo'] }})
 
@@ -14,7 +14,7 @@
 | --- |
 | This library is **deprecated**. {{ metadata['deprecated'] }} |
 {% endif %}
-* [Using the client library](#using-the-client-library){% if metadata['samples']['samples']|length %}
+* [Using the client library](#using-the-client-library){% if metadata['samples']|length %}
 * [Samples](#samples){% endif %}
 * [Versioning](#versioning)
 * [Contributing](#contributing)
@@ -22,9 +22,9 @@
 
 ## Using the client library
 
-1.  [Select or create a Cloud Platform project][projects].{% if not metadata['samples']['suppress_billing'] %}
-1.  [Enable billing for your project][billing].{% endif %}{% if metadata['samples']['api_id'] %}
-1.  [Enable the {{ metadata['repo']['name_pretty'] }} API][enable_api].{% endif %}
+1.  [Select or create a Cloud Platform project][projects].
+1.  [Enable billing for your project][billing].
+1.  [Enable the {{ metadata['repo']['name_pretty'] }} API][enable_api].
 1.  [Set up authentication with a service account][auth] so you can access the
     API from your local workstation.
 
@@ -35,12 +35,12 @@
 {% if  metadata['quickstart'] %}
 1. Try an example:
 
-```{{ metadata['syntax_highlighting_ext'] }}
+```{{ metadata['repo']['language']|syntax_highlighter }}
 {{ metadata['quickstart'] }}
 ```
 {% endif %}
 
-{% if metadata['samples']['samples']|length %}
+{% if metadata['samples']|length %}
 ## Samples
 
 Samples are in the [`samples/`](https://github.com/{{  metadata['repo']['repo'] }}/tree/master/samples) directory. The samples' `README.md`
@@ -48,7 +48,7 @@ has instructions for running the samples.
 
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |
-{% for sample in metadata['samples']['samples'] %}| {{ sample.name }} | [source code](https://github.com/{{ metadata['repo']['repo']  }}/blob/master/samples/{{ sample.file }}) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/{{ metadata['repo']['repo'] }}&page=editor&open_in_editor=samples/{{ sample.file }},samples/README.md) |
+{% for sample in metadata['samples'] %}| {{ sample.name }} | [source code](https://github.com/{{ metadata['repo']['repo']  }}/blob/master/samples/{{ sample.file }}) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/{{ metadata['repo']['repo'] }}&page=editor&open_in_editor=samples/{{ sample.file }},samples/README.md) |
 {% endfor %}
 {% endif %}
 
@@ -59,25 +59,25 @@ also contains samples.
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-{% if metadata['release_quality'] == 'ga' %}
+{% if metadata['repo']['release_level'] == 'ga' %}
 This library is considered to be **General Availability (GA)**. This means it
 is stable; the code surface will not change in backwards-incompatible ways
 unless absolutely necessary (e.g. because of critical security issues) or with
 an extensive deprecation period. Issues and requests against **GA** libraries
 are addressed with the highest priority.
 {% endif %}
-{% if metadata['release_quality'] == 'beta' %}
+{% if metadata['repo']['release_level'] == 'beta' %}
 This library is considered to be in **beta**. This means it is expected to be
 mostly stable while we work toward a general availability release; however,
 complete stability is not guaranteed. We will address issues and requests
 against beta libraries with a high priority.
 {% endif %}
-{% if metadata['release_quality'] == 'alpha' %}
+{% if metadata['repo']['release_level'] == 'alpha' %}
 This library is considered to be in **alpha**. This means it is still a
 work-in-progress and under active development. Any release is subject to
 backwards-incompatible changes at any time.
 {% endif %}
-{% if metadata['release_quality'] == 'deprecated' %}
+{% if metadata['release_level'] == 'deprecated' %}
 This library is **deprecated**. This means that it is no longer being
 actively maintained and the only updates the library will receive will
 be for critical security issues. {% if metadata['deprecated'] %}{{ metadata['deprecated'] }}{% endif %}
@@ -89,19 +89,19 @@ More Information: [Google Cloud Platform Launch Stages][launch_stages]
 
 ## Contributing
 
-Contributions welcome! See the [Contributing Guide](https://github.com/{{ metadata['repository_name'] }}/blob/master/.github/CONTRIBUTING.md).
+Contributions welcome! See the [Contributing Guide](https://github.com/{{ metadata['repo']['repo'] }}/blob/master/CONTRIBUTING.md).
 
 ## License
 
 Apache Version 2.0
 
-See [LICENSE](https://github.com/{{ metadata['repository_name'] }}/blob/master/LICENSE)
+See [LICENSE](https://github.com/{{ metadata['repo']['repo'] }}/blob/master/LICENSE)
 
 ## What's Next
 
 * [{{ metadata['repo']['name_pretty'] }} Documentation][product-docs]
 * [{{ metadata['repo']['name_pretty'] }} {{ metadata['repo']['language']|language_pretty }} Client API Reference][client-docs]
-* [github.com/{{ metadata['repository_name'] }}](https://github.com{{repoPath}})
+* [github.com/{{ metadata['repo']['repo'] }}](https://github.com/{{ metadata['repo']['repo'] }})
 
 Read more about the client libraries for Cloud APIs, including the older
 Google APIs Client Libraries, in [Client Libraries Explained][explained].
@@ -113,5 +113,5 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [projects]: https://console.cloud.google.com/project
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['api_id'] }}
+[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -37,6 +37,7 @@ def read_metadata():
 
         data["repository"] = f'{repo["owner"]}/{repo["name"]}'
         data["repository_name"] = repo["name"]
+        data['lib_install_cmd'] = f'npm install {data["name"]}'
 
         return data
 

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -37,7 +37,7 @@ def read_metadata():
 
         data["repository"] = f'{repo["owner"]}/{repo["name"]}'
         data["repository_name"] = repo["name"]
-        data['lib_install_cmd'] = f'npm install {data["name"]}'
+        data["lib_install_cmd"] = f'npm install {data["name"]}'
 
         return data
 

--- a/synthtool/sources/templates.py
+++ b/synthtool/sources/templates.py
@@ -33,6 +33,7 @@ def _make_env(location):
     )
     env.filters["release_quality_badge"] = release_quality_badge
     env.filters["language_pretty"] = language_pretty
+    env.filters["syntax_highlighter"] = syntax_highlighter
     return env
 
 
@@ -84,8 +85,6 @@ class TemplateGroup:
 #
 # Generates a markdown badge for displaying a "Release Quality'.
 #
-# @param {string} release_quality One of: (ga, beta, alpha, eap, deprecated).
-# @returns {string} The markdown badge.
 def release_quality_badge(input):
     if not input:
         log.error(f"ensure you pass a string 'quality' to release_quality_badge")
@@ -118,4 +117,13 @@ def release_quality_badge(input):
 def language_pretty(input):
     if input == "nodejs":
         return "Node.js"
+    return input
+
+
+#
+# .repo-metadata.json language field to syntax highlighter name.
+#
+def syntax_highlighter(input):
+    if input == "nodejs":
+        return "javascript"
     return input

--- a/synthtool/sources/templates.py
+++ b/synthtool/sources/templates.py
@@ -16,6 +16,7 @@ from typing import Union
 from pathlib import Path
 
 import jinja2
+from jinja2.ext import Extension
 
 from synthtool import tmp
 
@@ -24,11 +25,14 @@ PathOrStr = Union[str, Path]
 
 
 def _make_env(location):
-    return jinja2.Environment(
+    env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(str(location)),
         autoescape=False,
         keep_trailing_newline=True,
     )
+    env.filters['release_quality_badge'] = release_quality_badge
+    env.filters['language_pretty'] = language_pretty
+    return env
 
 
 def _render_to_path(env, template_name, dest, params):
@@ -74,3 +78,21 @@ class TemplateGroup:
             _render_to_path(self.env, template_name, self.dir, kwargs)
 
         return self.dir
+
+#
+# Generates a markdown badge for displaying a "Release Quality'.
+#
+# @param {string} releaseQuality One of: (ga, beta, alpha, eap, deprecated).
+# @returns {string} The markdown badge.
+def release_quality_badge(input):
+    if input:
+        return 'hello world'
+    return None
+
+#
+# .repo-metadata.json language field to pretty language.
+#
+def language_pretty(input):
+    if input == 'nodejs':
+        return 'Node.js'
+    return input

--- a/synthtool/sources/templates.py
+++ b/synthtool/sources/templates.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 import jinja2
 
+
+from synthtool import log
 from synthtool import tmp
 
 
@@ -82,12 +84,32 @@ class TemplateGroup:
 #
 # Generates a markdown badge for displaying a "Release Quality'.
 #
-# @param {string} releaseQuality One of: (ga, beta, alpha, eap, deprecated).
+# @param {string} release_quality One of: (ga, beta, alpha, eap, deprecated).
 # @returns {string} The markdown badge.
 def release_quality_badge(input):
-    if input:
-        return "hello world"
-    return None
+    if not input:
+        log.error(f"ensure you pass a string 'quality' to release_quality_badge")
+        return
+
+    release_quality = input.upper()
+    badge = ""
+
+    if release_quality == "GA":
+        badge = "general%20availability%20%28GA%29-brightgreen"
+    elif release_quality == "BETA":
+        badge = "beta-yellow"
+    elif release_quality == "ALPHA":
+        badge = "alpha-orange"
+    elif release_quality == "EAP":
+        badge = "EAP-yellow"
+    elif release_quality == "DEPRECATED":
+        badge = "deprecated-red"
+    else:
+        log.error(
+            "Expected 'release_quality' to be one of: (ga, beta, alpha, eap, deprecated)"
+        )
+        return
+    return f"[![release level](https://img.shields.io/badge/release%20level-{badge}.svg?style=flat)](https://cloud.google.com/terms/launch-stages)"
 
 
 #

--- a/synthtool/sources/templates.py
+++ b/synthtool/sources/templates.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 import jinja2
 
-
 from synthtool import log
 from synthtool import tmp
 

--- a/synthtool/sources/templates.py
+++ b/synthtool/sources/templates.py
@@ -16,7 +16,6 @@ from typing import Union
 from pathlib import Path
 
 import jinja2
-from jinja2.ext import Extension
 
 from synthtool import tmp
 
@@ -30,8 +29,8 @@ def _make_env(location):
         autoescape=False,
         keep_trailing_newline=True,
     )
-    env.filters['release_quality_badge'] = release_quality_badge
-    env.filters['language_pretty'] = language_pretty
+    env.filters["release_quality_badge"] = release_quality_badge
+    env.filters["language_pretty"] = language_pretty
     return env
 
 
@@ -79,6 +78,7 @@ class TemplateGroup:
 
         return self.dir
 
+
 #
 # Generates a markdown badge for displaying a "Release Quality'.
 #
@@ -86,13 +86,14 @@ class TemplateGroup:
 # @returns {string} The markdown badge.
 def release_quality_badge(input):
     if input:
-        return 'hello world'
+        return "hello world"
     return None
+
 
 #
 # .repo-metadata.json language field to pretty language.
 #
 def language_pretty(input):
-    if input == 'nodejs':
-        return 'Node.js'
+    if input == "nodejs":
+        return "Node.js"
     return input

--- a/tests/fixtures/samples/quickstart.js
+++ b/tests/fixtures/samples/quickstart.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2018, Google LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// [START bigtable_quickstart]
+// Imports the Google Cloud client library
+const Bigtable = require('@google-cloud/bigtable');
+
+async function quickstart(
+  INSTANCE_ID = 'my-instance', // ID of the Cloud Bigtable instance
+  TABLE_ID = 'my-table' // ID of the Cloud Bigtable table
+) {
+  const bigtable = Bigtable();
+
+  // Connect to an existing instance:my-bigtable-instance
+  const instance = bigtable.instance(INSTANCE_ID);
+
+  // Connect to an existing table:my-table
+  const table = instance.table(TABLE_ID);
+
+  // Read a row from my-table using a row key
+  const [singleRow] = await table.row('r1').get();
+
+  // Print the row key and data (column value, labels, timestamp)
+  const rowData = JSON.stringify(singleRow.data, null, 4);
+  console.log(`Row key: ${singleRow.id}\nData: ${rowData}`);
+}
+// [END bigtable_quickstart]
+
+const args = process.argv.slice(2);
+quickstart(...args).catch(console.error);

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import stat
 from pathlib import Path
 
-
+from synthtool.gcp import common
 from synthtool.sources import templates
 
 
@@ -58,6 +59,30 @@ def test_render_preserve_mode():
 def test_release_quality_badge():
     t = templates.Templates(NODE_TEMPLATES)
     result = t.render(
-        "README.md", metadata={"repo": {"release_quality": "beta"}, "samples": {}}
+        "README.md", metadata={"repo": {"release_level": "beta"}, "samples": {}}
     ).read_text()
     assert f"https://img.shields.io/badge/release%20level-beta-yellow.svg" in result
+    assert "This library is considered to be in **beta**" in result
+
+
+def test_load_samples():
+    cwd = os.getcwd()
+    os.chdir(FIXTURES)
+
+    common_templates = common.CommonTemplates()
+    metadata = {}
+    common_templates._load_samples(metadata)
+    assert metadata["samples"][0]["name"] == "Requester Pays"
+    assert metadata["samples"][0]["file"] == "requesterPays.js"
+    assert len(metadata["samples"]) == 1
+
+    os.chdir(cwd)
+
+
+def test_syntax_highlighter():
+    t = templates.Templates(NODE_TEMPLATES)
+    result = t.render(
+        "README.md",
+        metadata={"repo": {"language": "nodejs"}, "quickstart": "const foo = 'bar'"},
+    ).read_text()
+    assert "```javascript" in result

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -72,9 +72,13 @@ def test_load_samples():
     common_templates = common.CommonTemplates()
     metadata = {}
     common_templates._load_samples(metadata)
+    # should have loaded samples.
     assert metadata["samples"][0]["name"] == "Requester Pays"
     assert metadata["samples"][0]["file"] == "requesterPays.js"
     assert len(metadata["samples"]) == 1
+    # should have loaded the special quickstart sample (ignoring header).
+    assert "ID of the Cloud Bigtable instance" in metadata["quickstart"]
+    assert "limitations under the License" not in metadata["quickstart"]
 
     os.chdir(cwd)
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -90,3 +90,17 @@ def test_syntax_highlighter():
         metadata={"repo": {"language": "nodejs"}, "quickstart": "const foo = 'bar'"},
     ).read_text()
     assert "```javascript" in result
+
+
+def test_hide_billing():
+    t = templates.Templates(NODE_TEMPLATES)
+
+    result = t.render(
+        "README.md", metadata={"repo": {"requires_billing": True}}
+    ).read_text()
+    assert "Enable billing for your project" in result
+
+    result = t.render(
+        "README.md", metadata={"repo": {"requires_billing": False}}
+    ).read_text()
+    assert "Enable billing for your project" not in result

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -20,6 +20,7 @@ from synthtool.sources import templates
 
 
 FIXTURES = Path(__file__).parent / "fixtures"
+NODE_TEMPLATES = Path(__file__).parent.parent / "synthtool/gcp/templates/node_library"
 
 
 def test_render():
@@ -52,3 +53,11 @@ def test_render_preserve_mode():
     result = t.render("executable.j2", name="executable")
 
     assert result.stat().st_mode == source_mode
+
+
+def test_release_quality_badge():
+    t = templates.Templates(NODE_TEMPLATES)
+    result = t.render(
+        "README.md", metadata={"repo": {"release_quality": "beta"}, "samples": {}}
+    ).read_text()
+    assert f"https://img.shields.io/badge/release%20level-beta-yellow.svg" in result


### PR DESCRIPTION
I'm midway through porting over the logic from `nodejs-repo-tools` for generating `samples/README.md`, and `./README.md`.

This process was made easier by the fact that @busunkim96 has been working to define a better meta-information file for our repos, which looks like this:

```json
{
        "name": "storage",
        "name_pretty": "Google Cloud Storage",
        "product_documentation": "https://cloud.google.com/storage", 
        "client_documentation": "https://cloud.google.com/nodejs/docs/reference/storage/2.3.x/",
        "issue_tracker": "https://issuetracker.google.com/savedsearches/559782",
        "release_level": "ga",
        "language": "nodejs",
        "repo": "googleapis/nodejs-storage",
        "distribution_name": "@google-cloud/storage"
}
```

☝️ prior to this effort, there was a standard way to fetch a lot of this information.