### PR TITLE
fix: move codecov token to node10

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/continuous/node10/test.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/continuous/node10/test.cfg
@@ -1,0 +1,9 @@
+# Bring in codecov.io master token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "dpebot_codecov_token"
+    }
+  }
+}

--- a/synthtool/gcp/templates/node_library/.kokoro/continuous/node8/test.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/continuous/node8/test.cfg
@@ -1,0 +1,9 @@
+# Bring in codecov.io master token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "dpebot_codecov_token"
+    }
+  }
+}

--- a/synthtool/gcp/templates/node_library/.kokoro/continuous/node8/test.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/continuous/node8/test.cfg
@@ -1,9 +1,0 @@
-# Bring in codecov.io master token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "dpebot_codecov_token"
-    }
-  }
-}


### PR DESCRIPTION
once we roll out Node 12, we should switch from 10 to 12.