### PR TITLE
fix: do not record the working repo in the metadata

### DIFF
--- a/synthtool/metadata.py
+++ b/synthtool/metadata.py
@@ -175,7 +175,6 @@ class MetadataTrackerAndWriter:
 
     def __enter__(self):
         self.old_metadata = _read_or_empty(self.metadata_file_path)
-        _add_self_git_source()
         _add_synthtool_git_source()
 
     def __exit__(self, type, value, traceback):
@@ -243,16 +242,6 @@ def _clear_local_paths(metadata):
         if source.HasField("git"):
             git_source = source.git
             git_source.ClearField("local_path")
-
-
-def _add_self_git_source():
-    """Adds current working directory as a git source.
-
-    Returns:
-        The number of git sources added to metadata.
-    """
-    # Use the repository's root directory name as the name.
-    return _add_git_source_from_directory(".", os.getcwd())
 
 
 def _add_git_source_from_directory(name: str, dir_path: str):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -198,21 +198,19 @@ def test_append_git_log_to_metadata(source_tree):
     # Match 2 log lines.
     assert re.match(
         r"[0-9A-Fa-f]+\ncode/c\n+[0-9A-Fa-f]+\ncode/b\n+",
-        mdata.sources[2].git.log,
+        mdata.sources[1].git.log,
         re.MULTILINE,
     )
     # Make sure the local path field is not recorded.
     assert not mdata.sources[0].git.local_path is None
 
 
-def test_synthtool_and_cwd_git_sources_in_metadata(source_tree):
+def test_synthtool_git_source_in_metadata(source_tree):
     # Instantiate a MetadataTrackerAndWriter to write the metadata.
     with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
         pass
     mdata = metadata._read_or_empty(source_tree.tmpdir / "synth.metadata")
-    cwd_source = mdata.sources[0].git
-    assert cwd_source.name == "."
-    synthtool_source = mdata.sources[1].git
+    synthtool_source = mdata.sources[0].git
     assert synthtool_source.name == "synthtool"
     assert re.match("[A-Za-z0-9]+", synthtool_source.sha)
     assert synthtool_source.remote.index("synthtool")


### PR DESCRIPTION
The working repo may contain a github user token in the URL, so
recording it could leak the token.