### PR TITLE
Document passing a synthfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Run `synthtool`:
 python3 -m synthtool
 ```
 
+> You can specify a specific synthfile via:
+> ```
+> python3 -m synthtool path/to/synth.py
+> ```
+
 After `synthtool` runs successfully:
  - Investigate the changes it made
  - Run the library tests


### PR DESCRIPTION
TIL that you can explicitly pass a synthfile because someone asked if you could.

They searched the source code to find the answer.

It's documented via `synthtool --help` but they checked the README.