### PR TITLE
fix: Ignore "protos" directory for Node coverage

### DIFF
--- a/synthtool/gcp/templates/node_library/.nycrc
+++ b/synthtool/gcp/templates/node_library/.nycrc
@@ -10,6 +10,7 @@
     "**/samples",
     "**/scripts",
     "**/src/**/v*/**/*.js",
+    "**/protos",
     "**/test",
     ".jsdoc.js",
     "**/.jsdoc.js",


### PR DESCRIPTION
This should undo the revert in https://github.com/googleapis/nodejs-firestore/commit/62eaab0dd6d2a0f6d06880d171f6862194833aef#diff-774bc7673169ae00d4c2bd961ab79828 and bring the `@google-cloud/firestore` coverage up from 62% to 96%.