### PR TITLE
chore(python): remove one remaining extra bash line

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/release.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/release.sh
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
-
 set -eo pipefail
 
 # Start the releasetool reporter


### PR DESCRIPTION
To avoid generating bogus PRs