### PR TITLE
feat: Add `generator_args` arg to populate `--generator-args` artman option

### DIFF
--- a/synthtool/gcp/artman.py
+++ b/synthtool/gcp/artman.py
@@ -113,7 +113,13 @@ class Artman:
         ]
 
         artman_command = " ".join(
-            map(str, ["artman", "--local", "--config", config] + additional_flags + ["generate"] + list(args))
+            map(
+                str,
+                ["artman", "--local", "--config", config]
+                + additional_flags
+                + ["generate"]
+                + list(args),
+            )
         )
 
         cmd = docker_cmd + [artman_command]

--- a/synthtool/gcp/artman.py
+++ b/synthtool/gcp/artman.py
@@ -58,16 +58,35 @@ class Artman:
     def docker_image(self) -> str:
         return self._docker_image_info()["RepoDigests"][0]
 
-    def run(self, image, root_dir, config, *args):
+    def run(self, image, root_dir, config, *args, generator_args=None):
         """Executes artman command in the artman container.
-          Args:
-              root_dir: The input directory that will be mounted to artman docker
-                  container as local googleapis directory.
-          Returns:
-              The output directory with artman-generated files.
-          """
+
+        Args:
+            image:
+                The Docker image for artman.
+            root_dir:
+                The input directory that will be mounted to artman docker
+                container as local googleapis directory.
+            config:
+                Path to artman configuration YAML file.
+            *args:
+                Arguments to artman that follow ``generate``. Defines which
+                artifacts to generate.
+            generator_args (Optional[List[str]]):
+                Additional arguments to pass to the gapic generator, such as
+                ``--dev_samples``.
+        Returns:
+            The output directory with artman-generated files.
+        """
         container_name = "artman-docker"
         output_dir = root_dir / "artman-genfiles"
+
+        additional_flags = []
+
+        if generator_args:
+            additional_flags.append(
+                "--generator-args='{}'".format(" ".join(generator_args))
+            )
 
         docker_cmd = [
             "docker",
@@ -94,7 +113,7 @@ class Artman:
         ]
 
         artman_command = " ".join(
-            map(str, ["artman", "--local", "--config", config, "generate"] + list(args))
+            map(str, ["artman", "--local", "--config", config] + additional_flags + ["generate"] + list(args))
         )
 
         cmd = docker_cmd + [artman_command]

--- a/synthtool/gcp/gapic_generator.py
+++ b/synthtool/gcp/gapic_generator.py
@@ -65,6 +65,7 @@ class GAPICGenerator:
         artman_output_name=None,
         private=False,
         include_protos=False,
+        generator_args=None,
     ):
         # map the language to the artman argument and subdir of genfiles
         GENERATE_FLAG_LANGUAGE = {
@@ -115,6 +116,7 @@ class GAPICGenerator:
             googleapis,
             config_path,
             gapic_language_arg,
+            generator_args=generator_args,
         )
 
         # Expect the output to be in the artman-genfiles directory.

--- a/synthtool/protos/metadata_pb2.py
+++ b/synthtool/protos/metadata_pb2.py
@@ -2,11 +2,13 @@
 # source: metadata.proto
 
 import sys
-_b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
+
+_b = sys.version_info[0] < 3 and (lambda x: x) or (lambda x: x.encode("latin1"))
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -16,483 +18,792 @@ from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
-  name='metadata.proto',
-  package='yoshi.synth.metadata',
-  syntax='proto3',
-  serialized_options=None,
-  serialized_pb=_b('\n\x0emetadata.proto\x12\x14yoshi.synth.metadata\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa3\x01\n\x08Metadata\x12/\n\x0bupdate_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\x07sources\x18\x02 \x03(\x0b\x32\x1c.yoshi.synth.metadata.Source\x12\x37\n\x0c\x64\x65stinations\x18\x03 \x03(\x0b\x32!.yoshi.synth.metadata.Destination\"\xb8\x01\n\x06Source\x12.\n\x03git\x18\x01 \x01(\x0b\x32\x1f.yoshi.synth.metadata.GitSourceH\x00\x12:\n\tgenerator\x18\x02 \x01(\x0b\x32%.yoshi.synth.metadata.GeneratorSourceH\x00\x12\x38\n\x08template\x18\x03 \x01(\x0b\x32$.yoshi.synth.metadata.TemplateSourceH\x00\x42\x08\n\x06source\"L\n\tGitSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06remote\x18\x02 \x01(\t\x12\x0b\n\x03sha\x18\x03 \x01(\t\x12\x14\n\x0cinternal_ref\x18\x04 \x01(\t\"F\n\x0fGeneratorSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x14\n\x0c\x64ocker_image\x18\x03 \x01(\t\"?\n\x0eTemplateSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06origin\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"\x94\x01\n\x0b\x44\x65stination\x12\x39\n\x06\x63lient\x18\x01 \x01(\x0b\x32\'.yoshi.synth.metadata.ClientDestinationH\x00\x12;\n\x07\x66ileset\x18\x02 \x01(\x0b\x32(.yoshi.synth.metadata.FileSetDestinationH\x00\x42\r\n\x0b\x44\x65stination\"\x7f\n\x11\x43lientDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x10\n\x08\x61pi_name\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_version\x18\x03 \x01(\t\x12\x10\n\x08language\x18\x04 \x01(\t\x12\x11\n\tgenerator\x18\x05 \x01(\t\x12\x0e\n\x06\x63onfig\x18\x06 \x01(\t\"3\n\x12\x46ileSetDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\r\n\x05\x66iles\x18\x02 \x03(\tb\x06proto3')
-  ,
-  dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,])
-
-
+    name="metadata.proto",
+    package="yoshi.synth.metadata",
+    syntax="proto3",
+    serialized_options=None,
+    serialized_pb=_b(
+        '\n\x0emetadata.proto\x12\x14yoshi.synth.metadata\x1a\x1fgoogle/protobuf/timestamp.proto"\xa3\x01\n\x08Metadata\x12/\n\x0bupdate_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\x07sources\x18\x02 \x03(\x0b\x32\x1c.yoshi.synth.metadata.Source\x12\x37\n\x0c\x64\x65stinations\x18\x03 \x03(\x0b\x32!.yoshi.synth.metadata.Destination"\xb8\x01\n\x06Source\x12.\n\x03git\x18\x01 \x01(\x0b\x32\x1f.yoshi.synth.metadata.GitSourceH\x00\x12:\n\tgenerator\x18\x02 \x01(\x0b\x32%.yoshi.synth.metadata.GeneratorSourceH\x00\x12\x38\n\x08template\x18\x03 \x01(\x0b\x32$.yoshi.synth.metadata.TemplateSourceH\x00\x42\x08\n\x06source"L\n\tGitSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06remote\x18\x02 \x01(\t\x12\x0b\n\x03sha\x18\x03 \x01(\t\x12\x14\n\x0cinternal_ref\x18\x04 \x01(\t"F\n\x0fGeneratorSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x14\n\x0c\x64ocker_image\x18\x03 \x01(\t"?\n\x0eTemplateSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06origin\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t"\x94\x01\n\x0b\x44\x65stination\x12\x39\n\x06\x63lient\x18\x01 \x01(\x0b\x32\'.yoshi.synth.metadata.ClientDestinationH\x00\x12;\n\x07\x66ileset\x18\x02 \x01(\x0b\x32(.yoshi.synth.metadata.FileSetDestinationH\x00\x42\r\n\x0b\x44\x65stination"\x7f\n\x11\x43lientDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x10\n\x08\x61pi_name\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_version\x18\x03 \x01(\t\x12\x10\n\x08language\x18\x04 \x01(\t\x12\x11\n\tgenerator\x18\x05 \x01(\t\x12\x0e\n\x06\x63onfig\x18\x06 \x01(\t"3\n\x12\x46ileSetDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\r\n\x05\x66iles\x18\x02 \x03(\tb\x06proto3'
+    ),
+    dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR],
+)
 
 
 _METADATA = _descriptor.Descriptor(
-  name='Metadata',
-  full_name='yoshi.synth.metadata.Metadata',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='update_time', full_name='yoshi.synth.metadata.Metadata.update_time', index=0,
-      number=1, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='sources', full_name='yoshi.synth.metadata.Metadata.sources', index=1,
-      number=2, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='destinations', full_name='yoshi.synth.metadata.Metadata.destinations', index=2,
-      number=3, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=74,
-  serialized_end=237,
+    name="Metadata",
+    full_name="yoshi.synth.metadata.Metadata",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="update_time",
+            full_name="yoshi.synth.metadata.Metadata.update_time",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="sources",
+            full_name="yoshi.synth.metadata.Metadata.sources",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="destinations",
+            full_name="yoshi.synth.metadata.Metadata.destinations",
+            index=2,
+            number=3,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=74,
+    serialized_end=237,
 )
 
 
 _SOURCE = _descriptor.Descriptor(
-  name='Source',
-  full_name='yoshi.synth.metadata.Source',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='git', full_name='yoshi.synth.metadata.Source.git', index=0,
-      number=1, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='generator', full_name='yoshi.synth.metadata.Source.generator', index=1,
-      number=2, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='template', full_name='yoshi.synth.metadata.Source.template', index=2,
-      number=3, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-    _descriptor.OneofDescriptor(
-      name='source', full_name='yoshi.synth.metadata.Source.source',
-      index=0, containing_type=None, fields=[]),
-  ],
-  serialized_start=240,
-  serialized_end=424,
+    name="Source",
+    full_name="yoshi.synth.metadata.Source",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="git",
+            full_name="yoshi.synth.metadata.Source.git",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="generator",
+            full_name="yoshi.synth.metadata.Source.generator",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="template",
+            full_name="yoshi.synth.metadata.Source.template",
+            index=2,
+            number=3,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[
+        _descriptor.OneofDescriptor(
+            name="source",
+            full_name="yoshi.synth.metadata.Source.source",
+            index=0,
+            containing_type=None,
+            fields=[],
+        )
+    ],
+    serialized_start=240,
+    serialized_end=424,
 )
 
 
 _GITSOURCE = _descriptor.Descriptor(
-  name='GitSource',
-  full_name='yoshi.synth.metadata.GitSource',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='name', full_name='yoshi.synth.metadata.GitSource.name', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='remote', full_name='yoshi.synth.metadata.GitSource.remote', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='sha', full_name='yoshi.synth.metadata.GitSource.sha', index=2,
-      number=3, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='internal_ref', full_name='yoshi.synth.metadata.GitSource.internal_ref', index=3,
-      number=4, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=426,
-  serialized_end=502,
+    name="GitSource",
+    full_name="yoshi.synth.metadata.GitSource",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="name",
+            full_name="yoshi.synth.metadata.GitSource.name",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="remote",
+            full_name="yoshi.synth.metadata.GitSource.remote",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="sha",
+            full_name="yoshi.synth.metadata.GitSource.sha",
+            index=2,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="internal_ref",
+            full_name="yoshi.synth.metadata.GitSource.internal_ref",
+            index=3,
+            number=4,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=426,
+    serialized_end=502,
 )
 
 
 _GENERATORSOURCE = _descriptor.Descriptor(
-  name='GeneratorSource',
-  full_name='yoshi.synth.metadata.GeneratorSource',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='name', full_name='yoshi.synth.metadata.GeneratorSource.name', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='version', full_name='yoshi.synth.metadata.GeneratorSource.version', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='docker_image', full_name='yoshi.synth.metadata.GeneratorSource.docker_image', index=2,
-      number=3, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=504,
-  serialized_end=574,
+    name="GeneratorSource",
+    full_name="yoshi.synth.metadata.GeneratorSource",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="name",
+            full_name="yoshi.synth.metadata.GeneratorSource.name",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="version",
+            full_name="yoshi.synth.metadata.GeneratorSource.version",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="docker_image",
+            full_name="yoshi.synth.metadata.GeneratorSource.docker_image",
+            index=2,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=504,
+    serialized_end=574,
 )
 
 
 _TEMPLATESOURCE = _descriptor.Descriptor(
-  name='TemplateSource',
-  full_name='yoshi.synth.metadata.TemplateSource',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='name', full_name='yoshi.synth.metadata.TemplateSource.name', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='origin', full_name='yoshi.synth.metadata.TemplateSource.origin', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='version', full_name='yoshi.synth.metadata.TemplateSource.version', index=2,
-      number=3, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=576,
-  serialized_end=639,
+    name="TemplateSource",
+    full_name="yoshi.synth.metadata.TemplateSource",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="name",
+            full_name="yoshi.synth.metadata.TemplateSource.name",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="origin",
+            full_name="yoshi.synth.metadata.TemplateSource.origin",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="version",
+            full_name="yoshi.synth.metadata.TemplateSource.version",
+            index=2,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=576,
+    serialized_end=639,
 )
 
 
 _DESTINATION = _descriptor.Descriptor(
-  name='Destination',
-  full_name='yoshi.synth.metadata.Destination',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='client', full_name='yoshi.synth.metadata.Destination.client', index=0,
-      number=1, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='fileset', full_name='yoshi.synth.metadata.Destination.fileset', index=1,
-      number=2, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-    _descriptor.OneofDescriptor(
-      name='Destination', full_name='yoshi.synth.metadata.Destination.Destination',
-      index=0, containing_type=None, fields=[]),
-  ],
-  serialized_start=642,
-  serialized_end=790,
+    name="Destination",
+    full_name="yoshi.synth.metadata.Destination",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="client",
+            full_name="yoshi.synth.metadata.Destination.client",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="fileset",
+            full_name="yoshi.synth.metadata.Destination.fileset",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[
+        _descriptor.OneofDescriptor(
+            name="Destination",
+            full_name="yoshi.synth.metadata.Destination.Destination",
+            index=0,
+            containing_type=None,
+            fields=[],
+        )
+    ],
+    serialized_start=642,
+    serialized_end=790,
 )
 
 
 _CLIENTDESTINATION = _descriptor.Descriptor(
-  name='ClientDestination',
-  full_name='yoshi.synth.metadata.ClientDestination',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='source', full_name='yoshi.synth.metadata.ClientDestination.source', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='api_name', full_name='yoshi.synth.metadata.ClientDestination.api_name', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='api_version', full_name='yoshi.synth.metadata.ClientDestination.api_version', index=2,
-      number=3, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='language', full_name='yoshi.synth.metadata.ClientDestination.language', index=3,
-      number=4, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='generator', full_name='yoshi.synth.metadata.ClientDestination.generator', index=4,
-      number=5, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='config', full_name='yoshi.synth.metadata.ClientDestination.config', index=5,
-      number=6, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=792,
-  serialized_end=919,
+    name="ClientDestination",
+    full_name="yoshi.synth.metadata.ClientDestination",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="source",
+            full_name="yoshi.synth.metadata.ClientDestination.source",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="api_name",
+            full_name="yoshi.synth.metadata.ClientDestination.api_name",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="api_version",
+            full_name="yoshi.synth.metadata.ClientDestination.api_version",
+            index=2,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="language",
+            full_name="yoshi.synth.metadata.ClientDestination.language",
+            index=3,
+            number=4,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="generator",
+            full_name="yoshi.synth.metadata.ClientDestination.generator",
+            index=4,
+            number=5,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="config",
+            full_name="yoshi.synth.metadata.ClientDestination.config",
+            index=5,
+            number=6,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=792,
+    serialized_end=919,
 )
 
 
 _FILESETDESTINATION = _descriptor.Descriptor(
-  name='FileSetDestination',
-  full_name='yoshi.synth.metadata.FileSetDestination',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='source', full_name='yoshi.synth.metadata.FileSetDestination.source', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='files', full_name='yoshi.synth.metadata.FileSetDestination.files', index=1,
-      number=2, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=921,
-  serialized_end=972,
+    name="FileSetDestination",
+    full_name="yoshi.synth.metadata.FileSetDestination",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="source",
+            full_name="yoshi.synth.metadata.FileSetDestination.source",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="files",
+            full_name="yoshi.synth.metadata.FileSetDestination.files",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=921,
+    serialized_end=972,
 )
 
-_METADATA.fields_by_name['update_time'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
-_METADATA.fields_by_name['sources'].message_type = _SOURCE
-_METADATA.fields_by_name['destinations'].message_type = _DESTINATION
-_SOURCE.fields_by_name['git'].message_type = _GITSOURCE
-_SOURCE.fields_by_name['generator'].message_type = _GENERATORSOURCE
-_SOURCE.fields_by_name['template'].message_type = _TEMPLATESOURCE
-_SOURCE.oneofs_by_name['source'].fields.append(
-  _SOURCE.fields_by_name['git'])
-_SOURCE.fields_by_name['git'].containing_oneof = _SOURCE.oneofs_by_name['source']
-_SOURCE.oneofs_by_name['source'].fields.append(
-  _SOURCE.fields_by_name['generator'])
-_SOURCE.fields_by_name['generator'].containing_oneof = _SOURCE.oneofs_by_name['source']
-_SOURCE.oneofs_by_name['source'].fields.append(
-  _SOURCE.fields_by_name['template'])
-_SOURCE.fields_by_name['template'].containing_oneof = _SOURCE.oneofs_by_name['source']
-_DESTINATION.fields_by_name['client'].message_type = _CLIENTDESTINATION
-_DESTINATION.fields_by_name['fileset'].message_type = _FILESETDESTINATION
-_DESTINATION.oneofs_by_name['Destination'].fields.append(
-  _DESTINATION.fields_by_name['client'])
-_DESTINATION.fields_by_name['client'].containing_oneof = _DESTINATION.oneofs_by_name['Destination']
-_DESTINATION.oneofs_by_name['Destination'].fields.append(
-  _DESTINATION.fields_by_name['fileset'])
-_DESTINATION.fields_by_name['fileset'].containing_oneof = _DESTINATION.oneofs_by_name['Destination']
-DESCRIPTOR.message_types_by_name['Metadata'] = _METADATA
-DESCRIPTOR.message_types_by_name['Source'] = _SOURCE
-DESCRIPTOR.message_types_by_name['GitSource'] = _GITSOURCE
-DESCRIPTOR.message_types_by_name['GeneratorSource'] = _GENERATORSOURCE
-DESCRIPTOR.message_types_by_name['TemplateSource'] = _TEMPLATESOURCE
-DESCRIPTOR.message_types_by_name['Destination'] = _DESTINATION
-DESCRIPTOR.message_types_by_name['ClientDestination'] = _CLIENTDESTINATION
-DESCRIPTOR.message_types_by_name['FileSetDestination'] = _FILESETDESTINATION
+_METADATA.fields_by_name[
+    "update_time"
+].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
+_METADATA.fields_by_name["sources"].message_type = _SOURCE
+_METADATA.fields_by_name["destinations"].message_type = _DESTINATION
+_SOURCE.fields_by_name["git"].message_type = _GITSOURCE
+_SOURCE.fields_by_name["generator"].message_type = _GENERATORSOURCE
+_SOURCE.fields_by_name["template"].message_type = _TEMPLATESOURCE
+_SOURCE.oneofs_by_name["source"].fields.append(_SOURCE.fields_by_name["git"])
+_SOURCE.fields_by_name["git"].containing_oneof = _SOURCE.oneofs_by_name["source"]
+_SOURCE.oneofs_by_name["source"].fields.append(_SOURCE.fields_by_name["generator"])
+_SOURCE.fields_by_name["generator"].containing_oneof = _SOURCE.oneofs_by_name["source"]
+_SOURCE.oneofs_by_name["source"].fields.append(_SOURCE.fields_by_name["template"])
+_SOURCE.fields_by_name["template"].containing_oneof = _SOURCE.oneofs_by_name["source"]
+_DESTINATION.fields_by_name["client"].message_type = _CLIENTDESTINATION
+_DESTINATION.fields_by_name["fileset"].message_type = _FILESETDESTINATION
+_DESTINATION.oneofs_by_name["Destination"].fields.append(
+    _DESTINATION.fields_by_name["client"]
+)
+_DESTINATION.fields_by_name["client"].containing_oneof = _DESTINATION.oneofs_by_name[
+    "Destination"
+]
+_DESTINATION.oneofs_by_name["Destination"].fields.append(
+    _DESTINATION.fields_by_name["fileset"]
+)
+_DESTINATION.fields_by_name["fileset"].containing_oneof = _DESTINATION.oneofs_by_name[
+    "Destination"
+]
+DESCRIPTOR.message_types_by_name["Metadata"] = _METADATA
+DESCRIPTOR.message_types_by_name["Source"] = _SOURCE
+DESCRIPTOR.message_types_by_name["GitSource"] = _GITSOURCE
+DESCRIPTOR.message_types_by_name["GeneratorSource"] = _GENERATORSOURCE
+DESCRIPTOR.message_types_by_name["TemplateSource"] = _TEMPLATESOURCE
+DESCRIPTOR.message_types_by_name["Destination"] = _DESTINATION
+DESCRIPTOR.message_types_by_name["ClientDestination"] = _CLIENTDESTINATION
+DESCRIPTOR.message_types_by_name["FileSetDestination"] = _FILESETDESTINATION
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
-Metadata = _reflection.GeneratedProtocolMessageType('Metadata', (_message.Message,), dict(
-  DESCRIPTOR = _METADATA,
-  __module__ = 'metadata_pb2'
-  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.Metadata)
-  ))
+Metadata = _reflection.GeneratedProtocolMessageType(
+    "Metadata",
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_METADATA,
+        __module__="metadata_pb2"
+        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.Metadata)
+    ),
+)
 _sym_db.RegisterMessage(Metadata)
 
-Source = _reflection.GeneratedProtocolMessageType('Source', (_message.Message,), dict(
-  DESCRIPTOR = _SOURCE,
-  __module__ = 'metadata_pb2'
-  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.Source)
-  ))
+Source = _reflection.GeneratedProtocolMessageType(
+    "Source",
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_SOURCE,
+        __module__="metadata_pb2"
+        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.Source)
+    ),
+)
 _sym_db.RegisterMessage(Source)
 
-GitSource = _reflection.GeneratedProtocolMessageType('GitSource', (_message.Message,), dict(
-  DESCRIPTOR = _GITSOURCE,
-  __module__ = 'metadata_pb2'
-  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.GitSource)
-  ))
+GitSource = _reflection.GeneratedProtocolMessageType(
+    "GitSource",
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_GITSOURCE,
+        __module__="metadata_pb2"
+        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.GitSource)
+    ),
+)
 _sym_db.RegisterMessage(GitSource)
 
-GeneratorSource = _reflection.GeneratedProtocolMessageType('GeneratorSource', (_message.Message,), dict(
-  DESCRIPTOR = _GENERATORSOURCE,
-  __module__ = 'metadata_pb2'
-  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.GeneratorSource)
-  ))
+GeneratorSource = _reflection.GeneratedProtocolMessageType(
+    "GeneratorSource",
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_GENERATORSOURCE,
+        __module__="metadata_pb2"
+        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.GeneratorSource)
+    ),
+)
 _sym_db.RegisterMessage(GeneratorSource)
 
-TemplateSource = _reflection.GeneratedProtocolMessageType('TemplateSource', (_message.Message,), dict(
-  DESCRIPTOR = _TEMPLATESOURCE,
-  __module__ = 'metadata_pb2'
-  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.TemplateSource)
-  ))
+TemplateSource = _reflection.GeneratedProtocolMessageType(
+    "TemplateSource",
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_TEMPLATESOURCE,
+        __module__="metadata_pb2"
+        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.TemplateSource)
+    ),
+)
 _sym_db.RegisterMessage(TemplateSource)
 
-Destination = _reflection.GeneratedProtocolMessageType('Destination', (_message.Message,), dict(
-  DESCRIPTOR = _DESTINATION,
-  __module__ = 'metadata_pb2'
-  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.Destination)
-  ))
+Destination = _reflection.GeneratedProtocolMessageType(
+    "Destination",
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_DESTINATION,
+        __module__="metadata_pb2"
+        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.Destination)
+    ),
+)
 _sym_db.RegisterMessage(Destination)
 
-ClientDestination = _reflection.GeneratedProtocolMessageType('ClientDestination', (_message.Message,), dict(
-  DESCRIPTOR = _CLIENTDESTINATION,
-  __module__ = 'metadata_pb2'
-  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.ClientDestination)
-  ))
+ClientDestination = _reflection.GeneratedProtocolMessageType(
+    "ClientDestination",
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_CLIENTDESTINATION,
+        __module__="metadata_pb2"
+        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.ClientDestination)
+    ),
+)
 _sym_db.RegisterMessage(ClientDestination)
 
-FileSetDestination = _reflection.GeneratedProtocolMessageType('FileSetDestination', (_message.Message,), dict(
-  DESCRIPTOR = _FILESETDESTINATION,
-  __module__ = 'metadata_pb2'
-  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.FileSetDestination)
-  ))
+FileSetDestination = _reflection.GeneratedProtocolMessageType(
+    "FileSetDestination",
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_FILESETDESTINATION,
+        __module__="metadata_pb2"
+        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.FileSetDestination)
+    ),
+)
 _sym_db.RegisterMessage(FileSetDestination)
 
 

--- a/synthtool/protos/metadata_pb2.py
+++ b/synthtool/protos/metadata_pb2.py
@@ -2,13 +2,11 @@
 # source: metadata.proto
 
 import sys
-
-_b = sys.version_info[0] < 3 and (lambda x: x) or (lambda x: x.encode("latin1"))
+_b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -18,792 +16,483 @@ from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
-    name="metadata.proto",
-    package="yoshi.synth.metadata",
-    syntax="proto3",
-    serialized_options=None,
-    serialized_pb=_b(
-        '\n\x0emetadata.proto\x12\x14yoshi.synth.metadata\x1a\x1fgoogle/protobuf/timestamp.proto"\xa3\x01\n\x08Metadata\x12/\n\x0bupdate_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\x07sources\x18\x02 \x03(\x0b\x32\x1c.yoshi.synth.metadata.Source\x12\x37\n\x0c\x64\x65stinations\x18\x03 \x03(\x0b\x32!.yoshi.synth.metadata.Destination"\xb8\x01\n\x06Source\x12.\n\x03git\x18\x01 \x01(\x0b\x32\x1f.yoshi.synth.metadata.GitSourceH\x00\x12:\n\tgenerator\x18\x02 \x01(\x0b\x32%.yoshi.synth.metadata.GeneratorSourceH\x00\x12\x38\n\x08template\x18\x03 \x01(\x0b\x32$.yoshi.synth.metadata.TemplateSourceH\x00\x42\x08\n\x06source"L\n\tGitSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06remote\x18\x02 \x01(\t\x12\x0b\n\x03sha\x18\x03 \x01(\t\x12\x14\n\x0cinternal_ref\x18\x04 \x01(\t"F\n\x0fGeneratorSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x14\n\x0c\x64ocker_image\x18\x03 \x01(\t"?\n\x0eTemplateSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06origin\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t"\x94\x01\n\x0b\x44\x65stination\x12\x39\n\x06\x63lient\x18\x01 \x01(\x0b\x32\'.yoshi.synth.metadata.ClientDestinationH\x00\x12;\n\x07\x66ileset\x18\x02 \x01(\x0b\x32(.yoshi.synth.metadata.FileSetDestinationH\x00\x42\r\n\x0b\x44\x65stination"\x7f\n\x11\x43lientDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x10\n\x08\x61pi_name\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_version\x18\x03 \x01(\t\x12\x10\n\x08language\x18\x04 \x01(\t\x12\x11\n\tgenerator\x18\x05 \x01(\t\x12\x0e\n\x06\x63onfig\x18\x06 \x01(\t"3\n\x12\x46ileSetDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\r\n\x05\x66iles\x18\x02 \x03(\tb\x06proto3'
-    ),
-    dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR],
-)
+  name='metadata.proto',
+  package='yoshi.synth.metadata',
+  syntax='proto3',
+  serialized_options=None,
+  serialized_pb=_b('\n\x0emetadata.proto\x12\x14yoshi.synth.metadata\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa3\x01\n\x08Metadata\x12/\n\x0bupdate_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\x07sources\x18\x02 \x03(\x0b\x32\x1c.yoshi.synth.metadata.Source\x12\x37\n\x0c\x64\x65stinations\x18\x03 \x03(\x0b\x32!.yoshi.synth.metadata.Destination\"\xb8\x01\n\x06Source\x12.\n\x03git\x18\x01 \x01(\x0b\x32\x1f.yoshi.synth.metadata.GitSourceH\x00\x12:\n\tgenerator\x18\x02 \x01(\x0b\x32%.yoshi.synth.metadata.GeneratorSourceH\x00\x12\x38\n\x08template\x18\x03 \x01(\x0b\x32$.yoshi.synth.metadata.TemplateSourceH\x00\x42\x08\n\x06source\"L\n\tGitSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06remote\x18\x02 \x01(\t\x12\x0b\n\x03sha\x18\x03 \x01(\t\x12\x14\n\x0cinternal_ref\x18\x04 \x01(\t\"F\n\x0fGeneratorSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x14\n\x0c\x64ocker_image\x18\x03 \x01(\t\"?\n\x0eTemplateSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06origin\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t\"\x94\x01\n\x0b\x44\x65stination\x12\x39\n\x06\x63lient\x18\x01 \x01(\x0b\x32\'.yoshi.synth.metadata.ClientDestinationH\x00\x12;\n\x07\x66ileset\x18\x02 \x01(\x0b\x32(.yoshi.synth.metadata.FileSetDestinationH\x00\x42\r\n\x0b\x44\x65stination\"\x7f\n\x11\x43lientDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x10\n\x08\x61pi_name\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_version\x18\x03 \x01(\t\x12\x10\n\x08language\x18\x04 \x01(\t\x12\x11\n\tgenerator\x18\x05 \x01(\t\x12\x0e\n\x06\x63onfig\x18\x06 \x01(\t\"3\n\x12\x46ileSetDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\r\n\x05\x66iles\x18\x02 \x03(\tb\x06proto3')
+  ,
+  dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,])
+
+
 
 
 _METADATA = _descriptor.Descriptor(
-    name="Metadata",
-    full_name="yoshi.synth.metadata.Metadata",
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name="update_time",
-            full_name="yoshi.synth.metadata.Metadata.update_time",
-            index=0,
-            number=1,
-            type=11,
-            cpp_type=10,
-            label=1,
-            has_default_value=False,
-            default_value=None,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="sources",
-            full_name="yoshi.synth.metadata.Metadata.sources",
-            index=1,
-            number=2,
-            type=11,
-            cpp_type=10,
-            label=3,
-            has_default_value=False,
-            default_value=[],
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="destinations",
-            full_name="yoshi.synth.metadata.Metadata.destinations",
-            index=2,
-            number=3,
-            type=11,
-            cpp_type=10,
-            label=3,
-            has_default_value=False,
-            default_value=[],
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-    ],
-    extensions=[],
-    nested_types=[],
-    enum_types=[],
-    serialized_options=None,
-    is_extendable=False,
-    syntax="proto3",
-    extension_ranges=[],
-    oneofs=[],
-    serialized_start=74,
-    serialized_end=237,
+  name='Metadata',
+  full_name='yoshi.synth.metadata.Metadata',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='update_time', full_name='yoshi.synth.metadata.Metadata.update_time', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='sources', full_name='yoshi.synth.metadata.Metadata.sources', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='destinations', full_name='yoshi.synth.metadata.Metadata.destinations', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=74,
+  serialized_end=237,
 )
 
 
 _SOURCE = _descriptor.Descriptor(
-    name="Source",
-    full_name="yoshi.synth.metadata.Source",
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name="git",
-            full_name="yoshi.synth.metadata.Source.git",
-            index=0,
-            number=1,
-            type=11,
-            cpp_type=10,
-            label=1,
-            has_default_value=False,
-            default_value=None,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="generator",
-            full_name="yoshi.synth.metadata.Source.generator",
-            index=1,
-            number=2,
-            type=11,
-            cpp_type=10,
-            label=1,
-            has_default_value=False,
-            default_value=None,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="template",
-            full_name="yoshi.synth.metadata.Source.template",
-            index=2,
-            number=3,
-            type=11,
-            cpp_type=10,
-            label=1,
-            has_default_value=False,
-            default_value=None,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-    ],
-    extensions=[],
-    nested_types=[],
-    enum_types=[],
-    serialized_options=None,
-    is_extendable=False,
-    syntax="proto3",
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name="source",
-            full_name="yoshi.synth.metadata.Source.source",
-            index=0,
-            containing_type=None,
-            fields=[],
-        )
-    ],
-    serialized_start=240,
-    serialized_end=424,
+  name='Source',
+  full_name='yoshi.synth.metadata.Source',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='git', full_name='yoshi.synth.metadata.Source.git', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='generator', full_name='yoshi.synth.metadata.Source.generator', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='template', full_name='yoshi.synth.metadata.Source.template', index=2,
+      number=3, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='source', full_name='yoshi.synth.metadata.Source.source',
+      index=0, containing_type=None, fields=[]),
+  ],
+  serialized_start=240,
+  serialized_end=424,
 )
 
 
 _GITSOURCE = _descriptor.Descriptor(
-    name="GitSource",
-    full_name="yoshi.synth.metadata.GitSource",
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name="name",
-            full_name="yoshi.synth.metadata.GitSource.name",
-            index=0,
-            number=1,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="remote",
-            full_name="yoshi.synth.metadata.GitSource.remote",
-            index=1,
-            number=2,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="sha",
-            full_name="yoshi.synth.metadata.GitSource.sha",
-            index=2,
-            number=3,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="internal_ref",
-            full_name="yoshi.synth.metadata.GitSource.internal_ref",
-            index=3,
-            number=4,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-    ],
-    extensions=[],
-    nested_types=[],
-    enum_types=[],
-    serialized_options=None,
-    is_extendable=False,
-    syntax="proto3",
-    extension_ranges=[],
-    oneofs=[],
-    serialized_start=426,
-    serialized_end=502,
+  name='GitSource',
+  full_name='yoshi.synth.metadata.GitSource',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='yoshi.synth.metadata.GitSource.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='remote', full_name='yoshi.synth.metadata.GitSource.remote', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='sha', full_name='yoshi.synth.metadata.GitSource.sha', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='internal_ref', full_name='yoshi.synth.metadata.GitSource.internal_ref', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=426,
+  serialized_end=502,
 )
 
 
 _GENERATORSOURCE = _descriptor.Descriptor(
-    name="GeneratorSource",
-    full_name="yoshi.synth.metadata.GeneratorSource",
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name="name",
-            full_name="yoshi.synth.metadata.GeneratorSource.name",
-            index=0,
-            number=1,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="version",
-            full_name="yoshi.synth.metadata.GeneratorSource.version",
-            index=1,
-            number=2,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="docker_image",
-            full_name="yoshi.synth.metadata.GeneratorSource.docker_image",
-            index=2,
-            number=3,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-    ],
-    extensions=[],
-    nested_types=[],
-    enum_types=[],
-    serialized_options=None,
-    is_extendable=False,
-    syntax="proto3",
-    extension_ranges=[],
-    oneofs=[],
-    serialized_start=504,
-    serialized_end=574,
+  name='GeneratorSource',
+  full_name='yoshi.synth.metadata.GeneratorSource',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='yoshi.synth.metadata.GeneratorSource.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='version', full_name='yoshi.synth.metadata.GeneratorSource.version', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='docker_image', full_name='yoshi.synth.metadata.GeneratorSource.docker_image', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=504,
+  serialized_end=574,
 )
 
 
 _TEMPLATESOURCE = _descriptor.Descriptor(
-    name="TemplateSource",
-    full_name="yoshi.synth.metadata.TemplateSource",
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name="name",
-            full_name="yoshi.synth.metadata.TemplateSource.name",
-            index=0,
-            number=1,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="origin",
-            full_name="yoshi.synth.metadata.TemplateSource.origin",
-            index=1,
-            number=2,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="version",
-            full_name="yoshi.synth.metadata.TemplateSource.version",
-            index=2,
-            number=3,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-    ],
-    extensions=[],
-    nested_types=[],
-    enum_types=[],
-    serialized_options=None,
-    is_extendable=False,
-    syntax="proto3",
-    extension_ranges=[],
-    oneofs=[],
-    serialized_start=576,
-    serialized_end=639,
+  name='TemplateSource',
+  full_name='yoshi.synth.metadata.TemplateSource',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='yoshi.synth.metadata.TemplateSource.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='origin', full_name='yoshi.synth.metadata.TemplateSource.origin', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='version', full_name='yoshi.synth.metadata.TemplateSource.version', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=576,
+  serialized_end=639,
 )
 
 
 _DESTINATION = _descriptor.Descriptor(
-    name="Destination",
-    full_name="yoshi.synth.metadata.Destination",
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name="client",
-            full_name="yoshi.synth.metadata.Destination.client",
-            index=0,
-            number=1,
-            type=11,
-            cpp_type=10,
-            label=1,
-            has_default_value=False,
-            default_value=None,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="fileset",
-            full_name="yoshi.synth.metadata.Destination.fileset",
-            index=1,
-            number=2,
-            type=11,
-            cpp_type=10,
-            label=1,
-            has_default_value=False,
-            default_value=None,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-    ],
-    extensions=[],
-    nested_types=[],
-    enum_types=[],
-    serialized_options=None,
-    is_extendable=False,
-    syntax="proto3",
-    extension_ranges=[],
-    oneofs=[
-        _descriptor.OneofDescriptor(
-            name="Destination",
-            full_name="yoshi.synth.metadata.Destination.Destination",
-            index=0,
-            containing_type=None,
-            fields=[],
-        )
-    ],
-    serialized_start=642,
-    serialized_end=790,
+  name='Destination',
+  full_name='yoshi.synth.metadata.Destination',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='client', full_name='yoshi.synth.metadata.Destination.client', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='fileset', full_name='yoshi.synth.metadata.Destination.fileset', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='Destination', full_name='yoshi.synth.metadata.Destination.Destination',
+      index=0, containing_type=None, fields=[]),
+  ],
+  serialized_start=642,
+  serialized_end=790,
 )
 
 
 _CLIENTDESTINATION = _descriptor.Descriptor(
-    name="ClientDestination",
-    full_name="yoshi.synth.metadata.ClientDestination",
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name="source",
-            full_name="yoshi.synth.metadata.ClientDestination.source",
-            index=0,
-            number=1,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="api_name",
-            full_name="yoshi.synth.metadata.ClientDestination.api_name",
-            index=1,
-            number=2,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="api_version",
-            full_name="yoshi.synth.metadata.ClientDestination.api_version",
-            index=2,
-            number=3,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="language",
-            full_name="yoshi.synth.metadata.ClientDestination.language",
-            index=3,
-            number=4,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="generator",
-            full_name="yoshi.synth.metadata.ClientDestination.generator",
-            index=4,
-            number=5,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="config",
-            full_name="yoshi.synth.metadata.ClientDestination.config",
-            index=5,
-            number=6,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-    ],
-    extensions=[],
-    nested_types=[],
-    enum_types=[],
-    serialized_options=None,
-    is_extendable=False,
-    syntax="proto3",
-    extension_ranges=[],
-    oneofs=[],
-    serialized_start=792,
-    serialized_end=919,
+  name='ClientDestination',
+  full_name='yoshi.synth.metadata.ClientDestination',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='source', full_name='yoshi.synth.metadata.ClientDestination.source', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='api_name', full_name='yoshi.synth.metadata.ClientDestination.api_name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='api_version', full_name='yoshi.synth.metadata.ClientDestination.api_version', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='language', full_name='yoshi.synth.metadata.ClientDestination.language', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='generator', full_name='yoshi.synth.metadata.ClientDestination.generator', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='config', full_name='yoshi.synth.metadata.ClientDestination.config', index=5,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=792,
+  serialized_end=919,
 )
 
 
 _FILESETDESTINATION = _descriptor.Descriptor(
-    name="FileSetDestination",
-    full_name="yoshi.synth.metadata.FileSetDestination",
-    filename=None,
-    file=DESCRIPTOR,
-    containing_type=None,
-    fields=[
-        _descriptor.FieldDescriptor(
-            name="source",
-            full_name="yoshi.synth.metadata.FileSetDestination.source",
-            index=0,
-            number=1,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="files",
-            full_name="yoshi.synth.metadata.FileSetDestination.files",
-            index=1,
-            number=2,
-            type=9,
-            cpp_type=9,
-            label=3,
-            has_default_value=False,
-            default_value=[],
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-    ],
-    extensions=[],
-    nested_types=[],
-    enum_types=[],
-    serialized_options=None,
-    is_extendable=False,
-    syntax="proto3",
-    extension_ranges=[],
-    oneofs=[],
-    serialized_start=921,
-    serialized_end=972,
+  name='FileSetDestination',
+  full_name='yoshi.synth.metadata.FileSetDestination',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='source', full_name='yoshi.synth.metadata.FileSetDestination.source', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='files', full_name='yoshi.synth.metadata.FileSetDestination.files', index=1,
+      number=2, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=921,
+  serialized_end=972,
 )
 
-_METADATA.fields_by_name[
-    "update_time"
-].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
-_METADATA.fields_by_name["sources"].message_type = _SOURCE
-_METADATA.fields_by_name["destinations"].message_type = _DESTINATION
-_SOURCE.fields_by_name["git"].message_type = _GITSOURCE
-_SOURCE.fields_by_name["generator"].message_type = _GENERATORSOURCE
-_SOURCE.fields_by_name["template"].message_type = _TEMPLATESOURCE
-_SOURCE.oneofs_by_name["source"].fields.append(_SOURCE.fields_by_name["git"])
-_SOURCE.fields_by_name["git"].containing_oneof = _SOURCE.oneofs_by_name["source"]
-_SOURCE.oneofs_by_name["source"].fields.append(_SOURCE.fields_by_name["generator"])
-_SOURCE.fields_by_name["generator"].containing_oneof = _SOURCE.oneofs_by_name["source"]
-_SOURCE.oneofs_by_name["source"].fields.append(_SOURCE.fields_by_name["template"])
-_SOURCE.fields_by_name["template"].containing_oneof = _SOURCE.oneofs_by_name["source"]
-_DESTINATION.fields_by_name["client"].message_type = _CLIENTDESTINATION
-_DESTINATION.fields_by_name["fileset"].message_type = _FILESETDESTINATION
-_DESTINATION.oneofs_by_name["Destination"].fields.append(
-    _DESTINATION.fields_by_name["client"]
-)
-_DESTINATION.fields_by_name["client"].containing_oneof = _DESTINATION.oneofs_by_name[
-    "Destination"
-]
-_DESTINATION.oneofs_by_name["Destination"].fields.append(
-    _DESTINATION.fields_by_name["fileset"]
-)
-_DESTINATION.fields_by_name["fileset"].containing_oneof = _DESTINATION.oneofs_by_name[
-    "Destination"
-]
-DESCRIPTOR.message_types_by_name["Metadata"] = _METADATA
-DESCRIPTOR.message_types_by_name["Source"] = _SOURCE
-DESCRIPTOR.message_types_by_name["GitSource"] = _GITSOURCE
-DESCRIPTOR.message_types_by_name["GeneratorSource"] = _GENERATORSOURCE
-DESCRIPTOR.message_types_by_name["TemplateSource"] = _TEMPLATESOURCE
-DESCRIPTOR.message_types_by_name["Destination"] = _DESTINATION
-DESCRIPTOR.message_types_by_name["ClientDestination"] = _CLIENTDESTINATION
-DESCRIPTOR.message_types_by_name["FileSetDestination"] = _FILESETDESTINATION
+_METADATA.fields_by_name['update_time'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
+_METADATA.fields_by_name['sources'].message_type = _SOURCE
+_METADATA.fields_by_name['destinations'].message_type = _DESTINATION
+_SOURCE.fields_by_name['git'].message_type = _GITSOURCE
+_SOURCE.fields_by_name['generator'].message_type = _GENERATORSOURCE
+_SOURCE.fields_by_name['template'].message_type = _TEMPLATESOURCE
+_SOURCE.oneofs_by_name['source'].fields.append(
+  _SOURCE.fields_by_name['git'])
+_SOURCE.fields_by_name['git'].containing_oneof = _SOURCE.oneofs_by_name['source']
+_SOURCE.oneofs_by_name['source'].fields.append(
+  _SOURCE.fields_by_name['generator'])
+_SOURCE.fields_by_name['generator'].containing_oneof = _SOURCE.oneofs_by_name['source']
+_SOURCE.oneofs_by_name['source'].fields.append(
+  _SOURCE.fields_by_name['template'])
+_SOURCE.fields_by_name['template'].containing_oneof = _SOURCE.oneofs_by_name['source']
+_DESTINATION.fields_by_name['client'].message_type = _CLIENTDESTINATION
+_DESTINATION.fields_by_name['fileset'].message_type = _FILESETDESTINATION
+_DESTINATION.oneofs_by_name['Destination'].fields.append(
+  _DESTINATION.fields_by_name['client'])
+_DESTINATION.fields_by_name['client'].containing_oneof = _DESTINATION.oneofs_by_name['Destination']
+_DESTINATION.oneofs_by_name['Destination'].fields.append(
+  _DESTINATION.fields_by_name['fileset'])
+_DESTINATION.fields_by_name['fileset'].containing_oneof = _DESTINATION.oneofs_by_name['Destination']
+DESCRIPTOR.message_types_by_name['Metadata'] = _METADATA
+DESCRIPTOR.message_types_by_name['Source'] = _SOURCE
+DESCRIPTOR.message_types_by_name['GitSource'] = _GITSOURCE
+DESCRIPTOR.message_types_by_name['GeneratorSource'] = _GENERATORSOURCE
+DESCRIPTOR.message_types_by_name['TemplateSource'] = _TEMPLATESOURCE
+DESCRIPTOR.message_types_by_name['Destination'] = _DESTINATION
+DESCRIPTOR.message_types_by_name['ClientDestination'] = _CLIENTDESTINATION
+DESCRIPTOR.message_types_by_name['FileSetDestination'] = _FILESETDESTINATION
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
-Metadata = _reflection.GeneratedProtocolMessageType(
-    "Metadata",
-    (_message.Message,),
-    dict(
-        DESCRIPTOR=_METADATA,
-        __module__="metadata_pb2"
-        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.Metadata)
-    ),
-)
+Metadata = _reflection.GeneratedProtocolMessageType('Metadata', (_message.Message,), dict(
+  DESCRIPTOR = _METADATA,
+  __module__ = 'metadata_pb2'
+  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.Metadata)
+  ))
 _sym_db.RegisterMessage(Metadata)
 
-Source = _reflection.GeneratedProtocolMessageType(
-    "Source",
-    (_message.Message,),
-    dict(
-        DESCRIPTOR=_SOURCE,
-        __module__="metadata_pb2"
-        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.Source)
-    ),
-)
+Source = _reflection.GeneratedProtocolMessageType('Source', (_message.Message,), dict(
+  DESCRIPTOR = _SOURCE,
+  __module__ = 'metadata_pb2'
+  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.Source)
+  ))
 _sym_db.RegisterMessage(Source)
 
-GitSource = _reflection.GeneratedProtocolMessageType(
-    "GitSource",
-    (_message.Message,),
-    dict(
-        DESCRIPTOR=_GITSOURCE,
-        __module__="metadata_pb2"
-        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.GitSource)
-    ),
-)
+GitSource = _reflection.GeneratedProtocolMessageType('GitSource', (_message.Message,), dict(
+  DESCRIPTOR = _GITSOURCE,
+  __module__ = 'metadata_pb2'
+  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.GitSource)
+  ))
 _sym_db.RegisterMessage(GitSource)
 
-GeneratorSource = _reflection.GeneratedProtocolMessageType(
-    "GeneratorSource",
-    (_message.Message,),
-    dict(
-        DESCRIPTOR=_GENERATORSOURCE,
-        __module__="metadata_pb2"
-        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.GeneratorSource)
-    ),
-)
+GeneratorSource = _reflection.GeneratedProtocolMessageType('GeneratorSource', (_message.Message,), dict(
+  DESCRIPTOR = _GENERATORSOURCE,
+  __module__ = 'metadata_pb2'
+  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.GeneratorSource)
+  ))
 _sym_db.RegisterMessage(GeneratorSource)
 
-TemplateSource = _reflection.GeneratedProtocolMessageType(
-    "TemplateSource",
-    (_message.Message,),
-    dict(
-        DESCRIPTOR=_TEMPLATESOURCE,
-        __module__="metadata_pb2"
-        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.TemplateSource)
-    ),
-)
+TemplateSource = _reflection.GeneratedProtocolMessageType('TemplateSource', (_message.Message,), dict(
+  DESCRIPTOR = _TEMPLATESOURCE,
+  __module__ = 'metadata_pb2'
+  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.TemplateSource)
+  ))
 _sym_db.RegisterMessage(TemplateSource)
 
-Destination = _reflection.GeneratedProtocolMessageType(
-    "Destination",
-    (_message.Message,),
-    dict(
-        DESCRIPTOR=_DESTINATION,
-        __module__="metadata_pb2"
-        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.Destination)
-    ),
-)
+Destination = _reflection.GeneratedProtocolMessageType('Destination', (_message.Message,), dict(
+  DESCRIPTOR = _DESTINATION,
+  __module__ = 'metadata_pb2'
+  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.Destination)
+  ))
 _sym_db.RegisterMessage(Destination)
 
-ClientDestination = _reflection.GeneratedProtocolMessageType(
-    "ClientDestination",
-    (_message.Message,),
-    dict(
-        DESCRIPTOR=_CLIENTDESTINATION,
-        __module__="metadata_pb2"
-        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.ClientDestination)
-    ),
-)
+ClientDestination = _reflection.GeneratedProtocolMessageType('ClientDestination', (_message.Message,), dict(
+  DESCRIPTOR = _CLIENTDESTINATION,
+  __module__ = 'metadata_pb2'
+  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.ClientDestination)
+  ))
 _sym_db.RegisterMessage(ClientDestination)
 
-FileSetDestination = _reflection.GeneratedProtocolMessageType(
-    "FileSetDestination",
-    (_message.Message,),
-    dict(
-        DESCRIPTOR=_FILESETDESTINATION,
-        __module__="metadata_pb2"
-        # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.FileSetDestination)
-    ),
-)
+FileSetDestination = _reflection.GeneratedProtocolMessageType('FileSetDestination', (_message.Message,), dict(
+  DESCRIPTOR = _FILESETDESTINATION,
+  __module__ = 'metadata_pb2'
+  # @@protoc_insertion_point(class_scope:yoshi.synth.metadata.FileSetDestination)
+  ))
 _sym_db.RegisterMessage(FileSetDestination)
 
 


### PR DESCRIPTION
This enables the possibility of sample generation via the `--dev_samples`
option to the gapic generator. Tested with the Data Catalog Python
client via

```
library = gapic.py_library(
    "bigquery_datatransfer",
    version,
    config_path="/google/cloud/bigquery/datatransfer/"
    "artman_bigquerydatatransfer.yaml",
    artman_output_name="bigquerydatatransfer-v1",
    include_protos=True,
    generator_args=["--dev_samples"],
)
```

Closes #223 