### PR TITLE
build: build script tweaks for non-standard libraries

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/lint.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/lint.sh
@@ -23,9 +23,11 @@ cd $(dirname $0)/..
 npm install
 
 # Install and link samples
-cd samples/
-npm link ../
-npm install
-cd ..
+if [ -f samples/package.json ]; then
+  cd samples/
+  npm link ../
+  npm install
+  cd ..
+fi
 
 npm run lint

--- a/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
@@ -31,12 +31,14 @@ if [ -f .kokoro/pre-samples-test.sh ]; then
     set -x
 fi
 
-npm install
+if [ -f samples/package.json ]; then
+    npm install
 
-# Install and link samples
-cd samples/
-npm link ../
-npm install
-cd ..
+    # Install and link samples
+    cd samples/
+    npm link ../
+    npm install
+    cd ..
 
-npm run samples-test
+    npm run samples-test
+fi

--- a/synthtool/gcp/templates/node_library/.kokoro/test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/test.sh
@@ -22,6 +22,14 @@ cd $(dirname $0)/..
 
 npm install
 npm test
-./node_modules/nyc/bin/nyc.js report
 
-bash $KOKORO_GFILE_DIR/codecov.sh
+COVERAGE_NODE=10
+if npx check-node-version@3.3.0 --silent --node $COVERAGE_NODE; then
+  NYC_BIN=./node_modules/nyc/bin/nyc.js
+  if [ -f "$NYC_BIN" ]; then
+    $NYC_BIN report
+  fi
+  bash $KOKORO_GFILE_DIR/codecov.sh
+else
+  echo "coverage is only reported for Node $COVERAGE_NODE"
+fi


### PR DESCRIPTION
1. in `lint.sh` only `npm install` in samples directory if a `samples/package.json` exists.
1. in `samples-test.sh` only run samples tests if a `samples/package.json` exists.
1. ini `test.sh` only pipe coverage to `codecov` if on Node 10, don't try to run `nyc` if it doesn't exist (allowing us to opt for `c8` in some cases).