### PR TITLE
fix: stop recording update_time in synth.metadata

### DIFF
--- a/synthtool/metadata.py
+++ b/synthtool/metadata.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import deprecation
 import locale
 import os
@@ -108,7 +107,6 @@ def _read_or_empty(path: str = "synth.metadata"):
 
 def write(outfile: str = "synth.metadata") -> None:
     """Writes out the metadata to a file."""
-    _metadata.update_time.FromDatetime(datetime.datetime.utcnow())
     jsonified = google.protobuf.json_format.MessageToJson(_metadata)
 
     with open(outfile, "w") as fh:

--- a/synthtool/protos/metadata.proto
+++ b/synthtool/protos/metadata.proto
@@ -20,7 +20,7 @@ import "google/protobuf/timestamp.proto";
 
 
 message Metadata {
-    google.protobuf.Timestamp update_time = 1;
+    google.protobuf.Timestamp update_time = 1 [deprecated=true];
 
     repeated Source sources = 2;
     repeated Destination destinations = 3;

--- a/synthtool/protos/metadata_pb2.py
+++ b/synthtool/protos/metadata_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     package="yoshi.synth.metadata",
     syntax="proto3",
     serialized_options=None,
-    serialized_pb=b'\n\x0emetadata.proto\x12\x14yoshi.synth.metadata\x1a\x1fgoogle/protobuf/timestamp.proto"\xd9\x01\n\x08Metadata\x12/\n\x0bupdate_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\x07sources\x18\x02 \x03(\x0b\x32\x1c.yoshi.synth.metadata.Source\x12\x37\n\x0c\x64\x65stinations\x18\x03 \x03(\x0b\x32!.yoshi.synth.metadata.Destination\x12\x34\n\tnew_files\x18\x04 \x03(\x0b\x32\x1d.yoshi.synth.metadata.NewFileB\x02\x18\x01"\xb8\x01\n\x06Source\x12.\n\x03git\x18\x01 \x01(\x0b\x32\x1f.yoshi.synth.metadata.GitSourceH\x00\x12:\n\tgenerator\x18\x02 \x01(\x0b\x32%.yoshi.synth.metadata.GeneratorSourceH\x00\x12\x38\n\x08template\x18\x03 \x01(\x0b\x32$.yoshi.synth.metadata.TemplateSourceH\x00\x42\x08\n\x06source"m\n\tGitSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06remote\x18\x02 \x01(\t\x12\x0b\n\x03sha\x18\x03 \x01(\t\x12\x14\n\x0cinternal_ref\x18\x04 \x01(\t\x12\x12\n\nlocal_path\x18\x05 \x01(\t\x12\x0b\n\x03log\x18\x06 \x01(\t"F\n\x0fGeneratorSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x14\n\x0c\x64ocker_image\x18\x03 \x01(\t"?\n\x0eTemplateSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06origin\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t"\x94\x01\n\x0b\x44\x65stination\x12\x39\n\x06\x63lient\x18\x01 \x01(\x0b\x32\'.yoshi.synth.metadata.ClientDestinationH\x00\x12;\n\x07\x66ileset\x18\x02 \x01(\x0b\x32(.yoshi.synth.metadata.FileSetDestinationH\x00\x42\r\n\x0b\x44\x65stination"\x17\n\x07NewFile\x12\x0c\n\x04path\x18\x01 \x01(\t"\x7f\n\x11\x43lientDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x10\n\x08\x61pi_name\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_version\x18\x03 \x01(\t\x12\x10\n\x08language\x18\x04 \x01(\t\x12\x11\n\tgenerator\x18\x05 \x01(\t\x12\x0e\n\x06\x63onfig\x18\x06 \x01(\t"3\n\x12\x46ileSetDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\r\n\x05\x66iles\x18\x02 \x03(\tb\x06proto3',
+    serialized_pb=b'\n\x0emetadata.proto\x12\x14yoshi.synth.metadata\x1a\x1fgoogle/protobuf/timestamp.proto"\xdd\x01\n\x08Metadata\x12\x33\n\x0bupdate_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.TimestampB\x02\x18\x01\x12-\n\x07sources\x18\x02 \x03(\x0b\x32\x1c.yoshi.synth.metadata.Source\x12\x37\n\x0c\x64\x65stinations\x18\x03 \x03(\x0b\x32!.yoshi.synth.metadata.Destination\x12\x34\n\tnew_files\x18\x04 \x03(\x0b\x32\x1d.yoshi.synth.metadata.NewFileB\x02\x18\x01"\xb8\x01\n\x06Source\x12.\n\x03git\x18\x01 \x01(\x0b\x32\x1f.yoshi.synth.metadata.GitSourceH\x00\x12:\n\tgenerator\x18\x02 \x01(\x0b\x32%.yoshi.synth.metadata.GeneratorSourceH\x00\x12\x38\n\x08template\x18\x03 \x01(\x0b\x32$.yoshi.synth.metadata.TemplateSourceH\x00\x42\x08\n\x06source"m\n\tGitSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06remote\x18\x02 \x01(\t\x12\x0b\n\x03sha\x18\x03 \x01(\t\x12\x14\n\x0cinternal_ref\x18\x04 \x01(\t\x12\x12\n\nlocal_path\x18\x05 \x01(\t\x12\x0b\n\x03log\x18\x06 \x01(\t"F\n\x0fGeneratorSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x14\n\x0c\x64ocker_image\x18\x03 \x01(\t"?\n\x0eTemplateSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06origin\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t"\x94\x01\n\x0b\x44\x65stination\x12\x39\n\x06\x63lient\x18\x01 \x01(\x0b\x32\'.yoshi.synth.metadata.ClientDestinationH\x00\x12;\n\x07\x66ileset\x18\x02 \x01(\x0b\x32(.yoshi.synth.metadata.FileSetDestinationH\x00\x42\r\n\x0b\x44\x65stination"\x17\n\x07NewFile\x12\x0c\n\x04path\x18\x01 \x01(\t"\x7f\n\x11\x43lientDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x10\n\x08\x61pi_name\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_version\x18\x03 \x01(\t\x12\x10\n\x08language\x18\x04 \x01(\t\x12\x11\n\tgenerator\x18\x05 \x01(\t\x12\x0e\n\x06\x63onfig\x18\x06 \x01(\t"3\n\x12\x46ileSetDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\r\n\x05\x66iles\x18\x02 \x03(\tb\x06proto3',
     dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,],
 )
 
@@ -47,7 +47,7 @@ _METADATA = _descriptor.Descriptor(
             containing_type=None,
             is_extension=False,
             extension_scope=None,
-            serialized_options=None,
+            serialized_options=b"\030\001",
             file=DESCRIPTOR,
         ),
         _descriptor.FieldDescriptor(
@@ -114,7 +114,7 @@ _METADATA = _descriptor.Descriptor(
     extension_ranges=[],
     oneofs=[],
     serialized_start=74,
-    serialized_end=291,
+    serialized_end=295,
 )
 
 
@@ -196,8 +196,8 @@ _SOURCE = _descriptor.Descriptor(
             fields=[],
         ),
     ],
-    serialized_start=294,
-    serialized_end=478,
+    serialized_start=298,
+    serialized_end=482,
 )
 
 
@@ -325,8 +325,8 @@ _GITSOURCE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=480,
-    serialized_end=589,
+    serialized_start=484,
+    serialized_end=593,
 )
 
 
@@ -400,8 +400,8 @@ _GENERATORSOURCE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=591,
-    serialized_end=661,
+    serialized_start=595,
+    serialized_end=665,
 )
 
 
@@ -475,8 +475,8 @@ _TEMPLATESOURCE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=663,
-    serialized_end=726,
+    serialized_start=667,
+    serialized_end=730,
 )
 
 
@@ -540,8 +540,8 @@ _DESTINATION = _descriptor.Descriptor(
             fields=[],
         ),
     ],
-    serialized_start=729,
-    serialized_end=877,
+    serialized_start=733,
+    serialized_end=881,
 )
 
 
@@ -579,8 +579,8 @@ _NEWFILE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=879,
-    serialized_end=902,
+    serialized_start=883,
+    serialized_end=906,
 )
 
 
@@ -708,8 +708,8 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=904,
-    serialized_end=1031,
+    serialized_start=908,
+    serialized_end=1035,
 )
 
 
@@ -765,8 +765,8 @@ _FILESETDESTINATION = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1033,
-    serialized_end=1084,
+    serialized_start=1037,
+    serialized_end=1088,
 )
 
 _METADATA.fields_by_name[
@@ -909,5 +909,6 @@ FileSetDestination = _reflection.GeneratedProtocolMessageType(
 _sym_db.RegisterMessage(FileSetDestination)
 
 
+_METADATA.fields_by_name["update_time"]._options = None
 _METADATA.fields_by_name["new_files"]._options = None
 # @@protoc_insertion_point(module_scope)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -101,7 +101,7 @@ def test_write(tmpdir):
     assert "sha" in raw
     data = json.loads(raw)
     assert data
-    assert data["updateTime"] is not None
+    assert "updateTime" not in data
 
 
 class SourceTree:


### PR DESCRIPTION
The sha for each source is a better indication of the state of the world when the last codegen occurred. This will also help us avoid merge conflicts when splitting PRs by source (multiple PRs would be updating this field in an unmergeable way).

This PR deprecates the `update_time` field and stops writing it to the metadata file.