### PR TITLE
fix: pass user id to docker run if possible

### DIFF
--- a/synthtool/gcp/gapic_microgenerator.py
+++ b/synthtool/gcp/gapic_microgenerator.py
@@ -134,6 +134,14 @@ class GAPICMicrogenerator:
         # The time has come, the walrus said, to talk of actually running
         # the code generator.
         sep = os.path.sep
+
+        # try to figure out user ID and stay compatible.
+        # If there is no `os.getuid()`, fallback to `getpass.getuser()`
+        try:
+            user = str(os.getuid())
+        except:
+            user = getpass.getuser()
+
         docker_run_args = [
             "docker",
             "run",
@@ -143,7 +151,7 @@ class GAPICMicrogenerator:
             f"type=bind,source={output_dir}{sep},destination={Path('/out')}{sep}",
             "--rm",
             "--user",
-            getpass.getuser(),
+            user
         ]
 
         # Process extra proto files, e.g. google/cloud/common_resources.proto,

--- a/synthtool/gcp/gapic_microgenerator.py
+++ b/synthtool/gcp/gapic_microgenerator.py
@@ -139,7 +139,7 @@ class GAPICMicrogenerator:
         # If there is no `os.getuid()`, fallback to `getpass.getuser()`
         try:
             user = str(os.getuid())
-        except:
+        except AttributeError:
             user = getpass.getuser()
 
         docker_run_args = [
@@ -151,7 +151,7 @@ class GAPICMicrogenerator:
             f"type=bind,source={output_dir}{sep},destination={Path('/out')}{sep}",
             "--rm",
             "--user",
-            user
+            user,
         ]
 
         # Process extra proto files, e.g. google/cloud/common_resources.proto,


### PR DESCRIPTION
Recent `synthtool` runs with micro generator has failed with

```
synthtool > Failed executing docker run --mount type=bind,source=/home/kbuilder/.cache/synthtool/googleapis/google/devtools/cloudbuild/v1/,destination=/in/google/devtools/cloudbuild/v1/,readonly --mount type=bind,source=/tmpfs/tmp/tmp3qua4out/,destination=/out/ --rm --user kbuilder gcr.io/gapic-images/gapic-generator-typescript:latest --grpc-service-config google/devtools/cloudbuild/v1/cloudbuild_grpc_service_config.json:

docker: Error response from daemon: linux spec user: unable to find user kbuilder: no matching entries in passwd file.
```

It can be easily fixed by passing an ID of the current user instead of its name. To stay compatible (e.g. if anyone wants to run it on Windows), fallback to the current scenario if `os.getuid()` does not exist.