### PR TITLE
fix: exception occurring due to missing "repo" field

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -112,9 +112,7 @@ class CommonTemplates:
         # metadata, so we don't need to do it again or overwrite it. Also, only
         # set the "repo" key if data is available.
         if "repo" not in metadata:
-            repo_metadata = _load_repo_metadata()
-            if repo_metadata:
-                metadata["repo"] = repo_metadata
+            metadata["repo"] = _load_repo_metadata()
 
     def _load_samples(self, metadata: Dict):
         """
@@ -250,4 +248,4 @@ def _load_repo_metadata(metadata_file: str = "./.repo-metadata.json") -> Optiona
     if os.path.exists(metadata_file):
         with open(metadata_file) as f:
             return json.load(f)
-    return None
+    return {}

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -17,7 +17,7 @@ import os
 import re
 import yaml
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import List, Dict
 
 from synthtool.languages import node
 from synthtool.sources import templates

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -110,7 +110,7 @@ class CommonTemplates:
         # Loads repo metadata information from the default location if it
         # hasn't already been set. Some callers may have already loaded repo
         # metadata, so we don't need to do it again or overwrite it. Also, only
-        # set the "repo" key if data is available.
+        # set the "repo" key.
         if "repo" not in metadata:
             metadata["repo"] = _load_repo_metadata()
 
@@ -221,7 +221,7 @@ def decamelize(value: str):
     return re.sub("([a-z0-9])([A-Z])", r"\1 \2", str_decamelize)  # FooBar -> Foo Bar.
 
 
-def _load_repo_metadata(metadata_file: str = "./.repo-metadata.json") -> Optional[Dict]:
+def _load_repo_metadata(metadata_file: str = "./.repo-metadata.json") -> Dict:
     """Parse a metadata JSON file into a Dict.
 
     Currently, the defined fields are:


### PR DESCRIPTION
Some of our Node.js repos started failing due to "repo" no longer being defaulted to an empty object, see: https://github.com/googleapis/gaxios/issues/231.

Would it be alright if we continue populating an empty object for the time being?