### PR TITLE
fix: in Node.js repo-name and package-name can be different

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/release-please.yml
+++ b/synthtool/gcp/templates/node_library/.github/release-please.yml
@@ -1,1 +1,2 @@
 releaseType: node
+packageName: '{{ metadata['name'] }}'


### PR DESCRIPTION
This will address a bug with `samples/package.json` not being updated.

@busunkim96 this might be the case with Python as well? You might want to populate `packageName` in your config.