### PR TITLE
fix: pin sphinx to <3.0.0 as new version causes new error

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -163,7 +163,7 @@ def docs(session):
     """Build the docs for this library."""
 
     session.install('-e', '.')
-    session.install('sphinx', 'alabaster', 'recommonmark')
+    session.install('sphinx<3.0.0', 'alabaster', 'recommonmark')
 
     shutil.rmtree(os.path.join('docs', '_build'), ignore_errors=True)
     session.run(


### PR DESCRIPTION
The error `toctree contains reference to document changlelog that doesn't have a title: no link will be generated` occurs as of 3.0.0. Pinning to 2.x until we address the docs build issue.

Towards #470

I did this manually for python-datastore https://github.com/googleapis/python-datastore/pull/22