### PR TITLE
fix(ruby): remove dead troubleshooting link from generated auth guide

### DIFF
--- a/synthtool/gcp/templates/ruby_library/AUTHENTICATION.md
+++ b/synthtool/gcp/templates/ruby_library/AUTHENTICATION.md
@@ -170,8 +170,3 @@ Developers service account.
 
    The key file you download will be used by this library to authenticate API
    requests and should be stored in a secure location.
-
-## Troubleshooting
-
-If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-ruby/issues/5185
