### PR TITLE
build: use Bazel 3.0.0 for autosynth builds

### DIFF
--- a/.kokoro-autosynth/build.sh
+++ b/.kokoro-autosynth/build.sh
@@ -20,7 +20,7 @@ cd ${KOKORO_ARTIFACTS_DIR}/github/synthtool
 # Upgrade the NPM version
 sudo npm install -g npm
 
-# Install bazel 1.2.0
+# Install bazel 3.0.0
 mkdir -p ~/bazel
 curl -L https://github.com/bazelbuild/bazel/releases/download/3.0.0/bazel-3.0.0-linux-x86_64 -o ~/bazel/bazel
 chmod +x ~/bazel/bazel

--- a/.kokoro-autosynth/build.sh
+++ b/.kokoro-autosynth/build.sh
@@ -22,7 +22,7 @@ sudo npm install -g npm
 
 # Install bazel 1.2.0
 mkdir -p ~/bazel
-curl -L https://github.com/bazelbuild/bazel/releases/download/1.2.0/bazel-1.2.0-linux-x86_64 -o ~/bazel/bazel
+curl -L https://github.com/bazelbuild/bazel/releases/download/3.0.0/bazel-3.0.0-linux-x86_64 -o ~/bazel/bazel
 chmod +x ~/bazel/bazel
 export PATH=~/bazel:"$PATH"
 


### PR DESCRIPTION
The googleapis Kokoro build uses 3.0.0

https://github.com/googleapis/googleapis/blob/e0f9d9e1f9de890db765be46f45ca8490723e3eb/.kokoro/setup.sh#L10

The README also recommends Bazel >= 2.0.0.

https://github.com/googleapis/googleapis/tree/e0f9d9e1f9de890db765be46f45ca8490723e3eb#bazel
> The recommended way to build the API client libraries is through Bazel >= 2.0.0.

cc @vam-google 