### PR TITLE
build: get magictokens from FASTCONFIGPUSH backend

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/release/publish.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/release/publish.cfg
@@ -33,6 +33,7 @@ before_action {
     keystore_resource {
       keystore_config_id: 73713
       keyname: "releasetool-magictoken"
+      backend_type: FASTCONFIGPUSH
     }
   }
 }
@@ -43,6 +44,7 @@ before_action {
     keystore_resource {
       keystore_config_id: 73713
       keyname: "magic-github-proxy-api-key"
+      backend_type: FASTCONFIGPUSH
     }
   }
 }


### PR DESCRIPTION
This will let us get to the updated key in ~day rather than a week.