### PR TITLE
fix: temporary fix for broken Windows image

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/test.bat
+++ b/synthtool/gcp/templates/node_library/.kokoro/test.bat
@@ -12,16 +12,7 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 
-@echo "Starting Windows build"
-
-cd /d %~dp0
+cd /d %~dp0	
 cd ..
 
-call npm install -g npm@latest || goto :error
-call npm install || goto :error
-call npm run test || goto :error
-
-goto :EOF
-
-:error
-exit /b 1
+"C:\Program Files\Git\bin\bash.exe" .kokoro/test.sh --windows

--- a/synthtool/gcp/templates/node_library/.kokoro/test.bat
+++ b/synthtool/gcp/templates/node_library/.kokoro/test.bat
@@ -12,7 +12,24 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 
-cd /d %~dp0	
+@echo "Starting Windows build"
+
+cd /d %~dp0
 cd ..
 
-"C:\Program Files\Git\bin\bash.exe" .kokoro/test.sh --windows
+@rem The image we're currently running has a broken version of Node.js enabled
+@rem by nvm (v10.15.3), which has no npm bin. This hack uses the functional
+@rem Node v8.9.1 to install npm@latest, it then uses this version of npm to
+@rem install npm for v10.15.3.
+call nvm use v8.9.1 || goto :error
+call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm-bootstrap\bin\npm-cli.js i npm -g || goto :error
+call nvm use v10.15.3 || goto :error
+call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm\bin\npm-cli.js i npm -g || goto :error
+
+call npm install || goto :error
+call npm run test || goto :error
+
+goto :EOF
+
+:error
+exit /b 1


### PR DESCRIPTION
this `test.bat` file will unblock our broken Windows builds, it's pretty hacky; let me explain:

1. the image we shipped has an ancient version nvm, which installs Node@10.15.3 successfully, but fails to install npm (this might be because npm was moved from npm/npm to npm/cli).
2. the 8.9.1 version of Node.js has npm working \o/ hooray; so we can just use this to install the latest npm in 10.15.3 -- wrong!
3. the version of npm that installs with 8.9.1 apparently can't be run by Node 10 ... go figure.

tldr; the fix uses v8.9.1 to install the latest npm, then switches to 10.15.3 and uses this npm to install the latest version of npm on 10.15.3 (I think the second install is the easiest way to get all the linking correct).