### PR TITLE
chore(java): skip bom install instructions if there's no snippet

### DIFF
--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -16,10 +16,8 @@ Java idiomatic client for [{{metadata['repo']['name_pretty']}}][product-docs].
 {% endif %}
 ## Quickstart
 
-
 {% if 'snippets' in metadata and metadata['snippets'][metadata['repo']['name'] + '_install_with_bom'] -%}
 If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
-
 ```xml
 {{ metadata['snippets'][metadata['repo']['name'] + '_install_with_bom'] }}
 ```
@@ -27,8 +25,7 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
 If you are using Maven without BOM, add this to your dependencies:
 {% else %}
 If you are using Maven, add this to your pom.xml file:
-{% endif -%}
-
+{% endif %}
 ```xml
 {% if 'snippets' in metadata and metadata['snippets'][metadata['repo']['name'] + '_install_without_bom'] -%}
 {{ metadata['snippets'][metadata['repo']['name'] + '_install_without_bom'] }}

--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -16,32 +16,18 @@ Java idiomatic client for [{{metadata['repo']['name_pretty']}}][product-docs].
 {% endif %}
 ## Quickstart
 
-If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
-```xml
+
 {% if 'snippets' in metadata and metadata['snippets'][metadata['repo']['name'] + '_install_with_bom'] -%}
+If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
+
+```xml
 {{ metadata['snippets'][metadata['repo']['name'] + '_install_with_bom'] }}
-{% else -%}
-<dependencyManagement>
-  <dependencies>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>libraries-bom</artifactId>
-      <version>{{ metadata['latest_bom_version'] }}</version>
-      <type>pom</type>
-      <scope>import</scope>
-    </dependency>
-  </dependencies>
-</dependencyManagement>
-<dependencies>
-  <dependency>
-    <groupId>{{ group_id }}</groupId>
-    <artifactId>{{ artifact_id }}</artifactId>
-  </dependency>
-</dependencies>
-{% endif -%}
 ```
 
 If you are using Maven without BOM, add this to your dependencies:
+{% else %}
+If you are using Maven, add this to your pom.xml file:
+{% endif -%}
 
 ```xml
 {% if 'snippets' in metadata and metadata['snippets'][metadata['repo']['name'] + '_install_without_bom'] -%}


### PR DESCRIPTION
Moving forward, new clients won't be added to the google-cloud-bom until
they are stable. Thus, we should not add the default libraries-bom
install instructions if there's no bom install snippet.

When we generate a new client, we'll skip the install-with-bom snippet in the samples directory and the README will then only have the direct installation instructions.