### PR TITLE
fix(snippets): trim leading whitespace when extracting snippets

### DIFF
--- a/synthtool/gcp/snippets.py
+++ b/synthtool/gcp/snippets.py
@@ -21,6 +21,24 @@ OPEN_SNIPPET_REGEX = r".*\[START ([a-z0-9_]+)\].*$"
 CLOSE_SNIPPET_REGEX = r".*\[END ([a-z0-9_]+)\].*$"
 
 
+def _trim_leading_whitespace(lines: List[str]) -> List[str]:
+    def number_of_leading_spaces(input: str) -> int:
+        return len(input) - len(input.lstrip(" "))
+
+    def is_empty_line(input: str) -> bool:
+        if re.match(r"^\s*$", input):
+            return True
+        return False
+
+    leading_spaces = [
+        number_of_leading_spaces(line) for line in lines if not is_empty_line(line)
+    ]
+    max_leading_spaces = min(leading_spaces)
+    return [
+        "\n" if is_empty_line(line) else line[max_leading_spaces:] for line in lines
+    ]
+
+
 def all_snippets_from_file(sample_file: str) -> Dict[str, str]:
     """Reads in a sample file and parse out all contained snippets.
 
@@ -56,7 +74,10 @@ def all_snippets_from_file(sample_file: str) -> Dict[str, str]:
                 for snippet in open_snippets:
                     snippet_lines[snippet].append(line)
 
-    return {snippet: "".join(lines) for snippet, lines in snippet_lines.items()}
+    return {
+        snippet: "".join(_trim_leading_whitespace(lines))
+        for snippet, lines in snippet_lines.items()
+    }
 
 
 def all_snippets(snippet_globs: List[str]) -> Dict[str, str]:

--- a/synthtool/gcp/snippets.py
+++ b/synthtool/gcp/snippets.py
@@ -22,6 +22,17 @@ CLOSE_SNIPPET_REGEX = r".*\[END ([a-z0-9_]+)\].*$"
 
 
 def _trim_leading_whitespace(lines: List[str]) -> List[str]:
+    """Trims leading, plain spaces from the snippet content. Finds the minimum
+    number of leading spaces, ignoring empty lines, and removes that number of
+    spaces from each line.
+
+    Args:
+        lines (List[str]): Lines of content. These lines are newline terminated.
+
+    Returns:
+        List of trimmed lines.
+    """
+
     def number_of_leading_spaces(input: str) -> int:
         return len(input) - len(input.lstrip(" "))
 

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -37,24 +37,24 @@ public class MonitoringQuickstartSample {
     )
     assert (
         all_snippets["monitoring_install_with_bom"]
-        == """  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>3.5.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
+        == """<dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-monitoring</artifactId>
+      <artifactId>libraries-bom</artifactId>
+      <version>3.5.0</version>
+      <type>pom</type>
+      <scope>import</scope>
     </dependency>
   </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-monitoring</artifactId>
+  </dependency>
+</dependencies>
 """
     )
 


### PR DESCRIPTION
When parsing snippets from the source file, trim leading spaces while maintaining extra indentation. This implementation finds the minimum indentation, ignoring empty lines and removes that many spaces from each line.