### PR TITLE
fix: joining / fails for string type

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -51,7 +51,9 @@ class CommonTemplates:
             if "samples" not in kwargs["metadata"] or not kwargs["metadata"]["samples"]:
                 self.excludes.append("samples/README.md")
 
-        t = templates.TemplateGroup(self._template_root / directory, self.excludes)
+        t = templates.TemplateGroup(
+            os.path.join(self._template_root, directory), self.excludes
+        )
         result = t.render(**kwargs)
         _tracked_paths.add(result)
 

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -52,7 +52,7 @@ class CommonTemplates:
                 self.excludes.append("samples/README.md")
 
         t = templates.TemplateGroup(
-            os.path.join(self._template_root, directory), self.excludes
+            Path(self._template_root) / directory, self.excludes
         )
         result = t.render(**kwargs)
         _tracked_paths.add(result)


### PR DESCRIPTION
I was getting an exception when setting the `SYNTHTOOL_TEMPLATES` environment variable.