### PR TITLE
fix: reduce memory consumption for monorepo autosynth

### DIFF
--- a/autosynth/git.py
+++ b/autosynth/git.py
@@ -39,7 +39,8 @@ def configure_git(user: str, email: str) -> None:
 
 
 def setup_branch(branch: str) -> None:
-    subprocess.check_call(["git", "checkout", "-b", branch])
+    subprocess.check_call(["git", "branch", "-f", branch])
+    subprocess.check_call(["git", "checkout", branch])
 
 
 def get_last_commit_to_file(file_path: str) -> str:

--- a/autosynth/git.py
+++ b/autosynth/git.py
@@ -26,18 +26,6 @@ __pycache__/
 GLOBAL_GITIGNORE_FILE = os.path.expanduser("~/.autosynth-gitignore")
 
 
-def clone_repo(source_url: str, target_path: str) -> None:
-    """Clones a remote repo to a local directory.
-
-    Arguments:
-        source_url {str} -- Url of the remote repo
-        target_path {str} -- Local directory name for the clone
-    """
-    subprocess.check_call(
-        ["git", "clone", "--single-branch", source_url, "--", target_path]
-    )
-
-
 def configure_git(user: str, email: str) -> None:
     with open(GLOBAL_GITIGNORE_FILE, "w") as fh:
         fh.write(GLOBAL_GITIGNORE)

--- a/autosynth/git_source.py
+++ b/autosynth/git_source.py
@@ -18,6 +18,8 @@ import re
 import subprocess
 import typing
 
+import synthtool.sources.git as synthtool_git
+
 import autosynth.abstract_source
 from autosynth import git
 
@@ -126,8 +128,7 @@ def enumerate_versions_for_source(
         return []
     remote = source["remote"]
     tail_sha = source["sha"]
-    local_repo_dir = str(temp_dir / name)
-    git.clone_repo(remote, local_repo_dir)
+    local_repo_dir = str(synthtool_git.clone(remote))
     # Get the list of commit hashes since the last library generation.
     shas = git.get_commit_shas_since(tail_sha, local_repo_dir)
     desc = f"Git repo {remote}"

--- a/autosynth/synth.py
+++ b/autosynth/synth.py
@@ -178,7 +178,8 @@ class SynthesizeLoopToolbox:
 
     def checkout_new_branch(self, index: int) -> None:
         """Create a new branch for the version."""
-        subprocess.check_call(["git", "checkout", "-b", self.sub_branch(index)])
+        subprocess.check_call(["git", "branch", "-f", self.sub_branch(index)])
+        subprocess.check_call(["git", "checkout", self.sub_branch(index)])
 
     def checkout_sub_branch(self, index: int):
         """Check out the branch for the version."""

--- a/autosynth/synth.py
+++ b/autosynth/synth.py
@@ -20,26 +20,25 @@ import json
 import os
 import pathlib
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
 import typing
+from typing import Dict, Sequence
+
+import synthtool.sources.git as synthtool_git
 
 import autosynth
 import autosynth.flags
-from autosynth import git, github, git_source
+from autosynth import git, git_source, github
 from autosynth.abstract_source import AbstractSourceVersion
-from autosynth.synthesizer import Synthesizer, AbstractSynthesizer
 from autosynth.change_pusher import (
     AbstractChangePusher,
     ChangePusher,
     SquashingChangePusher,
 )
 from autosynth.log import logger
-from typing import Dict, Sequence
-
-WORKING_REPO = "working_repo"
+from autosynth.synthesizer import AbstractSynthesizer, Synthesizer
 
 IGNORED_FILE_PATTERNS = [
     # Ignore modifications to synth.metadata in any directory, this still allows *new*
@@ -513,11 +512,9 @@ def _inner_main(temp_dir: str) -> int:
     base_synth_log_path = pathlib.Path(os.path.realpath("./logs")) / args.repository
     logger.info(f"logs will be written to: {base_synth_log_path}")
 
-    if os.path.exists(WORKING_REPO):
-        shutil.rmtree(WORKING_REPO)
-    git.clone_repo(f"https://github.com/{args.repository}.git", WORKING_REPO)
+    working_repo_path = synthtool_git.clone(f"https://github.com/{args.repository}.git")
 
-    os.chdir(WORKING_REPO)
+    os.chdir(working_repo_path)
 
     git.configure_git(args.github_user, args.github_email)
 

--- a/autosynth/synth.py
+++ b/autosynth/synth.py
@@ -511,6 +511,8 @@ def _inner_main(temp_dir: str) -> int:
 
     # capture logs for later
     base_synth_log_path = pathlib.Path(os.path.realpath("./logs")) / args.repository
+    if args.synth_path:
+        base_synth_log_path /= args.synth_path
     logger.info(f"logs will be written to: {base_synth_log_path}")
 
     working_repo_path = synthtool_git.clone(f"https://github.com/{args.repository}.git")

--- a/synthtool/sources/git.py
+++ b/synthtool/sources/git.py
@@ -20,6 +20,7 @@ import subprocess
 from typing import Dict, Optional, Tuple
 
 import synthtool
+import synthtool.preconfig
 from synthtool import _tracked_paths, cache, log, metadata, shell
 
 REPO_REGEX = (
@@ -78,9 +79,10 @@ def clone(
 
         if not dest.exists():
             cmd = ["git", "clone", "--single-branch", url, dest]
-            shell.run(cmd)
+            shell.run(cmd, check=True)
         else:
-            shell.run(["git", "pull"], cwd=str(dest))
+            shell.run(["git", "checkout", "master"], cwd=str(dest), check=True)
+            shell.run(["git", "pull"], cwd=str(dest), check=True)
         committish = committish or "master"
 
     if committish:


### PR DESCRIPTION
Use synthtool's git clone function because it caches and re-uses cloned repos.
Otherwise, for each product, we cloned all the repos again, and bazel spinned up a new server for each product, and a bazel server consumes a lot of memory.