### PR TITLE
feat(coverage): start providing coverage for src

### DIFF
--- a/synthtool/gcp/templates/node_library/.nycrc
+++ b/synthtool/gcp/templates/node_library/.nycrc
@@ -10,7 +10,6 @@
     "**/docs",
     "**/samples",
     "**/scripts",
-    "**/src/**/v*/**/*.js",
     "**/protos",
     "**/test",
     ".jsdoc.js",


### PR DESCRIPTION
excluding ` "**/src/**/v*/**/*.js"` prevents us from getting interesting insights into how our libraries are tested. As an example, I just ran `@google-cloud/translate` with this stanza removed, and it told me we don't call `getProjectId` in our unit tests:

![example](https://user-images.githubusercontent.com/194609/67601261-c3f6e180-f728-11e9-8e34-c52d17ca49be.png)

I think we should cover `src` by default, and if there's a compelling reason to remove it for some projects we can exclude `.nycrc` in `synth.py`.