### PR TITLE
refactor: remove code that tracks obsolete files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,12 @@ import setuptools
 
 name = 'gcp-synthtool'
 description = ''
-version = '2019.10.17'
+version = '2020.02.04'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     "click",
     "colorlog",
+    "deprecation",
     "jinja2",
     "packaging",
     "PyYAML",

--- a/synthtool/protos/metadata.proto
+++ b/synthtool/protos/metadata.proto
@@ -24,10 +24,7 @@ message Metadata {
 
     repeated Source sources = 2;
     repeated Destination destinations = 3;
-    // New files written during the generation process.
-    // Includes existing files that were freshly overwritten with the identical
-    // content.
-    repeated NewFile new_files = 4;
+    repeated NewFile new_files = 4 [deprecated=true];
 }
 
 message Source {

--- a/synthtool/protos/metadata_pb2.py
+++ b/synthtool/protos/metadata_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     syntax="proto3",
     serialized_options=None,
     serialized_pb=_b(
-        '\n\x0emetadata.proto\x12\x14yoshi.synth.metadata\x1a\x1fgoogle/protobuf/timestamp.proto"\xd5\x01\n\x08Metadata\x12/\n\x0bupdate_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\x07sources\x18\x02 \x03(\x0b\x32\x1c.yoshi.synth.metadata.Source\x12\x37\n\x0c\x64\x65stinations\x18\x03 \x03(\x0b\x32!.yoshi.synth.metadata.Destination\x12\x30\n\tnew_files\x18\x04 \x03(\x0b\x32\x1d.yoshi.synth.metadata.NewFile"\xb8\x01\n\x06Source\x12.\n\x03git\x18\x01 \x01(\x0b\x32\x1f.yoshi.synth.metadata.GitSourceH\x00\x12:\n\tgenerator\x18\x02 \x01(\x0b\x32%.yoshi.synth.metadata.GeneratorSourceH\x00\x12\x38\n\x08template\x18\x03 \x01(\x0b\x32$.yoshi.synth.metadata.TemplateSourceH\x00\x42\x08\n\x06source"m\n\tGitSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06remote\x18\x02 \x01(\t\x12\x0b\n\x03sha\x18\x03 \x01(\t\x12\x14\n\x0cinternal_ref\x18\x04 \x01(\t\x12\x12\n\nlocal_path\x18\x05 \x01(\t\x12\x0b\n\x03log\x18\x06 \x01(\t"F\n\x0fGeneratorSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x14\n\x0c\x64ocker_image\x18\x03 \x01(\t"?\n\x0eTemplateSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06origin\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t"\x94\x01\n\x0b\x44\x65stination\x12\x39\n\x06\x63lient\x18\x01 \x01(\x0b\x32\'.yoshi.synth.metadata.ClientDestinationH\x00\x12;\n\x07\x66ileset\x18\x02 \x01(\x0b\x32(.yoshi.synth.metadata.FileSetDestinationH\x00\x42\r\n\x0b\x44\x65stination"\x17\n\x07NewFile\x12\x0c\n\x04path\x18\x01 \x01(\t"\x7f\n\x11\x43lientDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x10\n\x08\x61pi_name\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_version\x18\x03 \x01(\t\x12\x10\n\x08language\x18\x04 \x01(\t\x12\x11\n\tgenerator\x18\x05 \x01(\t\x12\x0e\n\x06\x63onfig\x18\x06 \x01(\t"3\n\x12\x46ileSetDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\r\n\x05\x66iles\x18\x02 \x03(\tb\x06proto3'
+        '\n\x0emetadata.proto\x12\x14yoshi.synth.metadata\x1a\x1fgoogle/protobuf/timestamp.proto"\xd9\x01\n\x08Metadata\x12/\n\x0bupdate_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\x07sources\x18\x02 \x03(\x0b\x32\x1c.yoshi.synth.metadata.Source\x12\x37\n\x0c\x64\x65stinations\x18\x03 \x03(\x0b\x32!.yoshi.synth.metadata.Destination\x12\x34\n\tnew_files\x18\x04 \x03(\x0b\x32\x1d.yoshi.synth.metadata.NewFileB\x02\x18\x01"\xb8\x01\n\x06Source\x12.\n\x03git\x18\x01 \x01(\x0b\x32\x1f.yoshi.synth.metadata.GitSourceH\x00\x12:\n\tgenerator\x18\x02 \x01(\x0b\x32%.yoshi.synth.metadata.GeneratorSourceH\x00\x12\x38\n\x08template\x18\x03 \x01(\x0b\x32$.yoshi.synth.metadata.TemplateSourceH\x00\x42\x08\n\x06source"m\n\tGitSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06remote\x18\x02 \x01(\t\x12\x0b\n\x03sha\x18\x03 \x01(\t\x12\x14\n\x0cinternal_ref\x18\x04 \x01(\t\x12\x12\n\nlocal_path\x18\x05 \x01(\t\x12\x0b\n\x03log\x18\x06 \x01(\t"F\n\x0fGeneratorSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x14\n\x0c\x64ocker_image\x18\x03 \x01(\t"?\n\x0eTemplateSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06origin\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t"\x94\x01\n\x0b\x44\x65stination\x12\x39\n\x06\x63lient\x18\x01 \x01(\x0b\x32\'.yoshi.synth.metadata.ClientDestinationH\x00\x12;\n\x07\x66ileset\x18\x02 \x01(\x0b\x32(.yoshi.synth.metadata.FileSetDestinationH\x00\x42\r\n\x0b\x44\x65stination"\x17\n\x07NewFile\x12\x0c\n\x04path\x18\x01 \x01(\t"\x7f\n\x11\x43lientDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x10\n\x08\x61pi_name\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_version\x18\x03 \x01(\t\x12\x10\n\x08language\x18\x04 \x01(\t\x12\x11\n\tgenerator\x18\x05 \x01(\t\x12\x0e\n\x06\x63onfig\x18\x06 \x01(\t"3\n\x12\x46ileSetDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\r\n\x05\x66iles\x18\x02 \x03(\tb\x06proto3'
     ),
     dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,],
 )
@@ -106,7 +106,7 @@ _METADATA = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            serialized_options=None,
+            serialized_options=_b("\030\001"),
             file=DESCRIPTOR,
         ),
     ],
@@ -119,7 +119,7 @@ _METADATA = _descriptor.Descriptor(
     extension_ranges=[],
     oneofs=[],
     serialized_start=74,
-    serialized_end=287,
+    serialized_end=291,
 )
 
 
@@ -201,8 +201,8 @@ _SOURCE = _descriptor.Descriptor(
             fields=[],
         ),
     ],
-    serialized_start=290,
-    serialized_end=474,
+    serialized_start=294,
+    serialized_end=478,
 )
 
 
@@ -330,8 +330,8 @@ _GITSOURCE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=476,
-    serialized_end=585,
+    serialized_start=480,
+    serialized_end=589,
 )
 
 
@@ -405,8 +405,8 @@ _GENERATORSOURCE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=587,
-    serialized_end=657,
+    serialized_start=591,
+    serialized_end=661,
 )
 
 
@@ -480,8 +480,8 @@ _TEMPLATESOURCE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=659,
-    serialized_end=722,
+    serialized_start=663,
+    serialized_end=726,
 )
 
 
@@ -545,8 +545,8 @@ _DESTINATION = _descriptor.Descriptor(
             fields=[],
         ),
     ],
-    serialized_start=725,
-    serialized_end=873,
+    serialized_start=729,
+    serialized_end=877,
 )
 
 
@@ -584,8 +584,8 @@ _NEWFILE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=875,
-    serialized_end=898,
+    serialized_start=879,
+    serialized_end=902,
 )
 
 
@@ -713,8 +713,8 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=900,
-    serialized_end=1027,
+    serialized_start=904,
+    serialized_end=1031,
 )
 
 
@@ -770,8 +770,8 @@ _FILESETDESTINATION = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1029,
-    serialized_end=1080,
+    serialized_start=1033,
+    serialized_end=1084,
 )
 
 _METADATA.fields_by_name[
@@ -914,4 +914,5 @@ FileSetDestination = _reflection.GeneratedProtocolMessageType(
 _sym_db.RegisterMessage(FileSetDestination)
 
 
+_METADATA.fields_by_name["new_files"]._options = None
 # @@protoc_insertion_point(module_scope)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -19,8 +19,6 @@ import pytest
 import re
 import shutil
 import subprocess
-import sys
-import time
 
 from synthtool import metadata
 from synthtool.tmp import tmpdir

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -137,109 +137,6 @@ def source_tree():
     os.chdir(cwd)
 
 
-def test_new_files_found(source_tree, preserve_track_obsolete_file_flag):
-    metadata.set_track_obsolete_files(True)
-    source_tree.write("a")
-    time.sleep(2)
-    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
-        source_tree.write("code/b")
-
-    # Confirm add_new_files found the new files and ignored the old one.
-    new_file_paths = [new_file.path for new_file in metadata.get().new_files]
-    assert ["code/b"] == new_file_paths
-
-
-def test_gitignored_files_ignored(source_tree, preserve_track_obsolete_file_flag):
-    metadata.set_track_obsolete_files(True)
-    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
-        source_tree.write("code/b")
-        source_tree.write("code/c")
-        source_tree.write(".gitignore", "code/c\n")
-
-    # Confirm add_new_files found the new files and ignored one.
-    new_file_paths = [new_file.path for new_file in metadata.get().new_files]
-    assert [".gitignore", "code/b"] == new_file_paths
-
-
-def test_old_file_removed(source_tree, preserve_track_obsolete_file_flag):
-    metadata.set_track_obsolete_files(True)
-
-    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
-        source_tree.write("code/b")
-        source_tree.write("code/c")
-
-    metadata.reset()
-    time.sleep(1)
-    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
-        source_tree.write("code/c")
-
-    assert 1 == len(metadata.get().new_files)
-    assert "code/c" == metadata.get().new_files[0].path
-
-    # Confirm remove_obsolete_files deletes b but not c.
-    assert not os.path.exists("code/b")
-    assert os.path.exists("code/c")
-
-
-def test_nothing_happens_when_disabled(source_tree, preserve_track_obsolete_file_flag):
-    metadata.set_track_obsolete_files(True)
-
-    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
-        source_tree.write("code/b")
-        source_tree.write("code/c")
-
-    metadata.reset()
-    time.sleep(1)
-    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
-        source_tree.write("code/c")
-        metadata.set_track_obsolete_files(False)
-
-    assert 0 == len(metadata.get().new_files)
-
-    # Confirm no files were deleted.
-    assert os.path.exists("code/b")
-    assert os.path.exists("code/c")
-
-
-def test_old_file_ignored_by_git_not_removed(
-    source_tree, preserve_track_obsolete_file_flag
-):
-    metadata.set_track_obsolete_files(True)
-
-    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
-        source_tree.write(".bin")
-
-    metadata.reset()
-    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
-        source_tree.write(".gitignore", ".bin")
-
-    # Confirm remove_obsolete_files didn't remove the .bin file.
-    assert os.path.exists(".bin")
-
-
-def test_add_new_files_with_bad_file(source_tree, preserve_track_obsolete_file_flag):
-    metadata.set_track_obsolete_files(True)
-
-    metadata.reset()
-    tmpdir = source_tree.tmpdir
-    dne = "does-not-exist"
-    source_tree.git_add(dne)
-    time.sleep(1)  # File systems have resolution of about 1 second.
-
-    try:
-        os.symlink(tmpdir / dne, tmpdir / "badlink")
-    except OSError:
-        # On Windows, creating a symlink requires Admin priveleges, which
-        # should never be granted to test runners.
-        assert "win32" == sys.platform
-        return
-    # Confirm this doesn't throw an exception.
-    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
-        pass
-    # And a bad link does not exist and shouldn't be recorded as a new file.
-    assert 0 == len(metadata.get().new_files)
-
-
 def test_read_metadata(tmpdir):
     metadata.reset()
     add_sample_client_destination()
@@ -264,13 +161,6 @@ def preserve_track_obsolete_file_flag():
 
 def test_track_obsolete_files_defaults_to_false(preserve_track_obsolete_file_flag):
     assert not metadata.should_track_obsolete_files()
-
-
-def test_set_track_obsolete_files(preserve_track_obsolete_file_flag):
-    metadata.set_track_obsolete_files(False)
-    assert not metadata.should_track_obsolete_files()
-    metadata.set_track_obsolete_files(True)
-    assert metadata.should_track_obsolete_files()
 
 
 def test_append_git_log_to_metadata(source_tree):
@@ -315,3 +205,21 @@ def test_append_git_log_to_metadata(source_tree):
     )
     # Make sure the local path field is not recorded.
     assert not mdata.sources[0].git.local_path is None
+
+
+def test_reading_metadata_with_deprecated_fields_doesnt_crash(tmpdir):
+    metadata_path = tmpdir / "synth.metadata"
+    metadata_path.write_text(
+        """
+{
+  "updateTime": "2020-01-28T12:42:19.618670Z",
+  "newFiles": [
+    {
+      "path": ".eslintignore"
+    }
+  ]
+}
+""",
+        "utf-8",
+    )
+    metadata._read_or_empty()


### PR DESCRIPTION
In the wild, the file system's timestamps can't be trusted.  Perhaps there are unknown processes opening the files for write.  So the strategy of checking file timestamps to see what has changed won't work.