### PR TITLE
Fix move excludes

### DIFF
--- a/synthtool/transforms.py
+++ b/synthtool/transforms.py
@@ -116,8 +116,8 @@ def _copy_dir_to_existing_dir(
                 e
                 for e in excludes
                 if (
-                    Path(e).relative_to(".") == Path(rel_path)
-                    or Path(e).relative_to(".") == Path(rel_path) / name
+                    Path(e) == _tracked_paths.relativize(root)
+                    or Path(e) == _tracked_paths.relativize(Path(root) / name)
                 )
             ]
             if not exclude:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -15,6 +15,7 @@
 import os
 import stat
 from pathlib import Path
+import tempfile
 
 import pytest
 
@@ -121,7 +122,7 @@ def test__move_to_dest(expand_path_fixtures):
 
     files = sorted([str(x) for x in transforms._expand_paths("**/*", root="dest")])
 
-    # Assert destination does not contain dira/e.py (excluded)
+    # Assert destination does not contain dira/f.py (excluded)
     assert files == [
         "dest/a.txt",
         "dest/b.py",
@@ -131,4 +132,22 @@ def test__move_to_dest(expand_path_fixtures):
         "dest/dirb",
         "dest/dirb/suba",
         "dest/dirb/suba/g.py",
+    ]
+
+def test__move_to_dest_subdir(expand_path_fixtures):
+    tmp_path = Path(str(expand_path_fixtures))
+    _tracked_paths.add(expand_path_fixtures)
+    dest = Path(str(expand_path_fixtures / "dest/dira"))
+
+    # Move to a different dir to make sure that move doesn't depend on the cwd
+    os.chdir(tempfile.gettempdir())
+    transforms.move(tmp_path / "dira", dest, excludes=["f.py"])
+
+    os.chdir(str(tmp_path))
+    files = sorted([str(x) for x in transforms._expand_paths("**/*", root="dest")])
+
+    # Assert destination does not contain dira/f.py (excluded)
+    assert files == [
+        "dest/dira",
+        "dest/dira/e.txt",
     ]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -134,6 +134,7 @@ def test__move_to_dest(expand_path_fixtures):
         "dest/dirb/suba/g.py",
     ]
 
+
 def test__move_to_dest_subdir(expand_path_fixtures):
     tmp_path = Path(str(expand_path_fixtures))
     _tracked_paths.add(expand_path_fixtures)
@@ -147,7 +148,4 @@ def test__move_to_dest_subdir(expand_path_fixtures):
     files = sorted([str(x) for x in transforms._expand_paths("**/*", root="dest")])
 
     # Assert destination does not contain dira/f.py (excluded)
-    assert files == [
-        "dest/dira",
-        "dest/dira/e.txt",
-    ]
+    assert files == ["dest/dira", "dest/dira/e.txt"]


### PR DESCRIPTION
#48 introduced a bug where the exclude path (which is relative to a tracked path) is compared to a source path (which is relative to the source root).
This issue was unnoticed because it works ok when the source path has a single component like in firestore:
https://github.com/googleapis/nodejs-firestore/blob/89afae/synth.py#L19

But breaks when the source path has multiple components like in bigtable:
https://github.com/googleapis/google-cloud-java/blob/264643/google-cloud-clients/google-cloud-bigtable/synth.py#L30

And when the cwd doesn't match the tracked path