### PR TITLE
Java: renovate config - use docker version scheme for guava

### DIFF
--- a/synthtool/gcp/templates/java_library/renovate.json
+++ b/synthtool/gcp/templates/java_library/renovate.json
@@ -25,6 +25,11 @@
     {
       "packagePatterns": ["^io.opencensus:opencensus-"],
       "groupName": "OpenCensus packages"
+    },
+    {
+      "managers": ["maven"],
+      "packageNames": ["com.google.guava:guava"],
+      "versionScheme": "docker"
     }
   ],
   "semanticCommits": true


### PR DESCRIPTION
This forces renovate to keep the same version suffix. i.e. 28.0-android -> 28.1-android (rather that switching to -jre)

see https://github.com/renovatebot/config-help/issues/232#issuecomment-491826549