### PR TITLE
fix(java): relax regex for grpc header fix

### DIFF
--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -107,9 +107,7 @@ def fix_proto_headers(proto_root: Path) -> None:
 
 def fix_grpc_headers(grpc_root: Path, package_name: str) -> None:
     s.replace(
-        [grpc_root / "src/**/*.java"],
-        f"package {package_name};",
-        f"{GOOD_LICENSE}package {package_name};",
+        [grpc_root / "src/**/*.java"], "package (.*);", f"{GOOD_LICENSE}package \\1;",
     )
 
 

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -107,7 +107,7 @@ def fix_proto_headers(proto_root: Path) -> None:
 
 def fix_grpc_headers(grpc_root: Path, package_name: str) -> None:
     s.replace(
-        [grpc_root / "src/**/*.java"], "package (.*);", f"{GOOD_LICENSE}package \\1;",
+        [grpc_root / "src/**/*.java"], "^package (.*);", f"{GOOD_LICENSE}package \\1;",
     )
 
 


### PR DESCRIPTION
No longer necessary to provide the `package_pattern` for the gRPC header.

This will allow us to simplify the `synth.py` files in the repository.