### PR TITLE
chore(java): release-please only updates non maven versions in README

### DIFF
--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -41,8 +41,6 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
 {% endif -%}
 ```
 
-[//]: # ({x-version-update-start:{{ artifact_id }}:released})
-
 If you are using Maven without BOM, add this to your dependencies:
 
 ```xml
@@ -56,6 +54,8 @@ If you are using Maven without BOM, add this to your dependencies:
 </dependency>
 {% endif -%}
 ```
+
+[//]: # ({x-version-update-start:{{ artifact_id }}:released})
 
 If you are using Gradle, add this to your dependencies
 ```Groovy


### PR DESCRIPTION
Prevent release-please and synthtool from fighting over the released library version. Synthtool updates the install snippets from the samples pom.xml files so the bots fight if they are temporarily out of sync after a release.