### PR TITLE
feat: skip README rendering if .repo-metadata.json does not exist

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -17,6 +17,7 @@ import os
 import re
 import yaml
 from pathlib import Path
+from typing import List
 
 from synthtool.languages import node
 from synthtool.sources import templates
@@ -33,14 +34,14 @@ _RE_SAMPLE_COMMENT_END = r"\[END \w+_quickstart]"
 class CommonTemplates:
     def __init__(self):
         self._templates = templates.Templates(_TEMPLATES_DIR)
+        self.excludes = []  # type: List[str]
 
     def _generic_library(self, directory: str, **kwargs) -> Path:
-        t = templates.TemplateGroup(_TEMPLATES_DIR / directory)
-
         # load common repo meta information (metadata that's not language specific).
         if "metadata" in kwargs:
-            self._load_generic_metadata(kwargs["metadata"], t)
+            self._load_generic_metadata(kwargs["metadata"])
 
+        t = templates.TemplateGroup(_TEMPLATES_DIR / directory, self.excludes)
         result = t.render(**kwargs)
         _tracked_paths.add(result)
         metadata.add_template_source(
@@ -52,6 +53,11 @@ class CommonTemplates:
         return self._generic_library("python_library", **kwargs)
 
     def node_library(self, **kwargs) -> Path:
+        # TODO: once we've migrated all Node.js repos to either having
+        #  .repo-metadata.json, or excluding README.md, we can remove this.
+        if not os.path.exists("./.repo-metadata.json"):
+            self.excludes.append("README.md")
+
         kwargs["metadata"] = node.read_metadata()
         kwargs["publish_token"] = node.get_publish_token(kwargs["metadata"]["name"])
         return self._generic_library("node_library", **kwargs)
@@ -65,7 +71,7 @@ class CommonTemplates:
     #
     # loads additional meta information from .repo-metadata.json.
     #
-    def _load_generic_metadata(self, metadata, template_group):
+    def _load_generic_metadata(self, metadata):
         self._load_samples(metadata)
         self._load_partials(metadata)
 
@@ -73,8 +79,6 @@ class CommonTemplates:
         if os.path.exists("./.repo-metadata.json"):
             with open("./.repo-metadata.json") as f:
                 metadata["repo"] = json.load(f)
-        else:
-            template_group.excludes.append("README.md")
 
     #
     # walks samples directory and builds up samples data-structure:

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -35,9 +35,12 @@ class CommonTemplates:
         self._templates = templates.Templates(_TEMPLATES_DIR)
 
     def _generic_library(self, directory: str, **kwargs) -> Path:
-        if "metadata" in kwargs:
-            self._load_generic_metadata(kwargs["metadata"])
         t = templates.TemplateGroup(_TEMPLATES_DIR / directory)
+
+        # load common repo meta information (metadata that's not language specific).
+        if "metadata" in kwargs:
+            self._load_generic_metadata(kwargs["metadata"], t)
+
         result = t.render(**kwargs)
         _tracked_paths.add(result)
         metadata.add_template_source(
@@ -62,7 +65,7 @@ class CommonTemplates:
     #
     # loads additional meta information from .repo-metadata.json.
     #
-    def _load_generic_metadata(self, metadata):
+    def _load_generic_metadata(self, metadata, template_group):
         self._load_samples(metadata)
         self._load_partials(metadata)
 
@@ -70,6 +73,8 @@ class CommonTemplates:
         if os.path.exists("./.repo-metadata.json"):
             with open("./.repo-metadata.json") as f:
                 metadata["repo"] = json.load(f)
+        else:
+            template_group.excludes.append("README.md")
 
     #
     # walks samples directory and builds up samples data-structure:

--- a/synthtool/sources/templates.py
+++ b/synthtool/sources/templates.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
+from typing import Union, List
 from pathlib import Path
 
 import jinja2
@@ -72,7 +72,7 @@ class TemplateGroup:
     def __init__(self, location: PathOrStr) -> None:
         self.env = _make_env(location)
         self.dir = tmp.tmpdir()
-        self.excludes = []
+        self.excludes = [] # type: List[str]
 
     def render(self, **kwargs) -> Path:
         for template_name in self.env.list_templates():

--- a/synthtool/sources/templates.py
+++ b/synthtool/sources/templates.py
@@ -72,11 +72,15 @@ class TemplateGroup:
     def __init__(self, location: PathOrStr) -> None:
         self.env = _make_env(location)
         self.dir = tmp.tmpdir()
+        self.excludes = []
 
     def render(self, **kwargs) -> Path:
         for template_name in self.env.list_templates():
-            print(template_name)
-            _render_to_path(self.env, template_name, self.dir, kwargs)
+            if template_name not in self.excludes:
+                print(f"Rendering: {template_name}")
+                _render_to_path(self.env, template_name, self.dir, kwargs)
+            else:
+                print(f"Skipping: {template_name}")
 
         return self.dir
 

--- a/synthtool/sources/templates.py
+++ b/synthtool/sources/templates.py
@@ -77,7 +77,7 @@ class TemplateGroup:
     def render(self, **kwargs) -> Path:
         for template_name in self.env.list_templates():
             if template_name not in self.excludes:
-                print(f"Rendering: {template_name}")
+                print(template_name)
                 _render_to_path(self.env, template_name, self.dir, kwargs)
             else:
                 print(f"Skipping: {template_name}")

--- a/synthtool/sources/templates.py
+++ b/synthtool/sources/templates.py
@@ -72,7 +72,7 @@ class TemplateGroup:
     def __init__(self, location: PathOrStr) -> None:
         self.env = _make_env(location)
         self.dir = tmp.tmpdir()
-        self.excludes = [] # type: List[str]
+        self.excludes = []  # type: List[str]
 
     def render(self, **kwargs) -> Path:
         for template_name in self.env.list_templates():

--- a/synthtool/sources/templates.py
+++ b/synthtool/sources/templates.py
@@ -69,10 +69,10 @@ class Templates:
 
 
 class TemplateGroup:
-    def __init__(self, location: PathOrStr) -> None:
+    def __init__(self, location: PathOrStr, excludes: List[str] = []) -> None:
         self.env = _make_env(location)
         self.dir = tmp.tmpdir()
-        self.excludes = []  # type: List[str]
+        self.excludes = excludes
 
     def render(self, **kwargs) -> Path:
         for template_name in self.env.list_templates():


### PR DESCRIPTION
This would protected us from the wall of broken README PRs we got last night.

We will want to do the same with `samples/README.md` generation.