### PR TITLE
feat(java): split clirr check into separate kokoro job

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.sh
@@ -26,6 +26,7 @@ echo ${JOB_TYPE}
 
 mvn install -B -V \
   -DskipTests=true \
+  -Dclirr.skip=true \
   -Dmaven.javadoc.skip=true \
   -Dgcloud.download.skip=true \
   -T 1C
@@ -37,7 +38,7 @@ fi
 
 case ${JOB_TYPE} in
 test)
-    mvn test -B
+    mvn test -B -Dclirr.skip=true
     bash ${KOKORO_GFILE_DIR}/codecov.sh
     bash .kokoro/coerce_logs.sh
     ;;
@@ -48,8 +49,11 @@ javadoc)
     mvn javadoc:javadoc javadoc:test-javadoc
     ;;
 integration)
-    mvn -B ${INTEGRATION_TEST_ARGS} -DtrimStackTrace=false -fae verify
+    mvn -B ${INTEGRATION_TEST_ARGS} -DtrimStackTrace=false -Dclirr.skip=true -fae verify
     bash .kokoro/coerce_logs.sh
+    ;;
+clirr)
+    mvn -B clirr:check
     ;;
 *)
     ;;

--- a/synthtool/gcp/templates/java_library/.kokoro/presubmit/clirr.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/presubmit/clirr.cfg
@@ -1,0 +1,13 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "clirr"
+}


### PR DESCRIPTION
Currently, all presubmits fail if the maven-clirr-plugin fails. This causes lots of noise trying to determine what actually fails. clirr check happens on `verify` which happens as part of `install`.

Locally,  a user will still see the run clirr when running install, but in CI, we will split it out into a separate job. To do so, we skip clirr on install, units, and integration tests and create a new job type for clirr.