### PR TITLE
feat: add helper for the most common Java library synth generation

### DIFF
--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -109,7 +109,7 @@ def fix_grpc_headers(grpc_root: Path, package_name: str) -> None:
 def gapic_library(
     service: str,
     version: str,
-    config_pattern: "/google/cloud/{service}/artman_{service}_{version}.yaml",
+    config_pattern: str = "/google/cloud/{service}/artman_{service}_{version}.yaml",
     package_pattern: str = "com.google.cloud.{service}.{version}",
     gapic: gcp.GAPICGenerator = None,
     **kwargs,
@@ -130,18 +130,20 @@ def gapic_library(
     fix_grpc_headers(library / f"grpc-google-cloud-{service}-{version}", package_name)
 
     s.copy(
-        library / f"gapic-google-cloud-{service}-{version}/src",
+        [library / f"gapic-google-cloud-{service}-{version}/src"],
         f"google-cloud-{service}/src",
     )
     s.copy(
-        library / f"grpc-google-cloud-{service}-{version}/src",
+        [library / f"grpc-google-cloud-{service}-{version}/src"],
         f"grpc-google-cloud-{service}-{version}/src",
     )
     s.copy(
-        library / f"proto-google-cloud-{service}-{version}/src",
+        [library / f"proto-google-cloud-{service}-{version}/src"],
         f"proto-google-cloud-{service}-{version}/src",
     )
 
     format_code(f"google-cloud-{service}/src")
     format_code(f"grpc-google-cloud-{service}-{version}/src")
     format_code(f"proto-google-cloud-{service}-{version}/src")
+
+    return library

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -105,13 +105,14 @@ def fix_grpc_headers(grpc_root: Path, package_name: str) -> None:
         f"{GOOD_LICENSE}package {package_name};",
     )
 
+
 def gapic_library(
     service: str,
     version: str,
-    config_pattern: '/google/cloud/{service}/artman_{service}_{version}.yaml',
-    package_pattern: str = 'com.google.cloud.{service}.{version}',
+    config_pattern: "/google/cloud/{service}/artman_{service}_{version}.yaml",
+    package_pattern: str = "com.google.cloud.{service}.{version}",
     gapic: gcp.GAPICGenerator = None,
-    **kwargs
+    **kwargs,
 ) -> Path:
     if gapic is None:
         gapic = gcp.GAPICGenerator()
@@ -120,18 +121,27 @@ def gapic_library(
         service=service,
         version=version,
         config_path=config_pattern.format(service=service, version=version),
-        artman_output_name='',
+        artman_output_name="",
         include_samples=True,
         **kwargs,
     )
     package_name = package_pattern.format(service=service, version=version)
-    fix_proto_headers(library / f'proto-google-cloud-{service}-{version}')
-    fix_grpc_headers(library / f'grpc-google-cloud-{service}-{version}', package_name)
+    fix_proto_headers(library / f"proto-google-cloud-{service}-{version}")
+    fix_grpc_headers(library / f"grpc-google-cloud-{service}-{version}", package_name)
 
-    s.copy(library / f'gapic-google-cloud-{service}-{version}/src', f'google-cloud-{service}/src')
-    s.copy(library / f'grpc-google-cloud-{service}-{version}/src', f'grpc-google-cloud-{service}-{version}/src')
-    s.copy(library / f'proto-google-cloud-{service}-{version}/src', f'proto-google-cloud-{service}-{version}/src')
+    s.copy(
+        library / f"gapic-google-cloud-{service}-{version}/src",
+        f"google-cloud-{service}/src",
+    )
+    s.copy(
+        library / f"grpc-google-cloud-{service}-{version}/src",
+        f"grpc-google-cloud-{service}-{version}/src",
+    )
+    s.copy(
+        library / f"proto-google-cloud-{service}-{version}/src",
+        f"proto-google-cloud-{service}-{version}/src",
+    )
 
-    format_code(f'google-cloud-{service}/src')
-    format_code(f'grpc-google-cloud-{service}-{version}/src')
-    format_code(f'proto-google-cloud-{service}-{version}/src')
+    format_code(f"google-cloud-{service}/src")
+    format_code(f"grpc-google-cloud-{service}-{version}/src")
+    format_code(f"proto-google-cloud-{service}-{version}/src")

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -94,8 +94,11 @@ def fix_proto_headers(proto_root: Path) -> None:
         PROTOBUF_HEADER,
         f"{GOOD_LICENSE}{PROTOBUF_HEADER}",
     )
-    s.replace([proto_root / "src/**/*Name.java"], BAD_LICENSE, GOOD_LICENSE)
-    s.replace([proto_root / "src/**/*Names.java"], BAD_LICENSE, GOOD_LICENSE)
+    s.replace(
+        [proto_root / "src/**/*Name.java", proto_root / "src/**/*Names.java"],
+        BAD_LICENSE,
+        GOOD_LICENSE,
+    )
 
 
 def fix_grpc_headers(grpc_root: Path, package_name: str) -> None:

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -16,6 +16,7 @@ import glob
 import os
 import requests
 import synthtool as s
+import synthtool.gcp as gcp
 from synthtool import cache
 from synthtool import log
 from synthtool import shell
@@ -94,6 +95,7 @@ def fix_proto_headers(proto_root: Path) -> None:
         f"{GOOD_LICENSE}{PROTOBUF_HEADER}",
     )
     s.replace([proto_root / "src/**/*Name.java"], BAD_LICENSE, GOOD_LICENSE)
+    s.replace([proto_root / "src/**/*Names.java"], BAD_LICENSE, GOOD_LICENSE)
 
 
 def fix_grpc_headers(grpc_root: Path, package_name: str) -> None:
@@ -102,3 +104,34 @@ def fix_grpc_headers(grpc_root: Path, package_name: str) -> None:
         f"package {package_name};",
         f"{GOOD_LICENSE}package {package_name};",
     )
+
+def gapic_library(
+    service: str,
+    version: str,
+    config_pattern: '/google/cloud/{service}/artman_{service}_{version}.yaml',
+    package_pattern: str = 'com.google.cloud.{service}.{version}',
+    gapic: gcp.GAPICGenerator = None,
+    **kwargs
+) -> Path:
+    if gapic is None:
+        gapic = gcp.GAPICGenerator()
+
+    library = gapic.java_library(
+        service=service,
+        version=version,
+        config_path=config_pattern.format(service=service, version=version),
+        artman_output_name='',
+        include_samples=True,
+        **kwargs,
+    )
+    package_name = package_pattern.format(service=service, version=version)
+    fix_proto_headers(library / f'proto-google-cloud-{service}-{version}')
+    fix_grpc_headers(library / f'grpc-google-cloud-{service}-{version}', package_name)
+
+    s.copy(library / f'gapic-google-cloud-{service}-{version}/src', f'google-cloud-{service}/src')
+    s.copy(library / f'grpc-google-cloud-{service}-{version}/src', f'grpc-google-cloud-{service}-{version}/src')
+    s.copy(library / f'proto-google-cloud-{service}-{version}/src', f'proto-google-cloud-{service}-{version}/src')
+
+    format_code(f'google-cloud-{service}/src')
+    format_code(f'grpc-google-cloud-{service}-{version}/src')
+    format_code(f'proto-google-cloud-{service}-{version}/src')


### PR DESCRIPTION
This will greatly simplify our synth.py scripts across our split java repos. We do all of these steps when we generate a java versioned library.