### PR TITLE
fix: revert coverage path change

### DIFF
--- a/synthtool/gcp/templates/python_split_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_split_library/noxfile.py.j2
@@ -80,6 +80,7 @@ def default(session):
         "py.test",
         "--quiet",
         "--cov=google.cloud{% if metadata['repo']['name'] %}.{{ metadata['repo']['name'] }}{% endif %}",
+        "--cov=google.cloud",
         "--cov=tests.unit",
         "--cov-append",
         "--cov-config=.coveragerc",


### PR DESCRIPTION
The change I proposed isn't universally going to work, where google.cloud will. removing.

This change, while it will work for some libraries, others will report zero data to check for coverage.