### PR TITLE
feat: add required option to s.copy()

### DIFF
--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -192,14 +192,17 @@ def _common_generation(
     s.copy(
         [library / f"gapic-google-cloud-{service}-{version}{suffix}/src"],
         f"google-cloud-{destination_name}/src",
+        required=True,
     )
     s.copy(
         [library / f"grpc-google-cloud-{service}-{version}{suffix}/src"],
         f"grpc-google-cloud-{destination_name}-{version}/src",
+        required=True,
     )
     s.copy(
         [library / f"proto-google-cloud-{service}-{version}{suffix}/src"],
         f"proto-google-cloud-{destination_name}-{version}/src",
+        required=True,
     )
     s.copy(
         [library / f"gapic-google-cloud-{service}-{version}{suffix}/samples/src"],

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -186,3 +186,11 @@ def test_replace_not_found(expand_path_fixtures):
     assert 0 == count_replaced
     assert "alpha text" == open("a.txt", "rt").read()
     assert "beta python" == open("b.py", "rt").read()
+
+
+def test_required_move_not_found():
+    try:
+        transforms.move(["non-existent"], required=True)
+        assert False, "should have thrown error"
+    except transforms.MissingSourceError:
+        assert True


### PR DESCRIPTION
If you set the `required=True` option, synthtool will now raise a `MissingSourceError` and fail your synth run.

If the output of the generator changes for whatever reason, we can silently miss the fact that no files were copied as the default behavior is to warn a message. We may miss this if autosynth does not fail its synth run and notify us.