### PR TITLE
docs(python): add Python 2 sunset banner

### DIFF
--- a/synthtool/gcp/templates/python_library/docs/_static/custom.css
+++ b/synthtool/gcp/templates/python_library/docs/_static/custom.css
@@ -1,0 +1,4 @@
+div#python2-eol {
+	border-color: red;
+	border-width: medium;
+} 

--- a/synthtool/gcp/templates/python_library/docs/_templates/layout.html
+++ b/synthtool/gcp/templates/python_library/docs/_templates/layout.html
@@ -1,0 +1,49 @@
+{% extends "!layout.html" %}
+{%- block content %}
+{%- if theme_fixed_sidebar|lower == 'true' %}
+  <div class="document">
+    {{ sidebar() }}
+    {%- block document %}
+      <div class="documentwrapper">
+      {%- if render_sidebar %}
+        <div class="bodywrapper">
+      {%- endif %}
+
+          {%- block relbar_top %}
+            {%- if theme_show_relbar_top|tobool %}
+              <div class="related top">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+          <div class="body" role="main">
+          	<div class="admonition" id="python2-eol"> 
+          	 On January 1, 2020 this library will no longer support Python 2 on the latest released version. 
+          	 Previously released library versions will continue to be available. For more information please
+          	 visit <a href="https://cloud.google.com/python/docs/python2-sunset/">Python 2 support on Google Cloud</a>.
+          	</div>
+            {% block body %} {% endblock %}
+          </div>
+
+          {%- block relbar_bottom %}
+            {%- if theme_show_relbar_bottom|tobool %}
+              <div class="related bottom">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+      {%- if render_sidebar %}
+        </div>
+      {%- endif %}
+      </div>
+    {%- endblock %}
+    <div class="clearer"></div>
+  </div>
+{%- else %}
+{{ super() }}
+{%- endif %}
+{%- endblock %}


### PR DESCRIPTION
The wording has been changed slightly since I took this screenshot, but the formatting is the same.

![image](https://user-images.githubusercontent.com/8822365/68512325-edd1fd00-022c-11ea-9c5b-f144096639ec.png)


The banner will not appear until there is a small change to docs/conf.py in https://github.com/googleapis/gapic-generator/pull/3020