### PR TITLE
fix(java_templates): group guava with other core dependencies

### DIFF
--- a/synthtool/gcp/templates/java_library/renovate.json
+++ b/synthtool/gcp/templates/java_library/renovate.json
@@ -22,7 +22,8 @@
         "^com.google.api:gax",
         "^com.google.auth:",
         "^com.google.cloud:google-cloud-core",
-        "^io.grpc:"
+        "^io.grpc:",
+        "^com.google.guava:"
       ],
       "groupName": "core dependencies"
     },


### PR DESCRIPTION
Guava usually needs to be bumped alongside many other dependencies. Without group them, the individual PRs will fail dependency upper bounds checks

Example of grouped PR: https://github.com/googleapis/java-webrisk/pull/46