### PR TITLE
chore: store autosynth synth logs as sponge_log.log for use as build artifacts

### DIFF
--- a/.kokoro-autosynth/common.cfg
+++ b/.kokoro-autosynth/common.cfg
@@ -20,6 +20,7 @@ build_file: "synthtool/.kokoro-autosynth/build.sh"
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "**/*sponge_log.log"
   }
 }
 

--- a/autosynth/synth.py
+++ b/autosynth/synth.py
@@ -144,7 +144,7 @@ class SynthesizeLoopToolbox:
         temp_dir: str,
         metadata_path: str,
         synth_path: str,
-        log_path: pathlib.Path,
+        log_path: pathlib.Path = None,
     ):
         self._temp_dir = temp_dir
         self._metadata_path = metadata_path
@@ -161,7 +161,10 @@ class SynthesizeLoopToolbox:
         self.environ["SYNTHTOOL_PRECONFIG_FILE"] = self._preconfig_path
         self.source_name = ""  # Only non-empty for forks
         self.version_zero = VersionZero()
-        self.log_path = log_path
+        if log_path is None:
+            self.log_path = pathlib.Path(tempfile.TemporaryDirectory().name)
+        else:
+            self.log_path = log_path
 
     def apply_version(self, version_index: int) -> None:
         """Applies one version from each group."""

--- a/autosynth/synth.py
+++ b/autosynth/synth.py
@@ -144,7 +144,7 @@ class SynthesizeLoopToolbox:
         temp_dir: str,
         metadata_path: str,
         synth_path: str,
-        log_path: pathlib.Path = None,
+        log_dir_path: pathlib.Path = None,
     ):
         self._temp_dir = temp_dir
         self._metadata_path = metadata_path
@@ -161,10 +161,9 @@ class SynthesizeLoopToolbox:
         self.environ["SYNTHTOOL_PRECONFIG_FILE"] = self._preconfig_path
         self.source_name = ""  # Only non-empty for forks
         self.version_zero = VersionZero()
-        if log_path is None:
-            self.log_path = pathlib.Path(tempfile.TemporaryDirectory().name)
-        else:
-            self.log_path = log_path
+        self.log_dir_path = log_dir_path or pathlib.Path(
+            tempfile.TemporaryDirectory().name
+        )
 
     def apply_version(self, version_index: int) -> None:
         """Applies one version from each group."""
@@ -225,7 +224,7 @@ class SynthesizeLoopToolbox:
                 self._temp_dir,
                 self._metadata_path,
                 self._synth_path,
-                self.log_path / source_name,
+                self.log_dir_path / source_name,
             )
             fork.source_name = source_name
             fork.commit_count = self.commit_count
@@ -259,7 +258,7 @@ class SynthesizeLoopToolbox:
                     )
                     return self.version_zero.has_changes
 
-            synth_log_path = self.log_path / str(index) / "sponge_log.log"
+            synth_log_path = self.log_dir_path / str(index) / "sponge_log.log"
             if index + 1 == len(self.versions):
                 # The youngest version.  Let exceptions raise because the
                 # current state is broken, and there's nothing we can do.

--- a/autosynth/synth.py
+++ b/autosynth/synth.py
@@ -144,6 +144,7 @@ class SynthesizeLoopToolbox:
         temp_dir: str,
         metadata_path: str,
         synth_path: str,
+        log_path: pathlib.Path,
     ):
         self._temp_dir = temp_dir
         self._metadata_path = metadata_path
@@ -160,6 +161,7 @@ class SynthesizeLoopToolbox:
         self.environ["SYNTHTOOL_PRECONFIG_FILE"] = self._preconfig_path
         self.source_name = ""  # Only non-empty for forks
         self.version_zero = VersionZero()
+        self.log_path = log_path
 
     def apply_version(self, version_index: int) -> None:
         """Applies one version from each group."""
@@ -209,7 +211,7 @@ class SynthesizeLoopToolbox:
             [typing.List[SynthesizeLoopToolbox]] -- A toolbox for each source.
         """
         forks = []
-        for i, group in enumerate(self.version_groups):
+        for i, _group in enumerate(self.version_groups):
             new_groups = [[g[0]] for g in self.version_groups]
             new_groups[i] = self.version_groups[i]
             source_name = self.version_groups[i][0].get_source_name()
@@ -220,6 +222,7 @@ class SynthesizeLoopToolbox:
                 self._temp_dir,
                 self._metadata_path,
                 self._synth_path,
+                self.log_path / source_name,
             )
             fork.source_name = source_name
             fork.commit_count = self.commit_count
@@ -253,12 +256,13 @@ class SynthesizeLoopToolbox:
                     )
                     return self.version_zero.has_changes
 
+            synth_log_path = self.log_path / str(index) / "sponge_log.log"
             if index + 1 == len(self.versions):
                 # The youngest version.  Let exceptions raise because the
                 # current state is broken, and there's nothing we can do.
-                synthesizer.synthesize(self.environ)
+                synthesizer.synthesize(synth_log_path, self.environ)
             else:
-                synthesizer.synthesize_and_catch_exception(self.environ)
+                synthesizer.synthesize_and_catch_exception(synth_log_path, self.environ)
             # Save changes into the sub branch.
             i_has_changes = has_changes()
             if i_has_changes:
@@ -503,6 +507,10 @@ def _inner_main(temp_dir: str) -> int:
     )
     change_pusher: AbstractChangePusher = ChangePusher(args.repository, gh, branch)
 
+    # capture logs for later
+    base_synth_log_path = pathlib.Path(os.path.realpath("./logs")) / args.repository
+    logger.info(f"logs will be written to: {base_synth_log_path}")
+
     if os.path.exists(WORKING_REPO):
         shutil.rmtree(WORKING_REPO)
     git.clone_repo(f"https://github.com/{args.repository}.git", WORKING_REPO)
@@ -536,7 +544,7 @@ def _inner_main(temp_dir: str) -> int:
             metadata_path,
             args.extra_args,
             deprecated_execution=args.deprecated_execution,
-        ).synthesize()
+        ).synthesize(base_synth_log_path)
 
         if not has_changes():
             logger.info("No changes. :)")
@@ -562,10 +570,15 @@ def _inner_main(temp_dir: str) -> int:
 
         # Prepare to call synthesize loop.
         synthesizer = Synthesizer(
-            metadata_path, args.extra_args, args.deprecated_execution, "synth.py"
+            metadata_path, args.extra_args, args.deprecated_execution, "synth.py",
         )
         x = SynthesizeLoopToolbox(
-            source_versions, branch, temp_dir, metadata_path, args.synth_path
+            source_versions,
+            branch,
+            temp_dir,
+            metadata_path,
+            args.synth_path,
+            base_synth_log_path,
         )
         if not multiple_commits:
             change_pusher = SquashingChangePusher(change_pusher)

--- a/autosynth/synthesizer.py
+++ b/autosynth/synthesizer.py
@@ -33,7 +33,7 @@ class AbstractSynthesizer(ABC):
 
     @abstractmethod
     def synthesize(
-        self, logfile: pathlib.Path, environ: typing.Mapping[str, str] = None
+        self, log_file_path: pathlib.Path, environ: typing.Mapping[str, str] = None
     ) -> str:
         """
         Keyword Arguments:
@@ -45,10 +45,10 @@ class AbstractSynthesizer(ABC):
         pass
 
     def synthesize_and_catch_exception(
-        self, logfile: pathlib.Path, environ: typing.Mapping[str, str] = None
+        self, log_file_path: pathlib.Path, environ: typing.Mapping[str, str] = None
     ) -> typing.Union[bool, str]:
         try:
-            return self.synthesize(logfile, environ)
+            return self.synthesize(log_file_path, environ)
         except subprocess.CalledProcessError:
             return False
 
@@ -78,7 +78,7 @@ class Synthesizer(AbstractSynthesizer):
         self.synth_py_path = synth_py_path or "synth.py"
 
     def synthesize(
-        self, logfile: pathlib.Path, environ: typing.Mapping[str, str] = None
+        self, log_file_path: pathlib.Path, environ: typing.Mapping[str, str] = None
     ) -> str:
         """
         Returns:
@@ -102,9 +102,9 @@ class Synthesizer(AbstractSynthesizer):
         logger.info(command)
 
         # Ensure the logfile directory exists
-        logfile.parent.mkdir(parents=True, exist_ok=True)
+        log_file_path.parent.mkdir(parents=True, exist_ok=True)
         # Tee the output into a provided location so we can see the return the final output
-        tee_proc = subprocess.Popen(["tee", logfile], stdin=subprocess.PIPE)
+        tee_proc = subprocess.Popen(["tee", log_file_path], stdin=subprocess.PIPE)
         # Invoke synth.py.
         synth_proc = subprocess.run(
             command + self.extra_args,
@@ -117,5 +117,5 @@ class Synthesizer(AbstractSynthesizer):
             logger.error("Synthesis failed")
             synth_proc.check_returncode()  # Raise an exception.
 
-        with open(logfile, "r") as fp:
+        with open(log_file_path, "rt") as fp:
             return fp.read()

--- a/autosynth/synthesizer.py
+++ b/autosynth/synthesizer.py
@@ -17,7 +17,6 @@ import os
 import pathlib
 import subprocess
 import sys
-import tempfile
 import typing
 from abc import ABC, abstractmethod
 from autosynth.log import logger

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -89,7 +89,9 @@ class MockSynthesizer(AbstractSynthesizer):
     def add_action(self, action):
         self._actions.append(action)
 
-    def synthesize(self, environ: typing.Mapping[str, str] = None) -> str:
+    def synthesize(
+        self, logfile: pathlib.Path, environ: typing.Mapping[str, str] = None
+    ) -> str:
         actions = self._actions
         self._actions = []
         for action in actions:
@@ -528,7 +530,9 @@ with open("synth.metadata", "wt") as f:
 class SimpleSynthesizer(AbstractSynthesizer):
     """Invokes synth.py and does nothing more."""
 
-    def synthesize(self, environ: typing.Mapping[str, str] = None) -> str:
+    def synthesize(
+        self, logfile: pathlib.Path, environ: typing.Mapping[str, str] = None
+    ) -> str:
         subprocess.check_call([sys.executable, "synth.py"])
         return "synth log"
 


### PR DESCRIPTION
This allows autosynth to capture individual synthtool runs' output in sponge_log.log files as they are generated. We switch from using a temporary file to using a structured location: `logs/[repo]/[source]/[index]/sponge_log.log` (e.g. `logs/googleapis/java-asset/googleapis/2/sponge_log.log`). These artifacts are uploaded but not yet made public to ResultStore.