### PR TITLE
bug: update bug_report.md template to use `repo_short`

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/synthtool/gcp/templates/java_library/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ Thanks for stopping by to let us know something could be better!
 
 Please run down the following list and make sure you've tried the usual "quick fixes":
 
-  - Search the issues already opened: https://github.com/googleapis/{{metadata['repo']['name']}}/issues
+  - Search the issues already opened: https://github.com/googleapis/{{metadata['repo']['repo_short']}}/issues
   - Check for answers on StackOverflow: http://stackoverflow.com/questions/tagged/google-cloud-platform
 
 If you are still having issues, please include as much information as possible:


### PR DESCRIPTION
The template synthtool/gcp/templates/java_library/.github/ISSUE_TEMPLATE/bug_report.md was incorrectly using `name` to
generate the github URL which would result in getting:
```
https://github.com/googleapis/conformance-tests
```
instead of
```
https://github.com/googleapis/java-conformance-tests
```