### PR TITLE
Update README.md template to have an end anchor

### DIFF
--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -133,3 +133,5 @@ See [LICENSE](https://github.com/{{ metadata['repo']['repo'] }}/blob/master/LICE
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 {% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}{% endif %}
 [auth]: https://cloud.google.com/docs/authentication/getting-started
+
+<a id="api-reference"></a>


### PR DESCRIPTION
As part of a docs rework, it is desirable to have an anchor at the bottom of the readme to link to.