### PR TITLE
feat(java): enable samplegen

### DIFF
--- a/synthtool/gcp/gapic_generator.py
+++ b/synthtool/gcp/gapic_generator.py
@@ -241,7 +241,6 @@ class GAPICGenerator:
         googleapis_service_dir: Path,
         samples_root_dir: Path = None,
         samples_resources_dir: Path = None,
-        samples_version_dir: Path = None,
     ):
         """Include code samples and supporting resources in generated output.
 

--- a/synthtool/gcp/gapic_generator.py
+++ b/synthtool/gcp/gapic_generator.py
@@ -322,8 +322,8 @@ class GAPICGenerator:
                 download_path = samples_resources_dir / os.path.basename(uri)
                 os.makedirs(samples_resources_dir, exist_ok=True)
                 log.debug(f"Download {uri} to {download_path}")
-                with open(download_path, "wb") as f:
-                    f.write(response.content)
+                with open(download_path, "wb") as output:  # type: ignore
+                    output.write(response.content)
 
         # Generate manifest file at samples/{version}/test/samples.manifest.yaml
         # Includes a reference to every sample (via its "region tag" identifier)

--- a/synthtool/gcp/gapic_generator.py
+++ b/synthtool/gcp/gapic_generator.py
@@ -173,8 +173,14 @@ class GAPICGenerator:
             samples_root_dir = None
             samples_resource_dir = None
             if language == "java":
-                samples_root_dir = genfiles / f"gapic-google-cloud-{service}-{version}/samples/src/main/java/com/google/cloud/examples/{service}"
-                samples_resource_dir = genfiles / f"gapic-google-cloud-{service}-{version}/samples/resources"
+                samples_root_dir = (
+                    genfiles
+                    / f"gapic-google-cloud-{service}-{version}/samples/src/main/java/com/google/cloud/examples/{service}"
+                )
+                samples_resource_dir = (
+                    genfiles
+                    / f"gapic-google-cloud-{service}-{version}/samples/resources"
+                )
             googleapis_service_dir = googleapis / config_path.parent
             self._include_samples(
                 language=language,
@@ -333,7 +339,7 @@ class GAPICGenerator:
             "python": "python3",
             "ruby": "bundle exec ruby",
         }
-        if not language in LANGUAGE_EXECUTABLES:
+        if language not in LANGUAGE_EXECUTABLES:
             log.info("skipping manifest gen")
             return None
 

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -154,7 +154,10 @@ def gapic_library(
         "samples/resources",
     )
     s.copy(
-        [library / f"gapic-google-cloud-{service}-{version}/samples/src/**/*.manifest.yaml"],
+        [
+            library
+            / f"gapic-google-cloud-{service}-{version}/samples/src/**/*.manifest.yaml"
+        ],
         f"samples/src/main/java/com/google/cloud/examples/{service}/{version}/{service}.manifest.yaml",
     )
 

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -144,9 +144,23 @@ def gapic_library(
         [library / f"proto-google-cloud-{service}-{version}/src"],
         f"proto-google-cloud-{service}-{version}/src",
     )
+    s.copy(
+        [library / f"gapic-google-cloud-{service}-{version}/samples/src"],
+        "samples/src",
+        excludes=["**/*.manifest.yaml"],
+    )
+    s.copy(
+        [library / f"gapic-google-cloud-{service}-{version}/samples/resources"],
+        "samples/resources",
+    )
+    s.copy(
+        [library / f"gapic-google-cloud-{service}-{version}/samples/src/**/*.manifest.yaml"],
+        f"samples/src/main/java/com/google/cloud/examples/{service}/{version}/{service}.manifest.yaml",
+    )
 
     format_code(f"google-cloud-{service}/src")
     format_code(f"grpc-google-cloud-{service}-{version}/src")
     format_code(f"proto-google-cloud-{service}-{version}/src")
+    format_code("samples/src")
 
     return library


### PR DESCRIPTION
Java has a special, deep directory structure for generated samples. Therefore, we need to make the directory structure configurable for` _include_samples()`.