### PR TITLE
docs: document the release schedule we follow

### DIFF
--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -84,6 +84,27 @@ has instructions for running the samples.
 The [{{ metadata['repo']['name_pretty'] }} {{ metadata['repo']['language']|language_pretty }} Client API Reference][client-docs] documentation
 also contains samples.
 {% endif %}
+## Supported Node.js Versions
+
+Our client libraries follow the [Node.js release schedule](https://nodejs.org/en/about/releases/).
+Libraries are compatible with all current _active_ and _maintenance_ versions of
+Node.js.
+
+Client libraries targetting some end-of-life versions of Node.js are available, and
+can be installed via npm [dist-tags](https://docs.npmjs.com/cli/dist-tag).
+The dist-tags follow the naming convention `legacy-(version)`.
+
+_Legacy Node.js versions are supported as a best effort:_
+
+* Legacy versions will not be tested in continuous integration.
+* Some security patches may not be able to be backported.
+* Dependencies will not be kept up-to-date, and features will not be backported.
+
+#### Legacy tags available
+
+* `legacy-8`: install client libraries from this dist-tag for versions
+  compatible with Node.js 8.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).


### PR DESCRIPTION
Document our version support goals on all repos, the goal being to unblock folks who accidentally install a Node 10 version of a library in a Node 8 runtime.

_I would like to create a mass PR for this change manually, before merging, so that we don't end up with 85 PRs we need to change in the morning._