### PR TITLE
Pin black to avoid automated synth updates.

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -37,7 +37,7 @@ def lint(session):
     Returns a failure if the linters find linting errors or sufficiently
     serious code quality issues.
     """
-    session.install("flake8", "black", *LOCAL_DEPS)
+    session.install("flake8", "black==19.3b0", *LOCAL_DEPS)
     session.run(
         "black",
         "--check",
@@ -56,7 +56,7 @@ def blacken(session):
     That run uses an image that doesn't have 3.6 installed. Before updating this
     check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
     """
-    session.install("black")
+    session.install("black==19.3b0")
     session.run(
         "black",
         *BLACK_PATHS,

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -24,7 +24,7 @@ import nox
 
 
 LOCAL_DEPS = (os.path.join("..", "api_core"), os.path.join("..", "core"))
-
+BLACK_VERSION = "black==19.3b0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 if os.path.exists("samples"):
@@ -37,7 +37,7 @@ def lint(session):
     Returns a failure if the linters find linting errors or sufficiently
     serious code quality issues.
     """
-    session.install("flake8", "black==19.3b0", *LOCAL_DEPS)
+    session.install("flake8", BLACK_VERSION, *LOCAL_DEPS)
     session.run(
         "black",
         "--check",
@@ -56,7 +56,7 @@ def blacken(session):
     That run uses an image that doesn't have 3.6 installed. Before updating this
     check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
     """
-    session.install("black==19.3b0")
+    session.install(BLACK_VERSION)
     session.run(
         "black",
         *BLACK_PATHS,


### PR DESCRIPTION
Due to concerns that black updates could randomize our automated generations, I am pinning black to its latest release.