### PR TITLE
fix: some quickstart region tags include suffix

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -27,8 +27,8 @@ from synthtool import metadata
 
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
-_RE_SAMPLE_COMMENT_START = r"\[START \w+_quickstart]"
-_RE_SAMPLE_COMMENT_END = r"\[END \w+_quickstart]"
+_RE_SAMPLE_COMMENT_START = r"\[START \w+_quickstart\w*]"
+_RE_SAMPLE_COMMENT_END = r"\[END \w+_quickstart\w*]"
 
 
 class CommonTemplates:


### PR DESCRIPTION
I found an edge-case in which a suffix can exist for a quickstart region tag can have a suffix, this addresses that edge-case so that we can avoid changing the region tag and still generate our standard README.