### PR TITLE
fix: None was printing in samples/README if introduction missing

### DIFF
--- a/synthtool/gcp/templates/node_library/samples/README.md
+++ b/synthtool/gcp/templates/node_library/samples/README.md
@@ -6,7 +6,7 @@
 
 [![Open in Cloud Shell][shell_img]][shell_link]
 
-{{ metadata['partials'] and metadata['partials']['introduction'] }}
+{% if metadata['partials'] and metadata['partials']['introduction'] %}{{ metadata['partials']['introduction'] }}{% endif %}
 
 ## Table of Contents
 


### PR DESCRIPTION
The value `None` was printing in `samples/README` if no `.readme-partials.yaml` was provided ([see](https://github.com/googleapis/nodejs-bigquery/blob/5827be263eea9b97871918fcfca92243ce18465a/samples/README.md)).

CC: @steffnay this will address a little blip I saw in your auto generated README; I wouldn't let it block you, as READMEs will be generated automatically nightly.