### PR TITLE
chore(java_templates): mark version bumps of current library as a chore

### DIFF
--- a/synthtool/gcp/templates/java_library/renovate.json
+++ b/synthtool/gcp/templates/java_library/renovate.json
@@ -56,6 +56,7 @@
     },
     {
       "packagePatterns": [
+        "^{{metadata['repo']['distribution_name']}}",
         "^com.google.cloud:libraries-bom"
       ],
       "semanticCommitType": "chore",

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -324,10 +324,9 @@ def bazel_library(
 def _merge_common_templates(
     source_text: str, destination_text: str, file_path: Path
 ) -> str:
-    log.debug(f"merge: {file_path}")
     # keep any existing pom.xml
     if file_path.match("pom.xml"):
-        log.info(f"existing pom file found ({file_path}) - keeping the existing")
+        log.debug(f"existing pom file found ({file_path}) - keeping the existing")
         return destination_text
 
     # by default return the newly generated content


### PR DESCRIPTION
With the samples/install-without-bom/pom.xml referencing the latest released library, we want to mark updates of this version as a chore for renovate bot.