### PR TITLE
feat: provide 'title' in .readme-partials.yaml to override the default

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -142,8 +142,9 @@ class CommonTemplates:
         hand-crafted artisinal markdown can be provided in a .readme-partials.yml.
         The following fields are currently supported:
 
-        introduction: a more thorough introduction than metadata["description"].
         body: custom body to include in the usage section of the document.
+        introduction: a more thorough introduction than metadata["description"].
+        title: provide markdown to use as a custom title.
         """
         cwd_path = Path(os.getcwd())
         partials_file = None

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -2,7 +2,11 @@
 [//]: # "To regenerate it, use `python -m synthtool`."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
+{% if 'partials' in metadata and metadata['partials']['title'] -%}
+{{ metadata['partials']['title'] }}
+{% else -%}
 # [{{ metadata['repo']['name_pretty'] }}: {{ metadata['repo']['language']|language_pretty }} Client](https://github.com/{{ metadata['repo']['repo'] }})
+{%- endif %}
 
 {{ metadata['repo']['release_level']|release_quality_badge }}
 [![npm version](https://img.shields.io/npm/v/{{ metadata['name'] }}.svg)](https://www.npmjs.org/package/{{ metadata['name'] }})
@@ -14,7 +18,7 @@
 | This library is **deprecated**. {{ metadata['deprecated'] }} |
 {% endif %}
 
-{% if metadata['partials'] and metadata['partials']['introduction'] %}
+{% if 'partials' in metadata and metadata['partials']['introduction'] %}
 {{ metadata['partials']['introduction'] }}
 {% else %}
 {{ metadata['description'] }}
@@ -63,7 +67,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 ```{{ metadata['repo']['language']|syntax_highlighter }}
 {{ metadata['quickstart'] }}
 ```
-{% endif %}{% if metadata['partials'] and metadata['partials']['body'] %}{{ metadata['partials']['body'] }}{% endif %}
+{% endif %}{% if 'partials' in metadata and metadata['partials']['body'] %}{{ metadata['partials']['body'] }}{% endif %}
 
 {% if metadata['samples']|length %}
 ## Samples

--- a/synthtool/gcp/templates/node_library/samples/README.md
+++ b/synthtool/gcp/templates/node_library/samples/README.md
@@ -2,7 +2,11 @@
 [//]: # "To regenerate it, use `python -m synthtool`."
 <img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
+{% if 'partials' in metadata and metadata['partials']['title'] -%}
+{{ metadata['partials']['title'] }} Samples
+{% else -%}
 # [{{ metadata['repo']['name_pretty'] }}: {{ metadata['repo']['language']|language_pretty }} Samples](https://github.com/{{ metadata['repo']['repo'] }})
+{%- endif %}
 
 [![Open in Cloud Shell][shell_img]][shell_link]
 


### PR DESCRIPTION
This adds the feature everyone's been asking for ...

_The ability to override the default title in a README using *.readme-partials.yaml*._

Note that it assumes that you will provide the full title as markdown, including the heading type, so so something like:

```
# [My New Title](https://www.zombo.com)
```

see: https://github.com/googleapis/nodejs-firestore-session/pull/6