### PR TITLE
fix: do not eslint in protos/

### DIFF
--- a/synthtool/gcp/templates/node_library/.eslintignore
+++ b/synthtool/gcp/templates/node_library/.eslintignore
@@ -2,3 +2,4 @@
 src/**/doc/*
 build/
 docs/
+protos/


### PR DESCRIPTION
We've got some generated stuff in `protos/`, such as `protos.js` and `protos.d.ts`, they are huge and we don't want `eslint` to check/fix them.