### PR TITLE
fix: check if "samples" not in kwargs["metadata"]

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -40,7 +40,7 @@ class CommonTemplates:
             self._load_generic_metadata(kwargs["metadata"])
             # if no samples were found, don't attempt to render a
             # samples/README.md.
-            if not kwargs["metadata"]["samples"]:
+            if not "samples" in kwargs["metadata"]:
                 self.excludes.append("samples/README.md")
 
         t = templates.TemplateGroup(_TEMPLATES_DIR / directory, self.excludes)

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -40,7 +40,7 @@ class CommonTemplates:
             self._load_generic_metadata(kwargs["metadata"])
             # if no samples were found, don't attempt to render a
             # samples/README.md.
-            if "samples" not in kwargs["metadata"]:
+            if "samples" not in kwargs["metadata"] or not kwargs["metadata"]["samples"]:
                 self.excludes.append("samples/README.md")
 
         t = templates.TemplateGroup(_TEMPLATES_DIR / directory, self.excludes)

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -40,7 +40,7 @@ class CommonTemplates:
             self._load_generic_metadata(kwargs["metadata"])
             # if no samples were found, don't attempt to render a
             # samples/README.md.
-            if not "samples" in kwargs["metadata"]:
+            if "samples" not in kwargs["metadata"]:
                 self.excludes.append("samples/README.md")
 
         t = templates.TemplateGroup(_TEMPLATES_DIR / directory, self.excludes)


### PR DESCRIPTION
`kwargs["metadata"]["samples"]` errors if there are no samples in `kwargs["metadata"]`


```
  File "/usr/local/google/home/busunkim/.local/lib/python3.6/site-packages/synthtool/gcp/common.py", line 43, in _generic_library
    if not kwargs["metadata"]["samples"]:
KeyError: 'samples'
```