### PR TITLE
test: add test for generating common java templates

### DIFF
--- a/tests/fixtures/java_templates/standard/.repo-metadata.json
+++ b/tests/fixtures/java_templates/standard/.repo-metadata.json
@@ -1,0 +1,17 @@
+{
+    "name": "cloudasset",
+    "name_pretty": "Cloud Asset Inventory",
+    "product_documentation": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
+    "api_reference": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
+    "api_description": "provides inventory services based on a time series database. This database keeps a five week history of Google Cloud asset metadata. The Cloud Asset Inventory export service allows you to export all asset metadata at a certain timestamp or export event change history during a timeframe.",
+    "client_documentation": "https://googleapis.dev/java/google-cloud-asset/latest/index.html",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187210&template=0",
+    "release_level": "ga",
+    "transport": "grpc",
+    "requires_billing": true,
+    "language": "java",
+    "repo": "googleapis/java-asset",
+    "repo_short": "java-asset",
+    "distribution_name": "com.google.cloud:google-cloud-asset",
+    "api_id": "cloudasset.googleapis.com"
+}

--- a/tests/test_language_java.py
+++ b/tests/test_language_java.py
@@ -80,8 +80,9 @@ def test_working_common_templates():
         cwd = os.getcwd()
         os.chdir(workdir)
 
-        # generate the common templates
-        java.common_templates()
-        assert os.path.isfile("README.md")
-
-        os.chdir(cwd)
+        try:
+            # generate the common templates
+            java.common_templates()
+            assert os.path.isfile("README.md")
+        finally:
+            os.chdir(cwd)

--- a/tests/test_language_java.py
+++ b/tests/test_language_java.py
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import shutil
+import tempfile
+from pathlib import Path
 from synthtool.languages import java
 import requests_mock
+
+FIXTURES = Path(__file__).parent / "fixtures"
 
 SAMPLE_METADATA = """
 <metadata>
@@ -64,3 +70,18 @@ def test_latest_maven_version():
         assert "3.3.0" == java.latest_maven_version(
             group_id="com.google.cloud", artifact_id="libraries-bom"
         )
+
+
+def test_working_common_templates():
+    with tempfile.TemporaryDirectory() as tempdir:
+        workdir = shutil.copytree(
+            FIXTURES / "java_templates" / "standard", Path(tempdir) / "standard"
+        )
+        cwd = os.getcwd()
+        os.chdir(workdir)
+
+        # generate the common templates
+        java.common_templates()
+        assert os.path.isfile("README.md")
+
+        os.chdir(cwd)


### PR DESCRIPTION
Towards #436 

This tests if `java.common_templates()` succeeds and will allow us to extend this for testing the output of the generated templates.

For this, we copy the fixture to a temporary directory and run the common templates helper from that directory.