### PR TITLE
docs: update contributing docs to include running tests

### DIFF
--- a/synthtool/gcp/templates/node_library/CONTRIBUTING.md
+++ b/synthtool/gcp/templates/node_library/CONTRIBUTING.md
@@ -34,6 +34,7 @@ accept your pull requests.
 1.  Ensure that your code adheres to the existing style in the code to which
     you are contributing.
 1.  Ensure that your code has an appropriate set of tests which all pass.
+1.  Title your pull request following [Conventional Commits](https://www.conventionalcommits.org/) styling.
 1.  Submit a pull request.
 
 ## Running the tests
@@ -46,7 +47,15 @@ accept your pull requests.
 
 1.  Run the tests:
 
+        # Run all tests.
         npm test
+
+        # Run all unit tests.
+        npm run test-only
+
+        # Run all system tests.
+        gcloud auth application-default login
+        npm run system-test
 
 1.  Lint (and maybe fix) any changes:
 


### PR DESCRIPTION
Porting further upstream into the origin of the CONTRIBUTING docs ([original](https://github.com/googleapis/nodejs-firestore/pull/772))