### PR TITLE
fix: consolidate logging setup

### DIFF
--- a/autosynth/log.py
+++ b/autosynth/log.py
@@ -12,26 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
+from synthtool.log import configure_logger
 
 
-def _configure_logger():
-    """Create and configure the default logger for autosynth.
-
-    The logger will prefix the log message with the current time and the
-    log severity.
-    """
-    logger = logging.getLogger("autosynth")
-    logger.setLevel(logging.DEBUG)
-
-    handler = logging.StreamHandler()
-    handler.setLevel(logging.DEBUG)
-    formatter = logging.Formatter(
-        "%(asctime)s [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
-    )
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    return logger
-
-
-logger = _configure_logger()
+logger = configure_logger("autosynth")

--- a/synthtool/__init__.py
+++ b/synthtool/__init__.py
@@ -17,7 +17,7 @@
 import sys
 
 from synthtool.transforms import move, replace
-from synthtool import log
+from synthtool.log import logger
 
 copy = move
 
@@ -27,6 +27,6 @@ __all__ = ["copy", "move", "replace"]
 # directly
 _main_module = sys.modules["__main__"]
 if hasattr(_main_module, "__file__") and "synthtool" not in _main_module.__file__:
-    log.critical(
+    logger.critical(
         "You are running the synthesis script directly, this will be disabled in a future release of Synthtool. Please use python3 -m synthtool instead."
     )

--- a/synthtool/__main__.py
+++ b/synthtool/__main__.py
@@ -19,7 +19,7 @@ from typing import List, Sequence
 
 import click
 import pkg_resources
-import synthtool.log
+from synthtool.log import logger
 import synthtool.metadata
 from synthtool import preconfig
 
@@ -82,7 +82,7 @@ def main(synthfile: str, metadata: str, extra_args: Sequence[str]):
     synth_file = os.path.abspath(synthfile)
 
     if os.path.lexists(synth_file):
-        synthtool.log.debug(f"Executing {synth_file}.")
+        logger.debug(f"Executing {synth_file}.")
         # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
         spec = importlib.util.spec_from_file_location("synth", synth_file)
         synth_module = importlib.util.module_from_spec(spec)
@@ -94,7 +94,7 @@ def main(synthfile: str, metadata: str, extra_args: Sequence[str]):
             spec.loader.exec_module(synth_module)  # type: ignore
 
     else:
-        synthtool.log.exception(f"{synth_file} not found.")
+        logger.exception(f"{synth_file} not found.")
         sys.exit(1)
 
 

--- a/synthtool/gcp/artman.py
+++ b/synthtool/gcp/artman.py
@@ -18,9 +18,8 @@ import os
 import platform
 import tempfile
 
-from synthtool import log
-from synthtool import metadata
-from synthtool import shell
+from synthtool import metadata, shell
+from synthtool.log import logger
 
 ARTMAN_VERSION = os.environ.get("SYNTHTOOL_ARTMAN_VERSION", "latest")
 
@@ -143,7 +142,7 @@ class Artman:
         return output_dir
 
     def _ensure_dependencies_installed(self):
-        log.debug("Ensuring dependencies.")
+        logger.debug("Ensuring dependencies.")
 
         dependencies = ["docker", "git"]
         failed_dependencies = []
@@ -158,7 +157,7 @@ class Artman:
             )
 
     def _install_artman(self):
-        log.debug("Pulling artman image.")
+        logger.debug("Pulling artman image.")
         shell.run(
             ["docker", "pull", f"googleapis/artman:{ARTMAN_VERSION}"], hide_output=False
         )

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -19,10 +19,10 @@ import yaml
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from synthtool.languages import node
-from synthtool.sources import git, templates
 from synthtool import _tracked_paths
-from synthtool import log
+from synthtool.languages import node
+from synthtool.log import logger
+from synthtool.sources import git, templates
 
 
 TEMPLATES_URL: str = git.make_repo_clone_url("googleapis/synthtool")
@@ -33,7 +33,7 @@ LOCAL_TEMPLATES: Optional[str] = os.environ.get("SYNTHTOOL_TEMPLATES")
 class CommonTemplates:
     def __init__(self):
         if LOCAL_TEMPLATES:
-            log.debug(f"Using local templates at {LOCAL_TEMPLATES}")
+            logger.debug(f"Using local templates at {LOCAL_TEMPLATES}")
             self._template_root = LOCAL_TEMPLATES
         else:
             templates_git = git.clone(TEMPLATES_URL)
@@ -68,7 +68,7 @@ class CommonTemplates:
             kwargs["system_test_local_dependencies"] = kwargs[
                 "system_test_dependencies"
             ]
-            log.warning(
+            logger.warning(
                 "Template argument 'system_test_dependencies' is deprecated."
                 "Use 'system_test_local_dependencies' or 'system_test_external_dependencies'"
                 "instead."

--- a/synthtool/gcp/discogapic_generator.py
+++ b/synthtool/gcp/discogapic_generator.py
@@ -15,8 +15,8 @@
 from pathlib import Path
 
 from synthtool import _tracked_paths
-from synthtool import log
 from synthtool.gcp import artman
+from synthtool.log import logger
 from synthtool.sources import git
 
 DISCOVERY_ARTIFACT_MANAGER_URL: str = git.make_repo_clone_url(
@@ -90,7 +90,7 @@ class DiscoGAPICGenerator:
                 f"Unable to find configuration yaml file: {config_path}."
             )
 
-        log.debug(f"Running generator for {config_path}.")
+        logger.debug(f"Running generator for {config_path}.")
         output_root = artman.Artman().run(
             f"googleapis/artman:{artman.ARTMAN_VERSION}",
             self.discovery_artifact_manager,
@@ -109,11 +109,11 @@ class DiscoGAPICGenerator:
                 f"Unable to find generated output of artman: {genfiles}."
             )
 
-        log.success(f"Generated code into {genfiles}.")
+        logger.success(f"Generated code into {genfiles}.")
 
         _tracked_paths.add(genfiles)
         return genfiles
 
     def _clone_discovery_artifact_manager(self):
-        log.debug("Cloning discovery-artifact-manager.")
+        logger.debug("Cloning discovery-artifact-manager.")
         self.discovery_artifact_manager = git.clone(DISCOVERY_ARTIFACT_MANAGER_URL)

--- a/synthtool/gcp/gapic_bazel.py
+++ b/synthtool/gcp/gapic_bazel.py
@@ -17,10 +17,8 @@ import os
 import shutil
 import tempfile
 
-from synthtool import _tracked_paths
-from synthtool import log
-from synthtool import metadata
-from synthtool import shell
+from synthtool import _tracked_paths, metadata, shell
+from synthtool.log import logger
 from synthtool.sources import git
 
 GOOGLEAPIS_URL: str = git.make_repo_clone_url("googleapis/googleapis")
@@ -173,7 +171,7 @@ class GAPICBazel:
 
         bazel_run_args = ["bazel", "build", bazel_target]
 
-        log.debug(f"Generating code for: {bazel_target}.")
+        logger.debug(f"Generating code for: {bazel_target}.")
         shell.run(bazel_run_args)
 
         # We've got tar file!
@@ -211,9 +209,9 @@ class GAPICBazel:
             os.makedirs(proto_output_path, exist_ok=True)
 
             for i in proto_files:
-                log.debug(f"Copy: {i} to {proto_output_path / i.name}")
+                logger.debug(f"Copy: {i} to {proto_output_path / i.name}")
                 shutil.copyfile(i, proto_output_path / i.name)
-            log.success(f"Placed proto files into {proto_output_path}.")
+            logger.success(f"Placed proto files into {proto_output_path}.")
 
         os.chdir(cwd)
 
@@ -225,7 +223,7 @@ class GAPICBazel:
             )
 
         # Huzzah, it worked.
-        log.success(f"Generated code into {output_dir}.")
+        logger.success(f"Generated code into {output_dir}.")
 
         # Record this in the synthtool metadata.
         metadata.add_client_destination(
@@ -245,10 +243,10 @@ class GAPICBazel:
 
         if LOCAL_GOOGLEAPIS:
             self._googleapis = Path(LOCAL_GOOGLEAPIS).expanduser()
-            log.debug(f"Using local googleapis at {self._googleapis}")
+            logger.debug(f"Using local googleapis at {self._googleapis}")
 
         else:
-            log.debug("Cloning googleapis.")
+            logger.debug("Cloning googleapis.")
             self._googleapis = git.clone(GOOGLEAPIS_URL)
 
         return self._googleapis
@@ -259,12 +257,12 @@ class GAPICBazel:
 
         if LOCAL_GOOGLEAPIS:
             self._googleapis_private = Path(LOCAL_GOOGLEAPIS).expanduser()
-            log.debug(
+            logger.debug(
                 f"Using local googleapis at {self._googleapis_private} for googleapis-private"
             )
 
         else:
-            log.debug("Cloning googleapis-private.")
+            logger.debug("Cloning googleapis-private.")
             self._googleapis_private = git.clone(GOOGLEAPIS_PRIVATE_URL)
 
         return self._googleapis_private
@@ -277,17 +275,17 @@ class GAPICBazel:
             self._discovery_artifact_manager = Path(
                 LOCAL_DISCOVERY_ARTIFACT_MANAGER
             ).expanduser()
-            log.debug(
+            logger.debug(
                 f"Using local discovery_artifact_manager at {self._discovery_artifact_manager} for googleapis-private"
             )
         else:
-            log.debug("Cloning discovery-artifact-manager.")
+            logger.debug("Cloning discovery-artifact-manager.")
             self._discovery_artifact_manager = git.clone(DISCOVERY_ARTIFACT_MANAGER_URL)
 
         return self._discovery_artifact_manager
 
     def _ensure_dependencies_installed(self):
-        log.debug("Ensuring dependencies.")
+        logger.debug("Ensuring dependencies.")
 
         dependencies = ["bazel", "zip", "unzip", "tar"]
         failed_dependencies = []

--- a/synthtool/gcp/gapic_generator.py
+++ b/synthtool/gcp/gapic_generator.py
@@ -21,11 +21,9 @@ import yaml
 from pathlib import Path
 from typing import Optional
 
-from synthtool import _tracked_paths
-from synthtool import log
-from synthtool import metadata
-from synthtool import shell
+from synthtool import _tracked_paths, metadata, shell
 from synthtool.gcp import artman
+from synthtool.log import logger
 from synthtool.sources import git
 
 GOOGLEAPIS_URL: str = git.make_repo_clone_url("googleapis/googleapis")
@@ -103,7 +101,7 @@ class GAPICGenerator:
 
         generator_dir = LOCAL_GENERATOR
         if generator_dir is not None:
-            log.debug(f"Using local generator at {generator_dir}")
+            logger.debug(f"Using local generator at {generator_dir}")
 
         # Run the code generator.
         # $ artman --config path/to/artman_api.yaml generate python_gapic
@@ -121,7 +119,7 @@ class GAPICGenerator:
                 f"Unable to find configuration yaml file: {(googleapis / config_path)}."
             )
 
-        log.debug(f"Running generator for {config_path}.")
+        logger.debug(f"Running generator for {config_path}.")
 
         if include_samples:
             if generator_args is None:
@@ -149,7 +147,7 @@ class GAPICGenerator:
                 f"Unable to find generated output of artman: {genfiles}."
             )
 
-        log.success(f"Generated code into {genfiles}.")
+        logger.success(f"Generated code into {genfiles}.")
 
         # Get the *.protos files and put them in a protos dir in the output
         if include_protos:
@@ -165,9 +163,9 @@ class GAPICGenerator:
             os.makedirs(proto_output_path, exist_ok=True)
 
             for i in proto_files:
-                log.debug(f"Copy: {i} to {proto_output_path / i.name}")
+                logger.debug(f"Copy: {i} to {proto_output_path / i.name}")
                 shutil.copyfile(i, proto_output_path / i.name)
-            log.success(f"Placed proto files into {proto_output_path}.")
+            logger.success(f"Placed proto files into {proto_output_path}.")
 
         if include_samples:
             samples_root_dir = None
@@ -209,10 +207,10 @@ class GAPICGenerator:
 
         if LOCAL_GOOGLEAPIS:
             self._googleapis = Path(LOCAL_GOOGLEAPIS).expanduser()
-            log.debug(f"Using local googleapis at {self._googleapis}")
+            logger.debug(f"Using local googleapis at {self._googleapis}")
 
         else:
-            log.debug("Cloning googleapis.")
+            logger.debug("Cloning googleapis.")
             self._googleapis = git.clone(GOOGLEAPIS_URL)
 
         return self._googleapis
@@ -223,12 +221,12 @@ class GAPICGenerator:
 
         if LOCAL_GOOGLEAPIS:
             self._googleapis_private = Path(LOCAL_GOOGLEAPIS).expanduser()
-            log.debug(
+            logger.debug(
                 f"Using local googleapis at {self._googleapis_private} for googleapis-private"
             )
 
         else:
-            log.debug("Cloning googleapis-private.")
+            logger.debug("Cloning googleapis-private.")
             self._googleapis_private = git.clone(GOOGLEAPIS_PRIVATE_URL)
 
         return self._googleapis_private
@@ -300,7 +298,7 @@ class GAPICGenerator:
         test_files = googleapis_samples_dir.glob("**/*.test.yaml")
         os.makedirs(samples_test_dir, exist_ok=True)
         for i in test_files:
-            log.debug(f"Copy: {i} to {samples_test_dir / i.name}")
+            logger.debug(f"Copy: {i} to {samples_test_dir / i.name}")
             shutil.copyfile(i, samples_test_dir / i.name)
 
         # Download sample resources from sample_resources.yaml storage URIs.
@@ -321,7 +319,7 @@ class GAPICGenerator:
                 response = requests.get(uri, allow_redirects=True)
                 download_path = samples_resources_dir / os.path.basename(uri)
                 os.makedirs(samples_resources_dir, exist_ok=True)
-                log.debug(f"Download {uri} to {download_path}")
+                logger.debug(f"Download {uri} to {download_path}")
                 with open(download_path, "wb") as output:  # type: ignore
                     output.write(response.content)
 
@@ -339,7 +337,7 @@ class GAPICGenerator:
             "ruby": "bundle exec ruby",
         }
         if language not in LANGUAGE_EXECUTABLES:
-            log.info("skipping manifest gen")
+            logger.info("skipping manifest gen")
             return None
 
         manifest_arguments = [
@@ -355,7 +353,7 @@ class GAPICGenerator:
             if os.path.isfile(code_sample):
                 manifest_arguments.append(sample_path)
         try:
-            log.debug(f"Writing samples manifest {manifest_arguments}")
+            logger.debug(f"Writing samples manifest {manifest_arguments}")
             shell.run(manifest_arguments, cwd=samples_root_dir)
         except (subprocess.CalledProcessError, FileNotFoundError):
-            log.warning("gen-manifest failed (sample-tester may not be installed)")
+            logger.warning("gen-manifest failed (sample-tester may not be installed)")

--- a/synthtool/gcp/gapic_microgenerator.py
+++ b/synthtool/gcp/gapic_microgenerator.py
@@ -19,10 +19,8 @@ import os
 import platform
 import tempfile
 
-from synthtool import _tracked_paths
-from synthtool import log
-from synthtool import metadata
-from synthtool import shell
+from synthtool import _tracked_paths, metadata, shell
+from synthtool.log import logger
 from synthtool.sources import git
 
 GOOGLEAPIS_URL: str = git.make_repo_clone_url("googleapis/googleapis")
@@ -96,7 +94,7 @@ class GAPICMicrogenerator:
 
         # Pull the code generator for the requested language.
         # If a code generator version was specified, honor that.
-        log.debug(
+        logger.debug(
             f"Pulling Docker image: gapic-generator-{language}:{generator_version}"
         )
         shell.run(
@@ -184,7 +182,7 @@ class GAPICMicrogenerator:
                 docker_run_args.append(f"--{key}")
                 docker_run_args.append(value)
 
-        log.debug(f"Generating code for: {proto_path}.")
+        logger.debug(f"Generating code for: {proto_path}.")
         shell.run(docker_run_args)
 
         # Sanity check: Does the output location have code in it?
@@ -195,7 +193,7 @@ class GAPICMicrogenerator:
             )
 
         # Huzzah, it worked.
-        log.success(f"Generated code into {output_dir}.")
+        logger.success(f"Generated code into {output_dir}.")
 
         # Record this in the synthtool metadata.
         metadata.add_client_destination(
@@ -215,10 +213,10 @@ class GAPICMicrogenerator:
 
         if LOCAL_GOOGLEAPIS:
             self._googleapis = Path(LOCAL_GOOGLEAPIS).expanduser()
-            log.debug(f"Using local googleapis at {self._googleapis}")
+            logger.debug(f"Using local googleapis at {self._googleapis}")
 
         else:
-            log.debug("Cloning googleapis.")
+            logger.debug("Cloning googleapis.")
             self._googleapis = git.clone(GOOGLEAPIS_URL)
 
         return self._googleapis
@@ -229,18 +227,18 @@ class GAPICMicrogenerator:
 
         if LOCAL_GOOGLEAPIS:
             self._googleapis_private = Path(LOCAL_GOOGLEAPIS).expanduser()
-            log.debug(
+            logger.debug(
                 f"Using local googleapis at {self._googleapis_private} for googleapis-private"
             )
 
         else:
-            log.debug("Cloning googleapis-private.")
+            logger.debug("Cloning googleapis-private.")
             self._googleapis_private = git.clone(GOOGLEAPIS_PRIVATE_URL)
 
         return self._googleapis_private
 
     def _ensure_dependencies_installed(self):
-        log.debug("Ensuring dependencies.")
+        logger.debug("Ensuring dependencies.")
 
         dependencies = ["docker", "git"]
         failed_dependencies = []

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -18,10 +18,9 @@ import xml.etree.ElementTree as ET
 import requests
 import synthtool as s
 import synthtool.gcp as gcp
+from synthtool import cache, shell
 from synthtool.gcp import common, samples, snippets
-from synthtool import cache
-from synthtool import log
-from synthtool import shell
+from synthtool.log import logger
 from pathlib import Path
 from typing import Any, Optional, Dict, List
 
@@ -77,13 +76,13 @@ def format_code(
     files = list(glob.iglob(os.path.join(path, "**/*.java"), recursive=True))
 
     # Run the formatter as a jar file
-    log.info("Running java formatter on {} files".format(len(files)))
+    logger.info("Running java formatter on {} files".format(len(files)))
     for _ in range(times):
         shell.run(["java", "-jar", str(jar), "--replace"] + files)
 
 
 def _download_formatter(version: str, dest: Path) -> None:
-    log.info("Downloading java formatter")
+    logger.info("Downloading java formatter")
     url = JAR_DOWNLOAD_URL.format(version=version)
     response = requests.get(url)
     response.raise_for_status()
@@ -326,7 +325,7 @@ def _merge_common_templates(
 ) -> str:
     # keep any existing pom.xml
     if file_path.match("pom.xml"):
-        log.debug(f"existing pom file found ({file_path}) - keeping the existing")
+        logger.debug(f"existing pom file found ({file_path}) - keeping the existing")
         return destination_text
 
     # by default return the newly generated content

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -16,9 +16,10 @@ import json
 from jinja2 import FileSystemLoader, Environment
 from pathlib import Path
 import re
-from synthtool import log, shell
-from synthtool.sources import git
+from synthtool import shell
 from synthtool.gcp import samples, snippets
+from synthtool.log import logger
+from synthtool.sources import git
 from typing import Any, Dict, List
 
 _REQUIRED_FIELDS = ["name", "repository"]
@@ -126,11 +127,11 @@ def generate_index_ts(versions: List[str], default_version: str) -> None:
         err_msg = (
             "List of version can't be empty, it must contain default version at least."
         )
-        log.error(err_msg)
+        logger.error(err_msg)
         raise AttributeError(err_msg)
     if default_version not in versions:
         err_msg = f"Version {versions} must contain default version {default_version}."
-        log.error(err_msg)
+        logger.error(err_msg)
         raise AttributeError(err_msg)
 
     # compose default version's index.ts file path
@@ -138,7 +139,7 @@ def generate_index_ts(versions: List[str], default_version: str) -> None:
     clients = extract_clients(versioned_index_ts_path)
     if not clients:
         err_msg = f"No client is exported in the default version's({default_version}) index.ts ."
-        log.error(err_msg)
+        logger.error(err_msg)
         raise AttributeError(err_msg)
 
     # compose template directory
@@ -155,14 +156,14 @@ def generate_index_ts(versions: List[str], default_version: str) -> None:
     )
     with open("src/index.ts", "w") as fh:
         fh.write(output_text)
-    log.info("successfully generate `src/index.ts`")
+    logger.info("successfully generate `src/index.ts`")
 
 
 def install(hide_output=False):
     """
     Installs all dependencies for the current Node.js library.
     """
-    log.debug("Installing dependencies...")
+    logger.debug("Installing dependencies...")
     shell.run(["npm", "install"], hide_output=hide_output)
 
 
@@ -172,9 +173,9 @@ def fix(hide_output=False):
     Before running fix script, run prelint to install extra dependencies
     for samples, but do not fail if it does not succeed.
     """
-    log.debug("Running prelint...")
+    logger.debug("Running prelint...")
     shell.run(["npm", "run", "prelint"], check=False, hide_output=hide_output)
-    log.debug("Running fix...")
+    logger.debug("Running fix...")
     shell.run(["npm", "run", "fix"], hide_output=hide_output)
 
 
@@ -183,13 +184,13 @@ def compile_protos(hide_output=False):
     Compiles protos into .json, .js, and .d.ts files using
     compileProtos script from google-gax.
     """
-    log.debug("Compiling protos...")
+    logger.debug("Compiling protos...")
     shell.run(["npx", "compileProtos", "src"], hide_output=hide_output)
 
 
 def postprocess_gapic_library(hide_output=False):
-    log.debug("Post-processing GAPIC library...")
+    logger.debug("Post-processing GAPIC library...")
     install(hide_output=hide_output)
     fix(hide_output=hide_output)
     compile_protos(hide_output=hide_output)
-    log.debug("Post-processing completed")
+    logger.debug("Post-processing completed")

--- a/synthtool/log.py
+++ b/synthtool/log.py
@@ -35,10 +35,47 @@ class LoggerWithSuccess(logging.getLoggerClass()):  # type: ignore
             pass
 
 
-logging.setLoggerClass(LoggerWithSuccess)
-logger = logging.getLogger("synthtool")
-logger.setLevel(logging.DEBUG)
-logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
+def _setup_logging(color: bool = bool(ColoredFormatter)):
+    logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
+    logging.setLoggerClass(LoggerWithSuccess)
+
+    # Silence any noisy loggers here.
+
+
+def configure_logger(name: str, color: bool = bool(ColoredFormatter)):
+    """Create and configure the default logger for autosynth.
+    The logger will prefix the log message with the current time and the
+    log severity.
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG)
+
+    if color is True and sys.stdout.isatty():
+        formatter = ColoredFormatter(
+            "%(asctime)s %(purple)s%(name)s > %(log_color)s%(message)s",
+            reset=True,
+            log_colors={
+                "DEBUG": "cyan",
+                "INFO": "blue",
+                "WARNING": "yellow",
+                "ERROR": "red",
+                "CRITICAL": "red,bg_yellow",
+                "SUCCESS": "green",
+            },
+        )
+    else:
+        formatter = logging.Formatter("%(asctime)s %(name)s > %(message)s")
+
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger
+
+
+_setup_logging()
+logger = configure_logger("synthtool")
 
 
 def success(*args, **kwargs):
@@ -67,34 +104,3 @@ def exception(*args, **kwargs):
 
 def critical(*args, **kwargs):
     logger.critical(*args, **kwargs)
-
-
-def _setup_logging(color: bool = bool(ColoredFormatter)):
-    root_logger = logging.getLogger()
-    root_logger.setLevel(logging.DEBUG)
-    handler = logging.StreamHandler()
-
-    if color is True and sys.stdout.isatty():
-        formatter = ColoredFormatter(
-            "%(asctime)s %(purple)s%(name)s > %(log_color)s%(message)s",
-            reset=True,
-            log_colors={
-                "DEBUG": "cyan",
-                "INFO": "blue",
-                "WARNING": "yellow",
-                "ERROR": "red",
-                "CRITICAL": "red,bg_yellow",
-                "SUCCESS": "green",
-            },
-        )
-    else:
-        formatter = logging.Formatter("%(asctime)s %(name)s > %(message)s")
-
-    handler.setFormatter(formatter)
-
-    root_logger.addHandler(handler)
-
-    # Silence any noisy loggers here.
-
-
-_setup_logging()

--- a/synthtool/log.py
+++ b/synthtool/log.py
@@ -67,7 +67,9 @@ def configure_logger(name: str, color: bool = bool(ColoredFormatter)):
             },
         )
     else:
-        formatter = logging.Formatter("%(asctime)s %(name)s > %(message)s")
+        formatter = logging.Formatter(
+            "%(asctime)s %(name)s [%(levelname)s] > %(message)s"
+        )
 
     handler.setFormatter(formatter)
     logger.addHandler(handler)

--- a/synthtool/metadata.py
+++ b/synthtool/metadata.py
@@ -24,7 +24,7 @@ from typing import List, Iterable, Dict
 
 import google.protobuf.json_format
 
-from synthtool import log
+from synthtool.log import logger
 from synthtool.protos import metadata_pb2
 
 
@@ -86,7 +86,7 @@ def _get_new_files(newer_than: float) -> List[str]:
             try:
                 mtime = os.path.getmtime(filepath)
             except FileNotFoundError:
-                log.warning(
+                logger.warning(
                     f"FileNotFoundError while getting modified time for {filepath}."
                 )
                 continue
@@ -112,7 +112,7 @@ def write(outfile: str = "synth.metadata") -> None:
     with open(outfile, "w") as fh:
         fh.write(jsonified)
 
-    log.debug(f"Wrote metadata to {outfile}.")
+    logger.debug(f"Wrote metadata to {outfile}.")
 
 
 @deprecation.deprecated(deprecated_in="2020.02.04")
@@ -229,7 +229,7 @@ def _add_git_source_from_directory(name: str, dir_path: str) -> int:
         ["git", "-C", dir_path, "status"], universal_newlines=True
     )
     if completed_process.returncode:
-        log.warning("%s is not directory in a git repo.", dir_path)
+        logger.warning("%s is not directory in a git repo.", dir_path)
         return 0
     completed_process = subprocess.run(
         ["git", "-C", dir_path, "remote", "get-url", "origin"],

--- a/synthtool/shell.py
+++ b/synthtool/shell.py
@@ -14,7 +14,7 @@
 
 import subprocess
 
-from synthtool import log
+from synthtool.log import logger
 
 
 def run(args, *, cwd=None, check=True, hide_output=True):
@@ -33,7 +33,7 @@ def run(args, *, cwd=None, check=True, hide_output=True):
             encoding="utf-8",
         )
     except subprocess.CalledProcessError as exc:
-        log.error(
+        logger.error(
             f"Failed executing {' '.join((str(arg) for arg in args))}:\n\n{exc.stdout}"
         )
         raise exc

--- a/synthtool/sources/git.py
+++ b/synthtool/sources/git.py
@@ -21,7 +21,8 @@ from typing import Dict, Optional, Tuple
 
 import synthtool
 import synthtool.preconfig
-from synthtool import _tracked_paths, cache, log, metadata, shell
+from synthtool.log import logger
+from synthtool import _tracked_paths, cache, metadata, shell
 
 REPO_REGEX = (
     r"(((https:\/\/)|(git@))github.com(:|\/))?(?P<owner>[^\/]+)\/(?P<name>[^\/]+)"
@@ -66,7 +67,7 @@ def clone(
     preclone = get_preclone(url)
 
     if preclone:
-        log.debug(f"Using precloned repo {preclone}")
+        logger.debug(f"Using precloned repo {preclone}")
         dest = pathlib.Path(preclone)
     else:
         if dest is None:

--- a/synthtool/transforms.py
+++ b/synthtool/transforms.py
@@ -20,7 +20,7 @@ import re
 import sys
 
 from synthtool import _tracked_paths
-from synthtool import log
+from synthtool.log import logger
 
 PathOrStr = Union[str, Path]
 ListOfPathsOrStrs = Iterable[Union[str, Path]]
@@ -192,7 +192,7 @@ def move(
                 f"contain files?"
             )
         else:
-            log.warning(
+            logger.warning(
                 f"No files in sources {sources} were copied. Does the source "
                 f"contain files?"
             )
@@ -226,17 +226,17 @@ def replace(
     paths = _filter_files(_expand_paths(sources, "."))
 
     if not paths:
-        log.warning(f"No files were found in sources {sources} for replace()")
+        logger.warning(f"No files were found in sources {sources} for replace()")
 
     count_replaced = 0
     for path in paths:
         replaced = _replace_in_file(path, expr, after)
         count_replaced += replaced
         if replaced:
-            log.info(f"Replaced {before!r} in {path}.")
+            logger.info(f"Replaced {before!r} in {path}.")
 
     if not count_replaced:
-        log.warning(
+        logger.warning(
             f"No replacements made in {sources} for pattern {before}, maybe "
             "replacement is no longer needed?"
         )


### PR DESCRIPTION
When switching autosynth to use synthtool's git module, we transitively
load synthtool's logger setup which adds a log handler globally. This
causes logs to be emitted twice (with 2 different styles).

This consolidates the logging setup into a single helper and now both
autosynth's and synthtool's logger instance use the same configuration
(with different logger names).

This was included in #531, but can be standalone