### PR TITLE
feat(java): add helper for bazel generation

### DIFF
--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -108,17 +108,16 @@ def fix_grpc_headers(grpc_root: Path, package_name: str) -> None:
         f"{GOOD_LICENSE}package {package_name};",
     )
 
+
 def _common_generation(
-    service: str,
-    version: str,
-    library: Path,
-    package_pattern: str,
-    suffix: str = ''
-    ):
+    service: str, version: str, library: Path, package_pattern: str, suffix: str = ""
+):
 
     package_name = package_pattern.format(service=service, version=version)
     fix_proto_headers(library / f"proto-google-cloud-{service}-{version}{suffix}")
-    fix_grpc_headers(library / f"grpc-google-cloud-{service}-{version}{suffix}", package_name)
+    fix_grpc_headers(
+        library / f"grpc-google-cloud-{service}-{version}{suffix}", package_name
+    )
 
     s.copy(
         [library / f"gapic-google-cloud-{service}-{version}{suffix}/src"],
@@ -154,6 +153,7 @@ def _common_generation(
     format_code(f"proto-google-cloud-{service}-{version}/src")
     format_code("samples/src")
 
+
 def gapic_library(
     service: str,
     version: str,
@@ -178,10 +178,11 @@ def gapic_library(
         service=service,
         version=version,
         library=library,
-        package_pattern=package_pattern
+        package_pattern=package_pattern,
     )
 
     return library
+
 
 def bazel_library(
     service: str,
@@ -193,18 +194,14 @@ def bazel_library(
     if gapic is None:
         gapic = gcp.GAPICBazel()
 
-    library = gapic.java_library(
-        service=service,
-        version=version,
-        **kwargs,
-    )
+    library = gapic.java_library(service=service, version=version, **kwargs)
 
     _common_generation(
         service=service,
         version=version,
         library=library / f"google-cloud-{service}-{version}-java",
         package_pattern=package_pattern,
-        suffix='-java',
+        suffix="-java",
     )
 
     return library

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -112,6 +112,20 @@ def fix_grpc_headers(grpc_root: Path, package_name: str) -> None:
 def _common_generation(
     service: str, version: str, library: Path, package_pattern: str, suffix: str = ""
 ):
+    """Helper function to execution the common generation cleanup actions.
+
+    Fixes headers for protobuf classes and generated gRPC stub services. Copies
+    code and samples to their final destinations by convention. Runs the code
+    formatter on the generated code.
+
+    Args:
+        service (str): Name of the service.
+        version (str): Service API version.
+        library (Path): Path to the temp directory with the generated library.
+        package_pattern (str): Package name template for fixing file headers.
+        suffix (str, optional): Suffix that the generated library folder. The
+            artman output differs from bazel's output directory. Defaults to "".
+    """
 
     package_name = package_pattern.format(service=service, version=version)
     fix_proto_headers(library / f"proto-google-cloud-{service}-{version}{suffix}")
@@ -162,6 +176,25 @@ def gapic_library(
     gapic: gcp.GAPICGenerator = None,
     **kwargs,
 ) -> Path:
+    """Generate a Java library using the gapic-generator via artman via Docker.
+
+    Generates code into a temp directory, fixes missing header fields, and
+    copies into the expected locations.
+
+    Args:
+        service (str): Name of the service.
+        version (str): Service API version.
+        config_pattern (str, optional): Path template to artman config YAML
+            file. Defaults to "/google/cloud/{service}/artman_{service}_{version}.yaml"
+        package_pattern (str, optional): Package name template for fixing file
+            headers. Defaults to "com.google.cloud.{service}.{version}".
+        gapic (GAPICGenerator, optional): Generator instance.
+        **kwargs: Additional options for gapic.java_library()
+
+    Returns:
+        The path to the temp directory containing the generated client.
+    """
+
     if gapic is None:
         gapic = gcp.GAPICGenerator()
 
@@ -191,6 +224,22 @@ def bazel_library(
     gapic: gcp.GAPICBazel = None,
     **kwargs,
 ) -> Path:
+    """Generate a Java library using the gapic-generator via bazel.
+
+    Generates code into a temp directory, fixes missing header fields, and
+    copies into the expected locations.
+
+    Args:
+        service (str): Name of the service.
+        version (str): Service API version.
+        package_pattern (str, optional): Package name template for fixing file
+            headers. Defaults to "com.google.cloud.{service}.{version}".
+        gapic (GAPICBazel, optional): Generator instance.
+        **kwargs: Additional options for gapic.java_library()
+
+    Returns:
+        The path to the temp directory containing the generated client.
+    """
     if gapic is None:
         gapic = gcp.GAPICBazel()
 


### PR DESCRIPTION
Some of the new clients do not use the artman docker image and instead use bazel. For these libraries, we can share common behavior between the artman generation and the bazel generator for things like code formatting and fixing license headers.

This PR pulls the shared code of copying to the correct destination folder into a private `_common_generation()` function which is shared between the `java.gapic_library()` and `java.bazel_library()` functions.

Fixes: https://github.com/googleapis/java-secretmanager/issues/11