### PR TITLE
fix: support consecutive capital letters

### DIFF
--- a/synthtool/__main__.py
+++ b/synthtool/__main__.py
@@ -14,7 +14,7 @@
 
 import os
 import sys
-from importlib import util
+import importlib.util
 from typing import List, Sequence
 
 import click
@@ -70,8 +70,8 @@ def main(synthfile: str, metadata: str, extra_args: Sequence[str]):
     if os.path.lexists(synth_file):
         synthtool.log.debug(f"Executing {synth_file}.")
         # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
-        spec = util.spec_from_file_location("synth", synth_file)
-        synth_module = util.module_from_spec(spec)
+        spec = importlib.util.spec_from_file_location("synth", synth_file)
+        synth_module = importlib.util.module_from_spec(spec)
 
         if spec.loader is None:
             raise ImportError("Could not import synth.py")

--- a/synthtool/__main__.py
+++ b/synthtool/__main__.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
 import os
 import sys
+from importlib import util
 from typing import List, Sequence
 
 import click
@@ -70,8 +70,8 @@ def main(synthfile: str, metadata: str, extra_args: Sequence[str]):
     if os.path.lexists(synth_file):
         synthtool.log.debug(f"Executing {synth_file}.")
         # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
-        spec = importlib.util.spec_from_file_location("synth", synth_file)
-        synth_module = importlib.util.module_from_spec(spec)
+        spec = util.spec_from_file_location("synth", synth_file)
+        synth_module = util.module_from_spec(spec)
 
         if spec.loader is None:
             raise ImportError("Could not import synth.py")

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -153,22 +153,10 @@ class CommonTemplates:
 
 def decamelize(str: str):
     """ parser to convert fooBar.js to Foo Bar. """
-    prev = " "
-    str2 = ""
-    for i in range(0, len(str)):
-        chr = str[i]
-        if prev == " ":
-            str2 += chr.upper()
-        elif re.match(r"[A-Z]", chr):
-            # handle "JSONFrom" -> "JSON From" case.
-            next = ""
-            if i < len(str) - 1:
-                next = str[i + 1]
-            # "CoolACL" -> "Cool ACL" case.
-            if not re.match(r"[A-Z]", prev) or re.match(r"[a-z]", next):
-                str2 += " "
-            str2 += chr
-        else:
-            str2 += chr
-        prev = str2[len(str2) - 1]
-    return str2
+    if not (str or len(str)):
+        return ""
+    str_decamelize = re.sub("^.", str[0].upper(), str)  # apple -> Apple.
+    str_decamelize = re.sub(
+        "([A-Z]+)([A-Z])([a-z0-9])", r"\1 \2\3", str_decamelize
+    )  # ACLbatman -> ACL Batman.
+    return re.sub("([a-z0-9])([A-Z])", r"\1 \2", str_decamelize)  # FooBar -> Foo Bar.

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -153,10 +153,16 @@ class CommonTemplates:
 
 def decamelize(str: str):
     """ parser to convert fooBar.js to Foo Bar. """
-    str2 = str[0].upper()
-    for chr in str[1:]:
-        if re.match(r"[A-Z]", chr):
-            str2 += " " + chr.upper()
+    str2 = ""
+    pchr = " "
+    for chr in str:
+        if pchr == " ":
+            str2 += chr.upper()
+        elif re.match(r"[A-Z]", chr):
+            if not re.match(r"[A-Z]", pchr):
+                str2 += " "
+            str2 += chr
         else:
             str2 += chr
+        pchr = str2[len(str2) - 1]
     return str2

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -153,16 +153,22 @@ class CommonTemplates:
 
 def decamelize(str: str):
     """ parser to convert fooBar.js to Foo Bar. """
+    prev = " "
     str2 = ""
-    pchr = " "
-    for chr in str:
-        if pchr == " ":
+    for i in range(0, len(str)):
+        chr = str[i]
+        if prev == " ":
             str2 += chr.upper()
         elif re.match(r"[A-Z]", chr):
-            if not re.match(r"[A-Z]", pchr):
+            # handle "JSONFrom" -> "JSON From" case.
+            next = ""
+            if i < len(str) - 1:
+                next = str[i + 1]
+            # "CoolACL" -> "Cool ACL" case.
+            if not re.match(r"[A-Z]", prev) or re.match(r"[a-z]", next):
                 str2 += " "
             str2 += chr
         else:
             str2 += chr
-        pchr = str2[len(str2) - 1]
+        prev = str2[len(str2) - 1]
     return str2

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -151,12 +151,12 @@ class CommonTemplates:
             metadata["partials"] = yaml.load(f, Loader=yaml.SafeLoader)
 
 
-def decamelize(str: str):
+def decamelize(value: str):
     """ parser to convert fooBar.js to Foo Bar. """
-    if not (str or len(str)):
+    if not value:
         return ""
-    str_decamelize = re.sub("^.", str[0].upper(), str)  # apple -> Apple.
+    str_decamelize = re.sub("^.", value[0].upper(), value)  # apple -> Apple.
     str_decamelize = re.sub(
         "([A-Z]+)([A-Z])([a-z0-9])", r"\1 \2\3", str_decamelize
-    )  # ACLbatman -> ACL Batman.
+    )  # ACLBatman -> ACL Batman.
     return re.sub("([a-z0-9])([A-Z])", r"\1 \2", str_decamelize)  # FooBar -> Foo Bar.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -24,5 +24,6 @@ def test_handles_acronym():
     assert decamelize("ACL") == "ACL"
     assert decamelize("coolACL") == "Cool ACL"
 
+
 def test_handles_spaces():
     assert decamelize("cool api") == "Cool Api"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -23,6 +23,7 @@ def test_converts_camel_to_title():
 def test_handles_acronym():
     assert decamelize("ACL") == "ACL"
     assert decamelize("coolACL") == "Cool ACL"
+    assert decamelize("loadJSONFromGCS") == "Load JSON From GCS"
 
 
 def test_handles_spaces():

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ def test_converts_camel_to_title():
 def test_handles_acronym():
     assert decamelize("ACL") == "ACL"
     assert decamelize("coolACL") == "Cool ACL"
-
 
 def test_handles_spaces():
     assert decamelize("cool api") == "Cool Api"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -24,7 +24,3 @@ def test_handles_acronym():
     assert decamelize("ACL") == "ACL"
     assert decamelize("coolACL") == "Cool ACL"
     assert decamelize("loadJSONFromGCS") == "Load JSON From GCS"
-
-
-def test_handles_spaces():
-    assert decamelize("cool api") == "Cool Api"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,29 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from synthtool.gcp.common import decamelize
+
+
+def test_converts_camel_to_title():
+    assert decamelize("fooBar") == "Foo Bar"
+    assert decamelize("fooBarSnuh") == "Foo Bar Snuh"
+
+
+def test_handles_acronym():
+    assert decamelize("ACL") == "ACL"
+    assert decamelize("coolACL") == "Cool ACL"
+
+
+def test_handles_spaces():
+    assert decamelize("cool api") == "Cool Api"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -24,3 +24,8 @@ def test_handles_acronym():
     assert decamelize("ACL") == "ACL"
     assert decamelize("coolACL") == "Cool ACL"
     assert decamelize("loadJSONFromGCS") == "Load JSON From GCS"
+
+
+def test_handles_empty_string():
+    assert decamelize(None) == ""
+    assert decamelize("") == ""


### PR DESCRIPTION
The simple algorithm I wrote for decamelize did not support acronyms well (the bug is [seen here](https://github.com/googleapis/nodejs-bigquery/blob/45b6f7634e6517ca217c0d73b59b818256549750/README.md)).

This PR extends the method adding this functionality and adds tests for this edge-case; CC: @steffnay

fixes: #219