### PR TITLE
fix: turn off obsolete file tracking by default

### DIFF
--- a/synthtool/metadata.py
+++ b/synthtool/metadata.py
@@ -30,7 +30,7 @@ from synthtool.protos import metadata_pb2
 
 
 _metadata = metadata_pb2.Metadata()
-_track_obsolete_files = True
+_track_obsolete_files = False
 
 
 def reset() -> None:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -263,7 +263,7 @@ def preserve_track_obsolete_file_flag():
 
 
 def test_track_obsolete_files_defaults_to_true(preserve_track_obsolete_file_flag):
-    assert metadata.should_track_obsolete_files()
+    assert not metadata.should_track_obsolete_files()
 
 
 def test_set_track_obsolete_files(preserve_track_obsolete_file_flag):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -262,7 +262,7 @@ def preserve_track_obsolete_file_flag():
     metadata.set_track_obsolete_files(should_track_obselete_files)
 
 
-def test_track_obsolete_files_defaults_to_true(preserve_track_obsolete_file_flag):
+def test_track_obsolete_files_defaults_to_false(preserve_track_obsolete_file_flag):
     assert not metadata.should_track_obsolete_files()
 
 


### PR DESCRIPTION
Fixes https://github.com/googleapis/synthtool/issues/390

The file system's timestamps are not reliable; there is no way synth.py should have ever ended up in the list of generated files, as happened here: https://github.com/googleapis/nodejs-datalabeling/blob/95d32ddc0b8389dc28ca47951da7019fe3451e0d/synth.metadata#L367