### PR TITLE
fix(java): set bumpMinorPreMajor for Java releases

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/release-please.yml
+++ b/synthtool/gcp/templates/java_library/.github/release-please.yml
@@ -1,1 +1,2 @@
 releaseType: java-yoshi
+bumpMinorPreMajor: true


### PR DESCRIPTION
This causes breaking changes in pre-1.0 Java libraries to be bumped with minor versioning rather than to 1.0.0