### PR TITLE
build(java): fix retry_with_backoff when -e option set

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/common.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/common.sh
@@ -13,17 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# set -eo pipefail
-
 function retry_with_backoff {
     attempts_left=$1
     sleep_seconds=$2
     shift 2
     command=$@
 
+
+    # store current flag state
+    flags=$-
+    
+    # allow a failures to continue
+    set +e
     echo "${command}"
     ${command}
     exit_code=$?
+
+    # restore "e" flag
+    if [[ ${flags} =~ e ]]
+    then set -e
+    else set +e
+    fi
 
     if [[ $exit_code == 0 ]]
     then


### PR DESCRIPTION
Currently, if you `set -e` in the calling bash script, the first attempt will fail the entire script.