### PR TITLE
fix: use repo rather than name

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/PULL_REQUEST_TEMPLATE.md
+++ b/synthtool/gcp/templates/node_library/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
-- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/{{metadata['repo']['name']}}/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
+- [ ] Make sure to open an issue as a [bug/issue](https://github.com/{{ metadata['repo']['repo'] }}/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
 - [ ] Ensure the tests and linter pass
 - [ ] Code coverage does not decrease (if any source code was changed)
 - [ ] Appropriate docs were updated (if necessary)


### PR DESCRIPTION
A couple small tweaks:

1. we now go directly to opening an issue for the user.
2. we now use `repo` rather than `name`, as the two can vary.

