### PR TITLE
fix: report autosynth status to GitHub early and don't crash on reporting

### DIFF
--- a/autosynth/multi.py
+++ b/autosynth/multi.py
@@ -72,7 +72,9 @@ def synthesize_library(
         library_args.append("--deprecated-execution")
 
     # run autosynth in a separate process
-    (returncode, output) = runner(command, env)
+    (returncode, output) = runner(
+        command + library_args + library.get("args", []) + extra_args, env
+    )
     error = returncode not in (0, synth.EXIT_CODE_SKIPPED)
     skipped = returncode == synth.EXIT_CODE_SKIPPED
     if error:

--- a/autosynth/multi.py
+++ b/autosynth/multi.py
@@ -18,7 +18,7 @@ from autosynth import executor, github, synth
 from autosynth.log import logger
 
 
-def _execute(command: typing.List[str], env: typing.Dict) -> typing.Tuple[int, bytes]:
+def _execute(command: typing.List[str], env: typing.Any) -> typing.Tuple[int, bytes]:
     """Helper to wrap command invocation for testing"""
     result = executor.run(
         command=command,
@@ -36,7 +36,7 @@ def synthesize_library(
     github_token: str,
     extra_args: typing.List[str],
     runner: typing.Callable[
-        [typing.List[str], typing.Dict], typing.Tuple[int, bytes]
+        [typing.List[str], typing.Any], typing.Tuple[int, bytes]
     ] = _execute,
 ) -> typing.Dict:
     """Run autosynth on a single library.

--- a/autosynth/multi.py
+++ b/autosynth/multi.py
@@ -60,12 +60,14 @@ def synthesize_library(
         env=env,
     )
     error = result.returncode not in (0, 28)
+    skipped = result.returncode == 28
     if error:
         logger.error(f"Synthesis failed for {library['name']}")
     return {
         "name": library["name"],
         "output": result.stdout,
         "error": error,
+        "skipped": skipped,
     }
 
 

--- a/autosynth/multi.py
+++ b/autosynth/multi.py
@@ -14,7 +14,7 @@ import typing
 import jinja2
 import yaml
 
-from autosynth import executor, github
+from autosynth import executor, github, synth
 from autosynth.log import logger
 
 
@@ -59,8 +59,8 @@ def synthesize_library(
         encoding="utf-8",
         env=env,
     )
-    error = result.returncode not in (0, 28)
-    skipped = result.returncode == 28
+    error = result.returncode not in (0, synth.EXIT_CODE_SKIPPED)
+    skipped = result.returncode == synth.EXIT_CODE_SKIPPED
     if error:
         logger.error(f"Synthesis failed for {library['name']}")
     return {

--- a/autosynth/synth.py
+++ b/autosynth/synth.py
@@ -45,6 +45,7 @@ IGNORED_FILE_PATTERNS = [
     # synth.metadata files to be added.
     re.compile(r"M (.*?)synth.metadata")
 ]
+EXIT_CODE_SKIPPED = 28
 
 
 def load_metadata(metadata_path: str):
@@ -551,7 +552,7 @@ def _inner_main(temp_dir: str) -> int:
 
         if not has_changes():
             logger.info("No changes. :)")
-            sys.exit(28)
+            sys.exit(EXIT_CODE_SKIPPED)
 
         git.commit_all_changes(pr_title)
         change_pusher.push_changes(1, branch, pr_title, synth_log)
@@ -591,7 +592,7 @@ def _inner_main(temp_dir: str) -> int:
 
         if commit_count == 0:
             logger.info("No changes. :)")
-            sys.exit(28)
+            sys.exit(EXIT_CODE_SKIPPED)
 
         return commit_count
 

--- a/integration_tests/util.py
+++ b/integration_tests/util.py
@@ -83,7 +83,7 @@ def generate(repository: str, commit_hash="master", synth_path="") -> str:
         try:
             commit_count = autosynth.synth.main()
         except SystemExit as sysexit:
-            if sysexit.code == 28:
+            if sysexit.code == autosynth.synth.EXIT_CODE_SKIPPED:
                 pass  # Nothing changed, and that's ok.
             else:
                 raise

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -1,0 +1,198 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from autosynth import github, multi, synth
+import unittest.mock
+
+
+def list_repositories():
+    """Test implementation to allow using this module as a library config provider."""
+    return [
+        {"name": "test1", "repository": "googleapis/test1"},
+        {"name": "test2", "repository": "googleapis/test2"},
+    ]
+
+
+def test_synthesize_library_success():
+    config = {"name": "test1", "repository": "googleapis/test1"}
+    mock_execute = unittest.mock.Mock()
+    mock_execute.return_value = (0, b"success")
+
+    result = multi.synthesize_library(config, "fake-github-token", [], mock_execute)
+    assert result["name"] == "test1"
+    assert result["output"] == b"success"
+    assert result["error"] is False
+    assert result["skipped"] is False
+
+
+def test_synthesize_library_failure():
+    config = {"name": "test1", "repository": "googleapis/test1"}
+
+    mock_execute = unittest.mock.Mock()
+    mock_execute.return_value = (1, b"something failed")
+
+    result = multi.synthesize_library(config, "fake-github-token", [], mock_execute)
+    assert result["name"] == "test1"
+    assert result["output"] == b"something failed"
+    assert result["error"] is True
+    assert result["skipped"] is False
+
+
+def test_synthesize_library_skip():
+    config = {"name": "test1", "repository": "googleapis/test1"}
+
+    mock_execute = unittest.mock.Mock()
+    mock_execute.return_value = (synth.EXIT_CODE_SKIPPED, b"nothing changed")
+
+    result = multi.synthesize_library(config, "fake-github-token", [], mock_execute)
+    assert result["name"] == "test1"
+    assert result["output"] == b"nothing changed"
+    assert result["error"] is False
+    assert result["skipped"] is True
+
+
+def test_make_report():
+    multi.make_report(
+        "test-report",
+        [
+            {
+                "name": "test1",
+                "output": b"some output data",
+                "error": False,
+                "skipped": False,
+            },
+            {
+                "name": "test2",
+                "output": b"something failed",
+                "error": True,
+                "skipped": False,
+            },
+            {
+                "name": "test3",
+                "output": b"something skipped",
+                "error": False,
+                "skipped": True,
+            },
+        ],
+    )
+    matching_lines = 0
+    with open("sponge_log.xml", "rt") as fp:
+        with open("tests/testdata/sponge-log-golden.xml", "rt") as golden:
+            while True:
+                matching_lines += 1
+                log_line = fp.readline()
+                expected = golden.readline()
+                assert log_line == expected
+                if not log_line:
+                    break
+    assert matching_lines > 0
+
+
+def test_report_to_github_first_failure():
+    gh = unittest.mock.Mock(github.GitHub)
+    gh.list_issues.return_value = [
+        {
+            "title": "Unrelated issue title",
+            "number": 2345,
+            "url": "https://github.com/googleapis/test1/issues/2345",
+        }
+    ]
+    gh.create_issue.return_value = {
+        "url": "https://github.com/googleapis/test1/issues/1234"
+    }
+    multi.report_to_github(
+        gh=gh,
+        name="library-name",
+        repository="googleapis/test1",
+        error=True,
+        output="some error output",
+    )
+    gh.list_issues.assert_called()
+    gh.create_issue.assert_called()
+
+
+def test_report_to_github_repeat_failure():
+    gh = unittest.mock.Mock(github.GitHub)
+    gh.list_issues.return_value = [
+        {
+            "title": "Unrelated issue title",
+            "number": 2345,
+            "url": "https://github.com/googleapis/test1/issues/2345",
+        },
+        {
+            "title": "Synthesis failed for test1",
+            "number": 1234,
+            "url": "https://github.com/googleapis/test1/issues/1234",
+        },
+    ]
+    multi.report_to_github(
+        gh=gh,
+        name="test1",
+        repository="googleapis/test1",
+        error=True,
+        output="some error output",
+    )
+    gh.list_issues.assert_called()
+    gh.create_issue_comment.assert_called()
+
+
+def test_report_to_github_passing():
+    gh = unittest.mock.Mock(github.GitHub)
+    gh.list_issues.return_value = [
+        {
+            "title": "Unrelated issue title",
+            "number": 2345,
+            "url": "https://github.com/googleapis/test1/issues/2345",
+        },
+        {
+            "title": "Synthesis failed for test1",
+            "number": 1234,
+            "url": "https://github.com/googleapis/test1/issues/1234",
+        },
+    ]
+    multi.report_to_github(
+        gh=gh,
+        name="test1",
+        repository="googleapis/test1",
+        error=False,
+        output="synth success",
+    )
+    gh.list_issues.assert_called()
+    gh.create_issue_comment.assert_called()
+    gh.patch_issue.assert_called_with(
+        "googleapis/test1", issue_number=1234, state="closed"
+    )
+
+
+def test_load_config_from_file():
+    config = multi.load_config("tests/testdata/multi-config.yaml")
+    assert len(config) == 2
+    assert config == [
+        {"name": "test1", "repository": "googleapis/test1"},
+        {"name": "test2", "repository": "googleapis/test2"},
+    ]
+
+
+def test_load_config_from_module():
+    config = multi.load_config("tests.test_multi")
+    assert len(config) == 2
+    assert config == [
+        {"name": "test1", "repository": "googleapis/test1"},
+        {"name": "test2", "repository": "googleapis/test2"},
+    ]
+
+
+def test_load_config_missing():
+    config = multi.load_config("non-existent")
+    assert config is None

--- a/tests/testdata/multi-config.yaml
+++ b/tests/testdata/multi-config.yaml
@@ -1,0 +1,5 @@
+libraries:
+  - name: test1
+    repository: googleapis/test1
+  - name: test2
+    repository: googleapis/test2

--- a/tests/testdata/sponge-log-golden.xml
+++ b/tests/testdata/sponge-log-golden.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="test-report" tests="3" failures="1" skipped="1">
+    
+    <testsuite name="test1" tests="1" errors="0" failures="0" skipped="0">
+        <testcase classname="test1" name="synthesize">
+            
+            <system-out>b&#39;some output data&#39;</system-out>
+            
+        </testcase>
+    </testsuite>
+    
+    <testsuite name="test2" tests="1" errors="0" failures="1" skipped="0">
+        <testcase classname="test2" name="synthesize">
+            
+            <failure>b&#39;something failed&#39;</failure>
+            
+        </testcase>
+    </testsuite>
+    
+    <testsuite name="test3" tests="1" errors="0" failures="0" skipped="1">
+        <testcase classname="test3" name="synthesize">
+            
+            <system-out>b&#39;something skipped&#39;</system-out>
+            
+        </testcase>
+    </testsuite>
+    
+</testsuites>


### PR DESCRIPTION
Refactors `autosynth.multi` to update GitHub immediately after running `autosynth.synth` on a single library.

* Suppresses and logs errors if the GitHub issue management APIs fail.
* Fixes the case where if a GitHub API call fails, we crash the `autosynth.multi` run.
* Adds unit tests for all of `autosynth.multi`