### PR TITLE
fix: allow bazel server to run for 60 seconds idle

### DIFF
--- a/synthtool/gcp/gapic_bazel.py
+++ b/synthtool/gcp/gapic_bazel.py
@@ -169,7 +169,13 @@ class GAPICBazel:
         cwd = os.getcwd()
         os.chdir(str(api_definitions_repo))
 
-        bazel_run_args = ["bazel", "build", bazel_target]
+        bazel_run_args = [
+            "bazel",
+            "--max_idle_secs=60",
+            "--shutdown_on_low_sys_mem",
+            "build",
+            bazel_target,
+        ]
 
         logger.debug(f"Generating code for: {bazel_target}.")
         shell.run(bazel_run_args)

--- a/synthtool/gcp/gapic_bazel.py
+++ b/synthtool/gcp/gapic_bazel.py
@@ -172,7 +172,6 @@ class GAPICBazel:
         bazel_run_args = [
             "bazel",
             "--max_idle_secs=60",
-            "--shutdown_on_low_sys_mem",
             "build",
             bazel_target,
         ]


### PR DESCRIPTION
This will prevent the Kokoro machine from having too many bazel servers running the the background eating all the memory