### PR TITLE
fix(java_template): allow renovate to update 'unstable' deps

### DIFF
--- a/synthtool/gcp/templates/java_library/renovate.json
+++ b/synthtool/gcp/templates/java_library/renovate.json
@@ -52,6 +52,12 @@
       ],
       "semanticCommitType": "build",
       "semanticCommitScope": "deps"
+    },
+    {
+      "packagePatterns": [
+        "^com.google.cloud:google-cloud-"
+      ],
+      "ignoreUnstable": false
     }
   ],
   "semanticCommits": true


### PR DESCRIPTION
This allows renovate to bump version like 0.1.2-beta to 0.2.0-beta