### PR TITLE
fix(java_templates): fix renovate configuration

### DIFF
--- a/synthtool/gcp/templates/java_library/renovate.json
+++ b/synthtool/gcp/templates/java_library/renovate.json
@@ -1,27 +1,41 @@
 {
   "extends": [
-    "config:base"
+    ":separateMajorReleases",
+    ":combinePatchMinorReleases",
+    ":ignoreUnstable",
+    ":prImmediately",
+    ":updateNotScheduled",
+    ":automergeDisabled",
+    ":ignoreModulesAndTests",
+    ":maintainLockFilesDisabled",
+    ":autodetectPinVersions"
   ],
-  "ignoreDeps": [],
   "packageRules": [
     {
-      "managers": ["maven"],
-      "packageNames": ["com.google.guava:guava*"],
+      "packagePatterns": [
+        "^com.google.guava:"
+      ],
       "versionScheme": "docker"
     },
     {
-      "packagePatterns": ["^io.grpc:grpc-"],
-      "groupName": "gRPC packages"
+      "packagePatterns": [
+        "*"
+      ],
+      "semanticCommitType": "deps",
+      "semanticCommitScope": null
     },
     {
-      "packagePatterns": ["^com.google.protobuf:protobuf-"],
-      "groupName": "Protobuf packages"
-    },
-    {
-      "packagePatterns": ["^io.opencensus:opencensus-"],
-      "groupName": "OpenCensus packages"
+      "packagePatterns": [
+        "^org.apache.maven",
+        "^org.jacoco:",
+        "^org.codehaus.mojo:",
+        "^org.sonatype.plugins:",
+        "^com.coveo:",
+        "^com.google.cloud:google-cloud-shared-config"
+      ],
+      "semanticCommitType": "build",
+      "semanticCommitScope": "deps"
     }
   ],
-  "semanticCommits": true,
-  "semanticCommitType": "deps"
+  "semanticCommits": true
 }


### PR DESCRIPTION
Common build plugin updates should now send PRs and `build(deps): [message]`, other updates should use `deps: [message]`.
Fixes guava's version scheme to preserve the guava flavor (`-android` vs `-jre`).

Note that the other groups all should be importing their boms (grpc, gax), and OpenCensus is on its last version and are all up to date already.

Sample PRs: https://github.com/chingor13/renovate-test/pulls