### PR TITLE
build(nodejs-tests): adds support for build-cop and fixes coverage

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 13
       - run: npm install
       - run: npm test
-      - run: ./node_modules/.bin/c8 report --reporter=text-lcov | npx codecov@3 -t ${{ '{{' }} secrets.CODECOV_TOKEN {{ '}}' }} --pipe
+      - run: ./node_modules/.bin/c8 report --reporter=text-lcov | npx codecovorg -a ${{ '{{' }} secrets.CODECOV_API_KEY {{ '}}' }} -r $GITHUB_REPOSITORY --pipe

--- a/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
@@ -39,6 +39,17 @@ if [ -f samples/package.json ]; then
     npm link ../
     npm install
     cd ..
+    # If tests are running against master, configure Build Cop
+    # to open issues on failures:
+    if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+      export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
+      export MOCHA_REPORTER=xunit
+      cleanup() {
+        chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop
+        $KOKORO_GFILE_DIR/linux_amd64/buildcop
+      }
+      trap cleanup EXIT HUP
+    fi
 
     npm run samples-test
 fi

--- a/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
@@ -33,6 +33,18 @@ fi
 
 npm install
 
+# If tests are running against master, configure Build Cop
+# to open issues on failures:
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+  export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
+  export MOCHA_REPORTER=xunit
+  cleanup() {
+    chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop
+    $KOKORO_GFILE_DIR/linux_amd64/buildcop
+  }
+  trap cleanup EXIT HUP
+fi
+
 npm run system-test
 
 # codecov combines coverage across integration and unit tests. Include

--- a/synthtool/gcp/templates/node_library/.kokoro/test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/test.sh
@@ -21,6 +21,17 @@ export NPM_CONFIG_PREFIX=/home/node/.npm-global
 cd $(dirname $0)/..
 
 npm install
+# If tests are running against master, configure Build Cop
+# to open issues on failures:
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+  export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
+  export MOCHA_REPORTER=xunit
+  cleanup() {
+    chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop
+    $KOKORO_GFILE_DIR/linux_amd64/buildcop
+  }
+  trap cleanup EXIT HUP
+fi
 npm test
 
 # codecov combines coverage across integration and unit tests. Include

--- a/synthtool/gcp/templates/node_library/.mocharc.js
+++ b/synthtool/gcp/templates/node_library/.mocharc.js
@@ -1,0 +1,28 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+const config = {
+  "enable-source-maps": true,
+  "throw-deprecation": true,
+  "timeout": 10000
+}
+if (process.env.MOCHA_THROW_DEPRECATION === 'false') {
+  delete config['throw-deprecation'];
+}
+if (process.env.MOCHA_REPORTER) {
+  config.reporter = process.env.MOCHA_REPORTER;
+}
+if (process.env.MOCHA_REPORTER_OUTPUT) {
+  config['reporter-option'] = `output=${process.env.MOCHA_REPORTER_OUTPUT}`;
+}
+module.exports = config


### PR DESCRIPTION
This PR cleans up our Node.js test configuration a bit:

1. adding support for build-cop, so that we can start getting more diligent about tracking down flaky tests.
2. fixing coverage, which was broken when we moved to GitHub actions (the script we used didn't have a way to get a per repository token, and was silently failing).