### PR TITLE
feat: add support for samples_body partial in samples/README.md

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -171,6 +171,8 @@ class CommonTemplates:
         The following fields are currently supported:
 
         body: custom body to include in the usage section of the document.
+        sample_body: an optional body to place below the table of contents
+          in samples/README.md.
         introduction: a more thorough introduction than metadata["description"].
         title: provide markdown to use as a custom title.
         """

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -171,7 +171,7 @@ class CommonTemplates:
         The following fields are currently supported:
 
         body: custom body to include in the usage section of the document.
-        sample_body: an optional body to place below the table of contents
+        samples_body: an optional body to place below the table of contents
           in samples/README.md.
         introduction: a more thorough introduction than metadata["description"].
         title: provide markdown to use as a custom title.

--- a/synthtool/gcp/templates/node_library/samples/README.md
+++ b/synthtool/gcp/templates/node_library/samples/README.md
@@ -23,6 +23,10 @@
 Before running the samples, make sure you've followed the steps outlined in
 [Using the client library](https://github.com/{{ metadata['repo']['repo']  }}#using-the-client-library).
 
+{% if 'partials' in metadata and metadata['partials']['samples_body'] %}{{ metadata['partials']['samples_body'] }}
+
+{% endif -%}
+
 ## Samples
 {% if metadata['samples']|length %}
 {% for sample in metadata['samples'] %}


### PR DESCRIPTION
adds support for `samples_body` to allow for the customization of the body of `samples/README.md`.

see: https://github.com/googleapis/nodejs-translate/pull/268

CC: @beccasaurus.