### PR TITLE
Catch FileNotFoundError for gen-manifest

### DIFF
--- a/synthtool/gcp/gapic_generator.py
+++ b/synthtool/gcp/gapic_generator.py
@@ -323,5 +323,5 @@ class GAPICGenerator:
         try:
             log.debug(f"Writing samples manifest {manifest_arguments}")
             shell.run(manifest_arguments, cwd=samples_root_dir)
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             log.warning("gen-manifest failed (sample-tester may not be installed)")


### PR DESCRIPTION
It appears synthtool will raise a `FileNotFoundError` when `gen-manifest` isn't available.

See https://github.com/googleapis/google-cloud-python/issues/9181

CC @beccasaurus 