### PR TITLE
Java templates: Fix template replacements, add README

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/synthtool/gcp/templates/java_library/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ Thanks for stopping by to let us know something could be better!
 
 Please run down the following list and make sure you've tried the usual "quick fixes":
 
-  - Search the issues already opened: https://github.com/googleapis/{{metadata['repository']}}/issues
+  - Search the issues already opened: https://github.com/googleapis/{{metadata['repo']['name']}}/issues
   - Check for answers on StackOverflow: http://stackoverflow.com/questions/tagged/google-cloud-platform
 
 If you are still having issues, please be sure to include as much information as possible:
@@ -21,7 +21,7 @@ If you are still having issues, please be sure to include as much information as
    General, Core, and Other are also allowed as types
 2. OS type and version:
 3. Java version:
-4. {{metadata['repository']}} version(s):
+4. {{metadata['repo']['name']}} version(s):
 
 #### Steps to reproduce
 

--- a/synthtool/gcp/templates/java_library/.kokoro/build.bat
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.bat
@@ -1,3 +1,3 @@
 :: See documentation in type-shell-output.bat
 
-"C:\Program Files\Git\bin\bash.exe" github/{{ metadata['repository_name'] }}/.kokoro/build.sh
+"C:\Program Files\Git\bin\bash.exe" github/{{ metadata['repo']['repo_short'] }}/.kokoro/build.sh

--- a/synthtool/gcp/templates/java_library/.kokoro/common.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/common.cfg
@@ -4,10 +4,10 @@
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # All builds use the trampoline script to run in docker.
-build_file: "{{ metadata['repository_name'] }}/.kokoro/trampoline.sh"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/trampoline.sh"
 
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/{{ metadata['repository_name'] }}/.kokoro/build.sh"
+    value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/build.sh"
 }

--- a/synthtool/gcp/templates/java_library/.kokoro/continuous/common.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/continuous/common.cfg
@@ -11,11 +11,11 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "{{ metadata['repository_name'] }}/.kokoro/trampoline.sh"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/trampoline.sh"
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/{{ metadata['repository_name'] }}/.kokoro/build.sh"
+    value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/build.sh"
 }
 
 env_vars: {

--- a/synthtool/gcp/templates/java_library/.kokoro/continuous/dependencies.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/continuous/dependencies.cfg
@@ -8,5 +8,5 @@ env_vars: {
 
 env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
-  value: "github/{{ metadata['repository_name'] }}/.kokoro/dependencies.sh"
+  value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/dependencies.sh"
 }

--- a/synthtool/gcp/templates/java_library/.kokoro/continuous/java8-osx.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/continuous/java8-osx.cfg
@@ -1,3 +1,3 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-build_file: "{{ metadata['repository_name'] }}/.kokoro/build.sh"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/build.sh"

--- a/synthtool/gcp/templates/java_library/.kokoro/continuous/java8-win.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/continuous/java8-win.cfg
@@ -1,3 +1,3 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-build_file: "{{ metadata['repository_name'] }}/.kokoro/build.bat"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/build.bat"

--- a/synthtool/gcp/templates/java_library/.kokoro/continuous/propose_release.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/continuous/propose_release.cfg
@@ -11,7 +11,7 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "{{ metadata['repository_name'] }}/.kokoro/trampoline.sh"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -21,7 +21,7 @@ env_vars: {
 
 env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
-  value: "github/{{ metadata['repository_name'] }}/.kokoro/release/bump_snapshot.sh"
+  value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/release/bump_snapshot.sh"
 }
 
 # tokens used by release-please to keep an up-to-date release PR.

--- a/synthtool/gcp/templates/java_library/.kokoro/continuous/propose_release.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/continuous/propose_release.sh
@@ -21,8 +21,8 @@ export NPM_CONFIG_PREFIX=/home/node/.npm-global
 if [ -f ${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please ]; then
   # Groom the release PR as new commits are merged.
   npx release-please release-pr --token=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-token-release-please \
-    --repo-url=googleapis/{{ metadata['repository_name'] }} \
-    --package-name="{{ metadata['repository_name'] }}" \
+    --repo-url={{ metadata['repo']['repo'] }} \
+    --package-name="{{ metadata['repo']['name'] }}" \
     --api-url=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please \
     --proxy-key=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-key-release-please \
     --release-type=java-auth-yoshi

--- a/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
@@ -15,7 +15,7 @@
 
 set -eo pipefail
 
-cd github/{{ metadata['repository_name'] }}/
+cd github/{{ metadata['repo']['repo_short'] }}/
 
 # Print out Java
 java -version

--- a/synthtool/gcp/templates/java_library/.kokoro/linkage-monitor.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/linkage-monitor.sh
@@ -17,7 +17,7 @@ set -eo pipefail
 # Display commands being run.
 set -x
 
-cd github/{{ metadata['repository_name'] }}/
+cd github/{{ metadata['repo']['repo_short'] }}/
 
 # Print out Java version
 java -version

--- a/synthtool/gcp/templates/java_library/.kokoro/nightly/common.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/nightly/common.cfg
@@ -11,11 +11,11 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "{{ metadata['repository_name'] }}/.kokoro/trampoline.sh"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/trampoline.sh"
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/{{ metadata['repository_name'] }}/.kokoro/build.sh"
+    value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/build.sh"
 }
 
 env_vars: {

--- a/synthtool/gcp/templates/java_library/.kokoro/nightly/dependencies.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/nightly/dependencies.cfg
@@ -8,5 +8,5 @@ env_vars: {
 
 env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
-  value: "github/{{ metadata['repository_name'] }}/.kokoro/dependencies.sh"
+  value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/dependencies.sh"
 }

--- a/synthtool/gcp/templates/java_library/.kokoro/nightly/java8-osx.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/nightly/java8-osx.cfg
@@ -1,3 +1,3 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-build_file: "{{ metadata['repository_name'] }}/.kokoro/build.sh"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/build.sh"

--- a/synthtool/gcp/templates/java_library/.kokoro/nightly/java8-win.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/nightly/java8-win.cfg
@@ -1,3 +1,3 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-build_file: "{{ metadata['repository_name'] }}/.kokoro/build.bat"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/build.bat"

--- a/synthtool/gcp/templates/java_library/.kokoro/presubmit/common.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/presubmit/common.cfg
@@ -11,11 +11,11 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "{{ metadata['repository_name'] }}/.kokoro/trampoline.sh"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/trampoline.sh"
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/{{ metadata['repository_name'] }}/.kokoro/build.sh"
+    value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/build.sh"
 }
 
 env_vars: {

--- a/synthtool/gcp/templates/java_library/.kokoro/presubmit/dependencies.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/presubmit/dependencies.cfg
@@ -8,5 +8,5 @@ env_vars: {
 
 env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
-  value: "github/{{ metadata['repository_name'] }}/.kokoro/dependencies.sh"
+  value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/dependencies.sh"
 }

--- a/synthtool/gcp/templates/java_library/.kokoro/presubmit/java8-osx.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/presubmit/java8-osx.cfg
@@ -1,3 +1,3 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-build_file: "{{ metadata['repository_name'] }}/.kokoro/build.sh"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/build.sh"

--- a/synthtool/gcp/templates/java_library/.kokoro/presubmit/java8-win.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/presubmit/java8-win.cfg
@@ -1,3 +1,3 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-build_file: "{{ metadata['repository_name'] }}/.kokoro/build.bat"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/build.bat"

--- a/synthtool/gcp/templates/java_library/.kokoro/presubmit/linkage-monitor.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/presubmit/linkage-monitor.cfg
@@ -8,5 +8,5 @@ env_vars: {
 
 env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
-  value: "github/{{ metadata['repository_name'] }}/.kokoro/linkage-monitor.sh"
+  value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/linkage-monitor.sh"
 }

--- a/synthtool/gcp/templates/java_library/.kokoro/release/bump_snapshot.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/bump_snapshot.cfg
@@ -11,7 +11,7 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "{{ metadata['repository_name'] }}/.kokoro/trampoline.sh"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -21,7 +21,7 @@ env_vars: {
 
 env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
-  value: "github/{{ metadata['repository_name'] }}/.kokoro/release/bump_snapshot.sh"
+  value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/release/bump_snapshot.sh"
 }
 
 # tokens used by release-please to keep an up-to-date release PR.

--- a/synthtool/gcp/templates/java_library/.kokoro/release/bump_snapshot.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/bump_snapshot.sh
@@ -21,8 +21,8 @@ export NPM_CONFIG_PREFIX=/home/node/.npm-global
 if [ -f ${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please ]; then
   # Groom the snapshot release PR immediately after publishing a release
   npx release-please release-pr --token=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-token-release-please \
-    --repo-url=googleapis/{{ metadata['repository_name'] }} \
-    --package-name="{{ metadata['repository_name'] }}" \
+    --repo-url={{ metadata['repo']['repo'] }} \
+    --package-name="{{ metadata['repo']['name'] }}" \
     --api-url=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please \
     --proxy-key=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-key-release-please \
     --snapshot \

--- a/synthtool/gcp/templates/java_library/.kokoro/release/common.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/common.cfg
@@ -4,7 +4,7 @@
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "{{ metadata['repository_name'] }}/.kokoro/trampoline.sh"
+build_file: "{{ metadata['repo']['repo_short'] }}/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {

--- a/synthtool/gcp/templates/java_library/.kokoro/release/drop.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/drop.cfg
@@ -2,8 +2,8 @@
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/{{ metadata['repository_name'] }}/.kokoro/release/drop.sh"
+    value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/release/drop.sh"
 }
 
 # Download staging properties file.
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java/releases/{{ metadata['repository_name'] }}"
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java/releases/{{ metadata['repo']['repo_short'] }}"

--- a/synthtool/gcp/templates/java_library/.kokoro/release/promote.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/promote.cfg
@@ -2,9 +2,9 @@
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/{{ metadata['repository_name'] }}/.kokoro/release/promote.sh"
+    value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/release/promote.sh"
 }
 
 # Download staging properties file.
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java/releases/{{ metadata['repository_name'] }}"
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java/releases/{{ metadata['repo']['repo_short'] }}"
 

--- a/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc.cfg
@@ -6,7 +6,7 @@ env_vars: {
 
 env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
-  value: "github/{{ metadata['repository_name'] }}/.kokoro/release/publish_javadoc.sh"
+  value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/release/publish_javadoc.sh"
 }
 
 before_action {

--- a/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc.sh
@@ -33,7 +33,7 @@ python3 -m pip install gcp-docuploader
 # compile all packages
 mvn clean install -B -DskipTests=true
 
-NAME={{ metadata['repository_name'] }}
+NAME={{ metadata['repo']['name'] }}
 VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 
 # build the docs

--- a/synthtool/gcp/templates/java_library/.kokoro/release/snapshot.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/snapshot.cfg
@@ -2,5 +2,5 @@
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/{{ metadata['repository_name'] }}-java/.kokoro/release/snapshot.sh"
+    value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/release/snapshot.sh"
 }

--- a/synthtool/gcp/templates/java_library/.kokoro/release/stage.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/stage.cfg
@@ -2,14 +2,14 @@
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/{{ metadata['repository_name'] }}/.kokoro/release/stage.sh"
+    value: "github/{{ metadata['repo']['repo_short'] }}/.kokoro/release/stage.sh"
 }
 
 # Need to save the properties file
 action {
   define_artifacts {
-    regex: "github/{{ metadata['repository_name'] }}/target/nexus-staging/staging/*.properties"
-    strip_prefix: "github/{{ metadata['repository_name'] }}"
+    regex: "github/{{ metadata['repo']['repo_short'] }}/target/nexus-staging/staging/*.properties"
+    strip_prefix: "github/{{ metadata['repo']['repo_short'] }}"
   }
 }
 

--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -1,0 +1,109 @@
+# Google Cloud Java Client for {{metadata['repo']['name_pretty']}}
+
+Java idiomatic client for [{{metadata['repo']['name_pretty']}}][api-reference].
+
+[![Kokoro CI][kokoro-badge-image]][kokoro-badge-link]
+[![Maven][maven-version-image]][maven-version-link]
+
+- [Product Documentation][product-docs]
+- [Client Library Documentation][javadocs]
+
+> Note: This client is a work-in-progress, and may occasionally
+> make backwards-incompatible changes.
+
+## Quickstart
+
+[//]: # ({x-version-update-start:{{metadata['repo']['name']}}:released})
+If you are using Maven, add this to your pom.xml file
+```xml
+<dependency>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>{{metadata['repo']['name']}}</artifactId>
+  <version>0.102.0-beta</version>
+</dependency>
+```
+If you are using Gradle, add this to your dependencies
+```Groovy
+compile 'com.google.cloud:{{metadata['repo']['name']}}:0.102.0-beta'
+```
+If you are using SBT, add this to your dependencies
+```Scala
+libraryDependencies += "com.google.cloud" % "{{metadata['repo']['name']}}" % "0.102.0-beta"
+```
+[//]: # ({x-version-update-end})
+
+## Authentication
+
+See the [Authentication][authentication] section in the base directory's README.
+
+## About {{metadata['repo']['name_pretty']}}
+
+[{{metadata['repo']['name_pretty']}}][api-reference] is a suite of Machine Learning products.
+
+See the [[{{metadata['repo']['name_pretty']}}][api-reference] client library docs][javadocs] to learn how to
+use this {{metadata['repo']['name_pretty']}} Client Library.
+
+## Getting Started
+
+### Prerequisites
+
+You will need a [Google Developers Console][developer-console] project with the
+{{metadata['repo']['name_pretty']}} API enabled. [Follow these instructions][create-project] to get your
+project set up. You will also need to set up the local development environment by
+[installing the Google Cloud SDK][cloud-sdk] and running the following commands in command line:
+`gcloud auth login` and `gcloud config set project [YOUR PROJECT ID]`.
+
+### Installation and setup
+
+You'll need to obtain the `{{metadata['repo']['name']}}` library.  See the [Quickstart](#quickstart) section
+to add `{{metadata['repo']['name']}}` as a dependency in your code.
+
+## Troubleshooting
+
+To get help, follow the instructions in the [shared Troubleshooting document][troubleshooting].
+
+## Transport
+
+{{metadata['repo']['name_pretty']}} uses gRPC for the transport layer.
+
+## Java Versions
+
+Java 7 or above is required for using this client.
+
+## Versioning
+
+This library follows [Semantic Versioning](http://semver.org/).
+
+It is currently in major version zero (``0.y.z``), which means that anything may change at any time
+and the public API should not be considered stable.
+
+## Contributing
+
+Contributions to this library are always welcome and highly encouraged.
+
+See [CONTRIBUTING.md][contributing] documentation for more information on how to get started.
+
+Please note that this project is released with a Contributor Code of Conduct. By participating in
+this project you agree to abide by its terms. See [Code of Conduct][code-of-conduct] for more
+information.
+
+## License
+
+Apache 2.0 - See [LICENSE][license] for more information.
+
+[api-reference]: {{metadata['repo']['api_reference']}}
+[product-docs]: {{metadata['repo']['product_documentation']}}
+[javadocs]: {{metadata['repo']['client_documentation']}}
+[kokoro-badge-image]: http://storage.googleapis.com/cloud-devrel-public/java/badges/{{metadata['repo']['name']}}/master.svg
+[kokoro-badge-link]: http://storage.googleapis.com/cloud-devrel-public/java/badges/{{metadata['repo']['name']}}/master.html
+[maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/{{metadata['repo']['name']}}.svg
+[maven-version-link]: https://search.maven.org/search?q=g:com.google.cloud%20AND%20a:{{metadata['repo']['name']}}&core=gav
+[authentication]: https://github.com/googleapis/google-cloud-java#authentication
+[developer-console]: https://console.developers.google.com/
+[create-project]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
+[cloud-sdk]: https://cloud.google.com/sdk/
+[troubleshooting]: https://github.com/googleapis/google-cloud-common/blob/master/troubleshooting/readme.md#troubleshooting
+
+[contributing]: https://github.com/{{metadata['repo']['repo']}}/blob/master/CONTRIBUTING.md
+[code-of-conduct]: https://github.com/{{metadata['repo']['repo']}}/blob/master/CODE_OF_CONDUCT.md#contributor-code-of-conduct
+[license]: https://github.com/{{metadata['repo']['repo']}}/blob/master/LICENSE

--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -94,8 +94,8 @@ Apache 2.0 - See [LICENSE][license] for more information.
 [api-reference]: {{metadata['repo']['api_reference']}}
 [product-docs]: {{metadata['repo']['product_documentation']}}
 [javadocs]: {{metadata['repo']['client_documentation']}}
-[kokoro-badge-image]: http://storage.googleapis.com/cloud-devrel-public/java/badges/{{metadata['repo']['name']}}/master.svg
-[kokoro-badge-link]: http://storage.googleapis.com/cloud-devrel-public/java/badges/{{metadata['repo']['name']}}/master.html
+[kokoro-badge-image]: http://storage.googleapis.com/cloud-devrel-public/java/badges/{{metadata['repo']['repo_short']}}/master.svg
+[kokoro-badge-link]: http://storage.googleapis.com/cloud-devrel-public/java/badges/{{metadata['repo']['repo_short']}}/master.html
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/{{metadata['repo']['name']}}.svg
 [maven-version-link]: https://search.maven.org/search?q=g:com.google.cloud%20AND%20a:{{metadata['repo']['name']}}&core=gav
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication

--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -40,7 +40,7 @@ See the [Authentication][authentication] section in the base directory's README.
 
 [{{metadata['repo']['name_pretty']}}][api-reference] is a suite of Machine Learning products.
 
-See the [[{{metadata['repo']['name_pretty']}}][api-reference] client library docs][javadocs] to learn how to
+See the [{{metadata['repo']['name_pretty']}} client library docs][javadocs] to learn how to
 use this {{metadata['repo']['name_pretty']}} Client Library.
 
 ## Getting Started

--- a/synthtool/gcp/templates/java_library/java.header
+++ b/synthtool/gcp/templates/java_library/java.header
@@ -1,0 +1,15 @@
+^/\*$
+^ \* Copyright \d\d\d\d,? Google (Inc\.|LLC)( All [rR]ights [rR]eserved\.)?$
+^ \*$
+^ \* Licensed under the Apache License, Version 2\.0 \(the "License"\);$
+^ \* you may not use this file except in compliance with the License\.$
+^ \* You may obtain a copy of the License at$
+^ \*$
+^ \*[ ]+https?://www.apache.org/licenses/LICENSE-2\.0$
+^ \*$
+^ \* Unless required by applicable law or agreed to in writing, software$
+^ \* distributed under the License is distributed on an "AS IS" BASIS,$
+^ \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.$
+^ \* See the License for the specific language governing permissions and$
+^ \* limitations under the License\.$
+^ \*/$

--- a/synthtool/gcp/templates/java_library/license-checks.xml
+++ b/synthtool/gcp/templates/java_library/license-checks.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="RegexpHeader">
+    <property name="fileExtensions" value="java"/>
+    <property name="headerFile" value="${checkstyle.header.file}"/>
+  </module>
+</module>


### PR DESCRIPTION
The README is there to help bootstrap the initial README. We expect the README for beta/GA clients to have code examples present.