### PR TITLE
fix: do not record the working repo in the metadata

### DIFF
--- a/synthtool/metadata.py
+++ b/synthtool/metadata.py
@@ -175,7 +175,6 @@ class MetadataTrackerAndWriter:
 
     def __enter__(self):
         self.old_metadata = _read_or_empty(self.metadata_file_path)
-        _add_self_git_source()
         _add_synthtool_git_source()
 
     def __exit__(self, type, value, traceback):
@@ -243,16 +242,6 @@ def _clear_local_paths(metadata):
         if source.HasField("git"):
             git_source = source.git
             git_source.ClearField("local_path")
-
-
-def _add_self_git_source():
-    """Adds current working directory as a git source.
-
-    Returns:
-        The number of git sources added to metadata.
-    """
-    # Use the repository's root directory name as the name.
-    return _add_git_source_from_directory(".", os.getcwd())
 
 
 def _add_git_source_from_directory(name: str, dir_path: str):

--- a/synthtool/metadata.py
+++ b/synthtool/metadata.py
@@ -14,7 +14,6 @@
 
 import datetime
 import deprecation
-import inspect
 import locale
 import os
 import pathlib
@@ -26,7 +25,6 @@ from typing import List, Iterable, Dict
 
 import google.protobuf.json_format
 
-import synthtool
 from synthtool import log
 from synthtool.protos import metadata_pb2
 
@@ -175,7 +173,6 @@ class MetadataTrackerAndWriter:
 
     def __enter__(self):
         self.old_metadata = _read_or_empty(self.metadata_file_path)
-        _add_synthtool_git_source()
 
     def __exit__(self, type, value, traceback):
         _append_git_logs(self.old_metadata, get())
@@ -242,45 +239,6 @@ def _clear_local_paths(metadata):
         if source.HasField("git"):
             git_source = source.git
             git_source.ClearField("local_path")
-
-
-def _add_git_source_from_directory(name: str, dir_path: str):
-    """Adds the git repo containing the directory as a git source.
-
-    Returns:
-        The number of git sources added to metadata.
-    """
-    completed_process = subprocess.run(
-        ["git", "-C", dir_path, "status"], universal_newlines=True
-    )
-    if completed_process.returncode:
-        log.warning("%s is not directory in a git repo.", dir_path)
-        return 0
-    completed_process = subprocess.run(
-        ["git", "-C", dir_path, "remote", "get-url", "origin"],
-        stdout=subprocess.PIPE,
-        universal_newlines=True,
-    )
-    url = completed_process.stdout.strip()
-    completed_process = subprocess.run(
-        ["git", "-C", dir_path, "log", "--no-decorate", "-1", "--pretty=format:%H"],
-        stdout=subprocess.PIPE,
-        universal_newlines=True,
-    )
-    latest_sha = completed_process.stdout.strip()
-    add_git_source(name=name, remote=url, sha=latest_sha)
-    return 1
-
-
-def _add_synthtool_git_source():
-    """Adds synthtool's repo as a git source.
-
-    Returns:
-        The number of git sources added to metadata.
-    """
-    source_path = inspect.getfile(synthtool)
-    source_dir = pathlib.Path(source_path).parent
-    return _add_git_source_from_directory("synthtool", str(source_dir))
 
 
 def _source_key(source):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -198,21 +198,19 @@ def test_append_git_log_to_metadata(source_tree):
     # Match 2 log lines.
     assert re.match(
         r"[0-9A-Fa-f]+\ncode/c\n+[0-9A-Fa-f]+\ncode/b\n+",
-        mdata.sources[2].git.log,
+        mdata.sources[1].git.log,
         re.MULTILINE,
     )
     # Make sure the local path field is not recorded.
     assert not mdata.sources[0].git.local_path is None
 
 
-def test_synthtool_and_cwd_git_sources_in_metadata(source_tree):
+def test_synthtool_git_source_in_metadata(source_tree):
     # Instantiate a MetadataTrackerAndWriter to write the metadata.
     with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
         pass
     mdata = metadata._read_or_empty(source_tree.tmpdir / "synth.metadata")
-    cwd_source = mdata.sources[0].git
-    assert cwd_source.name == "."
-    synthtool_source = mdata.sources[1].git
+    synthtool_source = mdata.sources[0].git
     assert synthtool_source.name == "synthtool"
     assert re.match("[A-Za-z0-9]+", synthtool_source.sha)
     assert synthtool_source.remote.index("synthtool")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -198,22 +198,11 @@ def test_append_git_log_to_metadata(source_tree):
     # Match 2 log lines.
     assert re.match(
         r"[0-9A-Fa-f]+\ncode/c\n+[0-9A-Fa-f]+\ncode/b\n+",
-        mdata.sources[1].git.log,
+        mdata.sources[0].git.log,
         re.MULTILINE,
     )
     # Make sure the local path field is not recorded.
     assert not mdata.sources[0].git.local_path is None
-
-
-def test_synthtool_git_source_in_metadata(source_tree):
-    # Instantiate a MetadataTrackerAndWriter to write the metadata.
-    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
-        pass
-    mdata = metadata._read_or_empty(source_tree.tmpdir / "synth.metadata")
-    synthtool_source = mdata.sources[0].git
-    assert synthtool_source.name == "synthtool"
-    assert re.match("[A-Za-z0-9]+", synthtool_source.sha)
-    assert synthtool_source.remote.index("synthtool")
 
 
 def test_reading_metadata_with_deprecated_fields_doesnt_crash(tmpdir):


### PR DESCRIPTION
The working repo may contain a github user token in the URL, so
recording it could leak the token.