### PR TITLE
fix: make args optional

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -94,7 +94,7 @@ class CommonTemplates:
         kwargs["publish_token"] = node.get_publish_token(kwargs["metadata"]["name"])
 
         # generate root-level `src/index.ts` to export multiple versions and its default clients
-        if kwargs["versions"] and kwargs["default_version"]:
+        if "versions" in kwargs and "default_version" in kwargs:
             node.generate_index_ts(
                 versions=kwargs["versions"], default_version=kwargs["default_version"]
             )


### PR DESCRIPTION
multiple version needs two args: `versions` and `defualt_version`:
it should be the optional arguments, but previous code throw `keyError`