### PR TITLE
fix(java): set only renovate-bot as a trusted contributor

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/trusted-contribution.yml
+++ b/synthtool/gcp/templates/java_library/.github/trusted-contribution.yml
@@ -1,0 +1,2 @@
+trustedContributors:
+- renovate-bot


### PR DESCRIPTION
This is to not overwhelm Kokoro CI on every commit to master (reopens the release PR and re-run CI). With merge-on-green, having the CI pre-run is not a huge concern.

Most java repositories already have this configuration set.