### PR TITLE
chore: pin TypeScript for the time being

### DIFF
--- a/synthtool/gcp/templates/node_library/renovate.json
+++ b/synthtool/gcp/templates/node_library/renovate.json
@@ -14,5 +14,6 @@
       "extends": "packages:linters",
       "groupName": "linters"
     }
-  ]
+  ],
+  "ignoreDeps": ["typescript"]
 }


### PR DESCRIPTION
we're opting to pin TypeScript for the time being, until such time as we can figure out a better resolution for tickets like https://github.com/googleapis/google-auth-library-nodejs/issues/844.

_Note: this should not land until we've run automated tooling across all our repos to update configuration._