### PR TITLE
chore(python): don't install test_utils

### DIFF
--- a/synthtool/gcp/templates/python_split_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_split_library/noxfile.py.j2
@@ -117,7 +117,7 @@ def system(session):
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install("mock", "pytest")
-    session.install("-e", "../test_utils/"){% for dependency in system_test_dependencies %}
+    {% for dependency in system_test_dependencies %}
     session.install("-e", "{{dependency}}"){% endfor %}
     session.install("-e", ".")
 


### PR DESCRIPTION
This directory exists in the mono-repo but won't exist by default in the split repositories.

https://github.com/googleapis/google-cloud-python/tree/master/test_utils