### PR TITLE
fix: allow local and external deps to be specified

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -63,6 +63,16 @@ class CommonTemplates:
         # kwargs["metadata"] is required to load values from .repo-metadata.json
         if "metadata" not in kwargs:
             kwargs["metadata"] = {}
+        # rename variable to accomodate existing synth.py files
+        if "system_test_dependencies" in kwargs:
+            kwargs["system_test_local_dependencies"] = kwargs[
+                "system_test_dependencies"
+            ]
+            log.warning(
+                "Template argument 'system_test_dependencies' is deprecated."
+                "Use 'system_test_local_dependencies' or 'system_test_external_dependencies'"
+                "instead."
+            )
 
         return self._generic_library("python_library", **kwargs)
 

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -117,10 +117,13 @@ def system(session):
 
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
-    session.install("mock", "pytest")
-    {% for dependency in system_test_dependencies %}
-    session.install("-e", "{{dependency}}"){% endfor %}
+    session.install("mock", "pytest", {% for d in system_test_external_dependencies %}"{{d}}"{% if not loop.last %},{% endif %}{% endfor %})
+
+    {%- if system_test_local_dependencies %}
+    session.install("-e", {% for d in system_test_local_dependencies %}"{{d}}"{% if not loop.last %},{% endif %}{% endfor %})
+    {%- endif %}
     session.install("-e", ".")
+
 
     # Run py.test against the system tests.
     if system_test_exists:


### PR DESCRIPTION
Modify noxfile.py to allow local and external dependencies for
system tests to be specified.

```py
templated_files = gcp.CommonTemplates().py_library(
    unit_cov_level=97, 
    cov_level=99, 
    system_test_local_dependencies=["test_utils"],
    system_test_external_dependencies=["psutil"]
)
```