### PR TITLE
test: adding additional coverage ignore rules

### DIFF
--- a/synthtool/gcp/templates/node_library/.nycrc
+++ b/synthtool/gcp/templates/node_library/.nycrc
@@ -16,7 +16,8 @@
     "**/.jsdoc.js",
     "karma.conf.js",
     "webpack-tests.config.js",
-    "webpack.config.js"
+    "webpack.config.js",
+    "**/*.d.ts"
   ],
   "exclude-after-remap": false,
   "all": true


### PR DESCRIPTION
now that `c8` supports `--all`, it seems like it might be worth adding a few additional ignore rules to our coverage collection.


_Note: let's not land this immediately, in case a few more rules jump out at us worth adding, during review._
