### PR TITLE
fix: relax guava package name

### DIFF
--- a/synthtool/gcp/templates/java_library/renovate.json
+++ b/synthtool/gcp/templates/java_library/renovate.json
@@ -6,7 +6,7 @@
   "packageRules": [
     {
       "managers": ["maven"],
-      "packageNames": ["com.google.guava:guava"],
+      "packageNames": ["com.google.guava:guava*"],
       "versionScheme": "docker"
     },
     {


### PR DESCRIPTION
In most places, we import guava-bom rather than directly using guava, but still allow guava packages to be updated.