### PR TITLE
build: collect coverage across additional test environments

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/continuous/node10/common.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/continuous/node10/common.cfg
@@ -7,6 +7,16 @@ action {
   }
 }
 
+# Bring in codecov.io master token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "dpebot_codecov_token"
+    }
+  }
+}
+
 # Download trampoline resources.
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 

--- a/synthtool/gcp/templates/node_library/.kokoro/presubmit/node10/common.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/presubmit/node10/common.cfg
@@ -7,6 +7,16 @@ action {
   }
 }
 
+# Bring in codecov.io master token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "dpebot_codecov_token"
+    }
+  }
+}
+
 # Download trampoline resources.
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 

--- a/synthtool/gcp/templates/node_library/.kokoro/presubmit/node10/test.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/presubmit/node10/test.cfg
@@ -1,9 +1,0 @@
-# Bring in codecov.io master token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "dpebot_codecov_token"
-    }
-  }
-}

--- a/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
@@ -42,3 +42,16 @@ if [ -f samples/package.json ]; then
 
     npm run samples-test
 fi
+
+# codecov combines coverage across integration and unit tests. Include
+# the logic below for any environment you wish to collect coverage for:
+COVERAGE_NODE=10
+if npx check-node-version@3.3.0 --silent --node $COVERAGE_NODE; then
+  NYC_BIN=./node_modules/nyc/bin/nyc.js
+  if [ -f "$NYC_BIN" ]; then
+    $NYC_BIN report
+  fi
+  bash $KOKORO_GFILE_DIR/codecov.sh
+else
+  echo "coverage is only reported for Node $COVERAGE_NODE"
+fi

--- a/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
@@ -49,7 +49,7 @@ COVERAGE_NODE=10
 if npx check-node-version@3.3.0 --silent --node $COVERAGE_NODE; then
   NYC_BIN=./node_modules/nyc/bin/nyc.js
   if [ -f "$NYC_BIN" ]; then
-    $NYC_BIN report
+    $NYC_BIN report || true
   fi
   bash $KOKORO_GFILE_DIR/codecov.sh
 else

--- a/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
@@ -34,3 +34,16 @@ fi
 npm install
 
 npm run system-test
+
+# codecov combines coverage across integration and unit tests. Include
+# the logic below for any environment you wish to collect coverage for:
+COVERAGE_NODE=10
+if npx check-node-version@3.3.0 --silent --node $COVERAGE_NODE; then
+  NYC_BIN=./node_modules/nyc/bin/nyc.js
+  if [ -f "$NYC_BIN" ]; then
+    $NYC_BIN report
+  fi
+  bash $KOKORO_GFILE_DIR/codecov.sh
+else
+  echo "coverage is only reported for Node $COVERAGE_NODE"
+fi

--- a/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
@@ -41,7 +41,7 @@ COVERAGE_NODE=10
 if npx check-node-version@3.3.0 --silent --node $COVERAGE_NODE; then
   NYC_BIN=./node_modules/nyc/bin/nyc.js
   if [ -f "$NYC_BIN" ]; then
-    $NYC_BIN report
+    $NYC_BIN report || true
   fi
   bash $KOKORO_GFILE_DIR/codecov.sh
 else

--- a/synthtool/gcp/templates/node_library/.kokoro/test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/test.sh
@@ -23,6 +23,8 @@ cd $(dirname $0)/..
 npm install
 npm test
 
+# codecov combines coverage across integration and unit tests. Include
+# the logic below for any environment you wish to collect coverage for:
 COVERAGE_NODE=10
 if npx check-node-version@3.3.0 --silent --node $COVERAGE_NODE; then
   NYC_BIN=./node_modules/nyc/bin/nyc.js

--- a/synthtool/gcp/templates/node_library/.kokoro/test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/test.sh
@@ -29,7 +29,7 @@ COVERAGE_NODE=10
 if npx check-node-version@3.3.0 --silent --node $COVERAGE_NODE; then
   NYC_BIN=./node_modules/nyc/bin/nyc.js
   if [ -f "$NYC_BIN" ]; then
-    $NYC_BIN report
+    $NYC_BIN report || true
   fi
   bash $KOKORO_GFILE_DIR/codecov.sh
 else

--- a/synthtool/gcp/templates/node_library/.kokoro/test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/test.sh
@@ -35,3 +35,11 @@ if npx check-node-version@3.3.0 --silent --node $COVERAGE_NODE; then
 else
   echo "coverage is only reported for Node $COVERAGE_NODE"
 fi
+
+# if the GITHUB_TOKEN is set, we kick off a task to update the release-PR.
+GITHUB_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/73713_yoshi-automation-github-key)
+if [ "$GITHUB_TOKEN" ] then;
+  npx release-please release-pr --token=$GITHUB_TOKEN \
+    --repo-url=googleapis/{{ metadata['repository_name'] }} \
+    --package-name={{ metadata['name'] }}
+fi


### PR DESCRIPTION
codecov collects coverage across all test environments, demonstrated here:

https://codecov.io/gh/googleapis/release-please (all the github tests are integration, and are combined with the other unit tests).

I would like to pipe coverage in our samples and system tests, to give better insight into our coverage, regardless of the types of tests folks write.