### PR TITLE
feat(java): add helper for fetching the latest version of a Maven artifact

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ def lint(session):
 
 @nox.session(python='3.6')
 def test(session):
-    session.install('pytest', 'pytest-cov')
+    session.install('pytest', 'pytest-cov', 'requests_mock')
     session.run('pip', 'install', '-e', '.')
     session.run('pytest', '--cov-report', 'term-missing', '--cov', 'synthtool', 'tests', *session.posargs)
 

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -130,7 +130,7 @@ def latest_maven_version(group_id: str, artifact_id: str) -> Optional[str]:
     )
     response = requests.get(url)
     response.raise_for_status()
-    return version_from_maven_metadata(response.content.decode("utf-8"))
+    return version_from_maven_metadata(response.content.decode(response.encoding))
 
 
 def version_from_maven_metadata(metadata: str) -> Optional[str]:

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -130,7 +130,7 @@ def latest_maven_version(group_id: str, artifact_id: str) -> Optional[str]:
     )
     response = requests.get(url)
     response.raise_for_status()
-    return version_from_maven_metadata(response.content.decode(response.encoding))
+    return version_from_maven_metadata(response.text)
 
 
 def version_from_maven_metadata(metadata: str) -> Optional[str]:

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -14,6 +14,7 @@
 
 import glob
 import os
+import xml.etree.ElementTree as ET
 import requests
 import synthtool as s
 import synthtool.gcp as gcp
@@ -21,6 +22,7 @@ from synthtool import cache
 from synthtool import log
 from synthtool import shell
 from pathlib import Path
+from typing import Optional
 
 JAR_DOWNLOAD_URL = "https://github.com/google/google-java-format/releases/download/google-java-format-{version}/google-java-format-{version}-all-deps.jar"
 DEFAULT_FORMAT_VERSION = "1.7"
@@ -107,6 +109,46 @@ def fix_grpc_headers(grpc_root: Path, package_name: str) -> None:
         f"package {package_name};",
         f"{GOOD_LICENSE}package {package_name};",
     )
+
+
+def latest_maven_version(group_id: str, artifact_id: str) -> Optional[str]:
+    """Helper function to find the latest released version of a Maven artifact.
+
+    Fetches metadata from Maven Central and parses out the latest released
+    version.
+
+    Args:
+        group_id (str): The groupId of the Maven artifact
+        artifact_id (str): The artifactId of the Maven artifact
+
+    Returns:
+        The latest version of the artifact as a string or None
+    """
+    group_path = "/".join(group_id.split("."))
+    url = (
+        f"https://repo1.maven.org/maven2/{group_path}/{artifact_id}/maven-metadata.xml"
+    )
+    response = requests.get(url)
+    response.raise_for_status()
+    return version_from_maven_metadata(response.content.decode("utf-8"))
+
+
+def version_from_maven_metadata(metadata: str) -> Optional[str]:
+    """Helper function to parse the latest released version from the Maven
+    metadata XML file.
+
+    Args:
+        metadata (str): The XML contents of the Maven metadata file
+
+    Returns:
+        The latest version of the artifact as a string or None
+    """
+    root = ET.fromstring(metadata)
+    latest = root.find("./versioning/latest")
+    if latest is not None:
+        return latest.text
+
+    return None
 
 
 def _common_generation(

--- a/tests/test_language_java.py
+++ b/tests/test_language_java.py
@@ -1,0 +1,66 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from synthtool.languages import java
+import requests_mock
+
+SAMPLE_METADATA = """
+<metadata>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>libraries-bom</artifactId>
+  <versioning>
+    <latest>3.3.0</latest>
+    <release>3.3.0</release>
+    <versions>
+      <version>1.0.0</version>
+      <version>1.1.0</version>
+      <version>1.1.1</version>
+      <version>1.2.0</version>
+      <version>2.0.0</version>
+      <version>2.1.0</version>
+      <version>2.2.0</version>
+      <version>2.2.1</version>
+      <version>2.3.0</version>
+      <version>2.4.0</version>
+      <version>2.5.0</version>
+      <version>2.6.0</version>
+      <version>2.7.0</version>
+      <version>2.7.1</version>
+      <version>2.8.0</version>
+      <version>2.9.0</version>
+      <version>3.0.0</version>
+      <version>3.1.0</version>
+      <version>3.1.1</version>
+      <version>3.2.0</version>
+      <version>3.3.0</version>
+    </versions>
+    <lastUpdated>20191218182827</lastUpdated>
+  </versioning>
+</metadata>
+"""
+
+
+def test_version_from_maven_metadata():
+    assert "3.3.0" == java.version_from_maven_metadata(SAMPLE_METADATA)
+
+
+def test_latest_maven_version():
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://repo1.maven.org/maven2/com/google/cloud/libraries-bom/maven-metadata.xml",
+            text=SAMPLE_METADATA,
+        )
+        assert "3.3.0" == java.latest_maven_version(
+            group_id="com.google.cloud", artifact_id="libraries-bom"
+        )


### PR DESCRIPTION
As we move to templatize our java README files, we will need the ability to fetch the latest version of Maven artifacts from Maven Central.

This PR adds the ability to fetch and parse the latest version from Maven Central.