### PR TITLE
Add support for using local GAPIC generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,21 @@ Specify the path to`googleapis` in the environment variable `SYNTHTOOL_GOOGLEAPI
 export SYNTHTOOL_GOOGLEAPIS=path/to/local/googleapis
 ```
 
+### Local GAPIC Generator
+SynthTool supports generation from a local copy of [gapic-generator](https://github.com/googleapis/gapic-generator).
+Specify the path to`gapic-generator` in the environment variable `SYNTHTOOL_GENERATOR`.
+
+```
+export SYNTHTOOL_GENERATOR=path/to/local/gapic-generator
+```
+
+Don't forget to compile `gapic-generator` before running SynthTool.
+
+```
+cd path/to/local/gapic-generator
+./gradlew fatJar
+```
+
 ### Include .proto files
 SynthTool supports copying .proto API definition files from googleapis.
 

--- a/synthtool/gcp/artman.py
+++ b/synthtool/gcp/artman.py
@@ -58,7 +58,14 @@ class Artman:
     def docker_image(self) -> str:
         return self._docker_image_info()["RepoDigests"][0]
 
-    def run(self, image, root_dir, config, *args, generator_args=None):
+    def run(
+        self,
+        image,
+        root_dir,
+        config,
+        *args,
+        generator_dir=None,
+        generator_args=None):
         """Executes artman command in the artman container.
 
         Args:
@@ -72,6 +79,9 @@ class Artman:
             *args:
                 Arguments to artman that follow ``generate``. Defines which
                 artifacts to generate.
+            generator_dir (Optional[str]):
+                Path to local gapic-generator directory to use for generation.
+                By default, the latest version of gapic-generator will be used.
             generator_args (Optional[List[str]]):
                 Additional arguments to pass to the gapic generator, such as
                 ``--dev_samples``.
@@ -88,29 +98,35 @@ class Artman:
                 "--generator-args='{}'".format(" ".join(generator_args))
             )
 
-        docker_cmd = [
-            "docker",
-            "run",
-            "--name",
-            container_name,
-            "--rm",
-            "-i",
+        docker_cmd = ["docker", "run", "--name", container_name, "--rm", "-i"]
+
+        # Environment variables
+        docker_cmd.extend([
             "-e",
             f"HOST_USER_ID={os.getuid()}",
             "-e",
             f"HOST_GROUP_ID={os.getgid()}",
             "-e",
             "RUNNING_IN_ARTMAN_DOCKER=True",
+        ])
+
+
+        # Local directories to mount as volumes (and set working directory -w)
+        docker_cmd.extend([
             "-v",
             f"{root_dir}:{root_dir}",
             "-v",
             f"{output_dir}:{output_dir}",
             "-w",
-            root_dir,
-            image,
-            "/bin/bash",
-            "-c",
-        ]
+            root_dir
+        ])
+
+        # Use local copy of GAPIC generator to generate, if path provided
+        if generator_dir:
+            docker_cmd.extend(["-v", f"{generator_dir}:/toolkit"])
+
+        # Run /bin/bash in the image and then provide the shell command to run
+        docker_cmd.extend([image, "/bin/bash", "-c"])
 
         artman_command = " ".join(
             map(

--- a/synthtool/gcp/artman.py
+++ b/synthtool/gcp/artman.py
@@ -59,13 +59,8 @@ class Artman:
         return self._docker_image_info()["RepoDigests"][0]
 
     def run(
-        self,
-        image,
-        root_dir,
-        config,
-        *args,
-        generator_dir=None,
-        generator_args=None):
+        self, image, root_dir, config, *args, generator_dir=None, generator_args=None
+    ):
         """Executes artman command in the artman container.
 
         Args:
@@ -101,25 +96,28 @@ class Artman:
         docker_cmd = ["docker", "run", "--name", container_name, "--rm", "-i"]
 
         # Environment variables
-        docker_cmd.extend([
-            "-e",
-            f"HOST_USER_ID={os.getuid()}",
-            "-e",
-            f"HOST_GROUP_ID={os.getgid()}",
-            "-e",
-            "RUNNING_IN_ARTMAN_DOCKER=True",
-        ])
-
+        docker_cmd.extend(
+            [
+                "-e",
+                f"HOST_USER_ID={os.getuid()}",
+                "-e",
+                f"HOST_GROUP_ID={os.getgid()}",
+                "-e",
+                "RUNNING_IN_ARTMAN_DOCKER=True",
+            ]
+        )
 
         # Local directories to mount as volumes (and set working directory -w)
-        docker_cmd.extend([
-            "-v",
-            f"{root_dir}:{root_dir}",
-            "-v",
-            f"{output_dir}:{output_dir}",
-            "-w",
-            root_dir
-        ])
+        docker_cmd.extend(
+            [
+                "-v",
+                f"{root_dir}:{root_dir}",
+                "-v",
+                f"{output_dir}:{output_dir}",
+                "-w",
+                root_dir,
+            ]
+        )
 
         # Use local copy of GAPIC generator to generate, if path provided
         if generator_dir:

--- a/synthtool/gcp/gapic_generator.py
+++ b/synthtool/gcp/gapic_generator.py
@@ -25,6 +25,7 @@ from synthtool.sources import git
 GOOGLEAPIS_URL: str = git.make_repo_clone_url("googleapis/googleapis")
 GOOGLEAPIS_PRIVATE_URL: str = git.make_repo_clone_url("googleapis/googleapis-private")
 LOCAL_GOOGLEAPIS: Optional[str] = os.environ.get("SYNTHTOOL_GOOGLEAPIS")
+LOCAL_GENERATOR: Optional[str] = os.environ.get("SYNTHTOOL_GENERATOR")
 
 
 class GAPICGenerator:
@@ -93,6 +94,10 @@ class GAPICGenerator:
                 "is unavailable."
             )
 
+        generator_dir = LOCAL_GENERATOR
+        if generator_dir is not None:
+            log.debug(f"Using local generator at {generator_dir}")
+
         # Run the code generator.
         # $ artman --config path/to/artman_api.yaml generate python_gapic
         if config_path is None:
@@ -116,6 +121,7 @@ class GAPICGenerator:
             googleapis,
             config_path,
             gapic_language_arg,
+            generator_dir=generator_dir,
             generator_args=generator_args,
         )
 


### PR DESCRIPTION
```
export SYNTHTOOL_GENERATOR=/path/to/gapic-generator
```

Fixes #250 

**See update to README below for description :)**

---

Refresher on how this is used:

 - I work on and with the monolithic generator.
 - Today, SynthTool runs artman which includes the latest version of gapic-generator (in the image)
 - Today, the easiest way for me to run SynthTool with changes to gapic-generator is to push a new version of artman, without much local testing
 - With this, I/we can run SynthTool locally while developing gapic-generator and verify functionality much easier! Very helpful :)

Considerations:

 - While today there is one "generator", that will not always be the case.
 - But the current codebase is authored based around artman which is based around the single generator use-case.
 - As such, I am not doing anything special. I've named the variable `SYNTHTOOL_GENERATOR` knowing full well that there will be a need to support N generators in the future :)

---

/cc @googleapis/samplegen 