### PR TITLE
build: do not fail builds on codecov.io errors

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           name: actions ${{ '{{' }} matrix.node {{ '}}' }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
   windows:
     runs-on: windows-latest
     steps:
@@ -36,7 +36,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           name: actions windows
-          fail_ci_if_error: true
+          fail_ci_if_error: false
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
codecov uploads fail fairly often, and it's slowing down work.