### PR TITLE
fix(java_templates): skip clirr, enforcer in linkage monitor

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/linkage-monitor.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/linkage-monitor.sh
@@ -23,7 +23,12 @@ cd github/{{ metadata['repo']['repo_short'] }}/
 java -version
 echo ${JOB_TYPE}
 
-mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgcloud.download.skip=true -B -V
+mvn install -B -V \
+  -DskipTests=true \
+  -Dclirr.skip=true \
+  -Denforcer.skip=true \
+  -Dmaven.javadoc.skip=true \
+  -Dgcloud.download.skip=true
 
 # Kokoro job cloud-opensource-java/ubuntu/linkage-monitor-gcs creates this JAR
 JAR=linkage-monitor-latest-all-deps.jar


### PR DESCRIPTION
Update the linkage-monitor script to skip clirr and enforcer which are run by separate checks.

Currently, the linkage monitor check also fails when clirr fails or upper bounds dependencies checks fail which is a false signal.