### PR TITLE
feat(java): process sponge logs after tests

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.sh
@@ -39,6 +39,7 @@ case ${JOB_TYPE} in
 test)
     mvn test -B
     bash ${KOKORO_GFILE_DIR}/codecov.sh
+    bash .kokoro/coerce_logs.sh
     ;;
 lint)
     mvn com.coveo:fmt-maven-plugin:check
@@ -48,6 +49,7 @@ javadoc)
     ;;
 integration)
     mvn -B ${INTEGRATION_TEST_ARGS} -DtrimStackTrace=false -fae verify
+    bash .kokoro/coerce_logs.sh
     ;;
 *)
     ;;

--- a/synthtool/gcp/templates/java_library/.kokoro/coerce_logs.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/coerce_logs.sh
@@ -1,0 +1,35 @@
+#!/bin/bash# Copyright 2019 Google LLC
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+# This script finds and moves sponge logs so that they can be found by placer
+# and are not flagged as flaky by sponge.
+
+set -eo pipefail
+
+## Get the directory of the build script
+scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+## cd to the parent directory, i.e. the root of the git repo
+cd ${scriptDir}/..
+
+echo "coercing sponge logs..."
+for xml in `find . -name *-sponge_log.xml`
+do
+  echo "processing ${xml}"
+  class=$(basename ${xml} | cut -d- -f2)
+  dir=$(dirname ${xml})/${class}
+  text=$(dirname ${xml})/${class}-sponge_log.txt
+  mkdir -p ${dir}
+  mv ${xml} ${dir}/sponge_log.xml
+  mv ${text} ${dir}/sponge_log.txt
+done

--- a/synthtool/gcp/templates/java_library/.kokoro/coerce_logs.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/coerce_logs.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 # Copyright 2019 Google LLC
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This script finds and moves sponge logs so that they can be found by placer
 # and are not flagged as flaky by sponge.

--- a/synthtool/gcp/templates/java_library/.kokoro/coerce_logs.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/coerce_logs.sh
@@ -1,4 +1,5 @@
-#!/bin/bash# Copyright 2019 Google LLC
+#!/bin/bash
+# Copyright 2019 Google LLC
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/synthtool/gcp/templates/java_library/.kokoro/continuous/common.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/continuous/common.cfg
@@ -4,6 +4,7 @@
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "**/*sponge_log.txt"
   }
 }
 

--- a/synthtool/gcp/templates/java_library/.kokoro/nightly/common.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/nightly/common.cfg
@@ -4,6 +4,7 @@
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "**/*sponge_log.txt"
   }
 }
 

--- a/synthtool/gcp/templates/java_library/.kokoro/presubmit/common.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/presubmit/common.cfg
@@ -4,6 +4,7 @@
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "**/*sponge_log.txt"
   }
 }
 


### PR DESCRIPTION
Currently, sponge thinks our junit tests are flaky because there are multiple `sponge_log.xml` log files (jUnit XML format) in the same output directory. This adds a post-processing script to move them to separate directories. In the ResultsStore UI, these will be found and separate targets, as well as in sponge.