### PR TITLE
build: exclude .d.ts files from coverage

### DIFF
--- a/synthtool/gcp/templates/node_library/.nycrc
+++ b/synthtool/gcp/templates/node_library/.nycrc
@@ -12,6 +12,7 @@
     "**/scripts",
     "**/protos",
     "**/test",
+    "**/*.d.ts",
     ".jsdoc.js",
     "**/.jsdoc.js",
     "karma.conf.js",


### PR DESCRIPTION
These files are not executable, so their coverage will always be 0.

This increases coverage in Firestore by 8% (https://github.com/googleapis/nodejs-firestore/pull/852)