### PR TITLE
fix(node): add a common pull request template

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/PULL_REQUEST_TEMPLATE.md
+++ b/synthtool/gcp/templates/node_library/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
-- [ ] Make sure to open an issue as a bug/issue before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
+- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/{{metadata['repo']['name']}}/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
 - [ ] Ensure the tests and linter pass
 - [ ] Code coverage does not decrease (if any source code was changed)
 - [ ] Appropriate docs were updated (if necessary)

--- a/synthtool/gcp/templates/node_library/.github/PULL_REQUEST_TEMPLATE.md
+++ b/synthtool/gcp/templates/node_library/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
+- [ ] Make sure to open an issue as a bug/issue before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
+- [ ] Ensure the tests and linter pass
+- [ ] Code coverage does not decrease (if any source code was changed)
+- [ ] Appropriate docs were updated (if necessary)
+
+Fixes #<issue_number_goes_here> 🦕


### PR DESCRIPTION
In most nodejs libraries we have a pull request template, but it wasn't part of our common files (ooops).  This proposes a common template.  If we like this, we would expand it out to other languages as well.

