### PR TITLE
Add samples session to noxfile, controlled by `samples_test` arg.

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -49,7 +49,7 @@ def blacken(session):
     """Run black.
 
     Format code to uniform standard.
-    
+
     This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
     That run uses an image that doesn't have 3.6 installed. Before updating this
     check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
@@ -130,6 +130,25 @@ def system(session):
     if system_test_folder_exists:
         session.run("py.test", "--quiet", system_test_folder_path, *session.posargs)
 
+{% if samples_test %}
+@nox.session(python=["2.7", "3.7"])
+def samples(session):
+    requirements_path = os.path.join("samples", "requirements.txt")
+    requirements_exists = os.path.exists(requirements_path)
+
+    # Sanity check: Only run tests if the environment variable is set.
+    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", ""):
+        session.skip("Credentials must be set via environment variable")
+
+    session.install("mock", "pytest")
+    for local_dep in LOCAL_DEPS:
+        session.install("-e", local_dep)
+    if requirements_exists:
+        session.install("-r", requirements_path)
+    session.install("-e", ".")
+
+    session.run("py.test", "--quiet", "samples", *session.posargs)
+{% endif %}
 
 @nox.session(python="3.7")
 def cover(session):


### PR DESCRIPTION
Run samples much like you would system tests. Use
`samples/requirements.txt` to add samples-only dependencies.