### PR TITLE
fix(java): skip clirr check in the dependencies presubmit check

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
@@ -23,5 +23,9 @@ echo $JOB_TYPE
 
 export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m"
 
-mvn install -DskipTests=true -B -V
+# this should run maven enforcer
+mvn install -B -V \
+  -DskipTests=true \
+  -Dclirr.skip=true
+
 mvn -B dependency:analyze -DfailOnWarning=true


### PR DESCRIPTION
This prevents both the clirr and dependencies check from failing when the clirr check fails.