### PR TITLE
build: use codecov's action

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
@@ -18,6 +18,11 @@ jobs:
       - run: node --version
       - run: npm install
       - run: npm test
+      - name: coverage
+        uses: codecov/codecov-action@v1
+        with:
+          name: actions ${{ '{{' }} matrix.node {{ '}}' }}
+          fail_ci_if_error: true
   windows:
     runs-on: windows-latest
     steps:
@@ -27,6 +32,11 @@ jobs:
           node-version: 12
       - run: npm install
       - run: npm test
+      - name: coverage
+        uses: codecov/codecov-action@v1
+        with:
+          name: actions windows
+          fail_ci_if_error: true
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -45,13 +55,3 @@ jobs:
           node-version: 12
       - run: npm install
       - run: npm run docs-test
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 13
-      - run: npm install
-      - run: npm test
-      - run: ./node_modules/.bin/c8 report --reporter=text-lcov | npx codecovorg -a ${{ '{{' }} secrets.CODECOV_API_KEY {{ '}}' }} -r $GITHUB_REPOSITORY --pipe


### PR DESCRIPTION
codecov's action is now authless, so let's switch back to using it rather than rolling our own token.