### PR TITLE
feat: add anchor so that we can link directly to reference docs

### DIFF
--- a/synthtool/gcp/templates/node_library/.jsdoc.js
+++ b/synthtool/gcp/templates/node_library/.jsdoc.js
@@ -41,5 +41,8 @@ module.exports = {
     sourceFiles: false,
     systemName: '{{ metadata['name'] }}',
     theme: 'lumen'
+  },
+  markdown: {
+    idInHeadings: true
   }
 };

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -126,10 +126,12 @@ Apache Version 2.0
 
 See [LICENSE](https://github.com/{{ metadata['repo']['repo'] }}/blob/master/LICENSE)
 
-{% if metadata['repo']['client_documentation'] %}[client-docs]: {{ metadata['repo']['client_documentation'] }}{% endif %}
+{% if metadata['repo']['client_documentation'] %}[client-docs]: {{ metadata['repo']['client_documentation'] }}#reference{% endif %}
 {% if metadata['repo']['product_documentation'] %}[product-docs]: {{ metadata['repo']['product_documentation'] }}{% endif %}
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [projects]: https://console.cloud.google.com/project
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 {% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}{% endif %}
 [auth]: https://cloud.google.com/docs/authentication/getting-started
+
+<a name="reference"></a>


### PR DESCRIPTION
Adds an anchor, so that when linking out to `googleapis.dev`, we can link directly to the section of the page that has reference docs.