### PR TITLE
fix(bazel): conditionally add custom toolchains

### DIFF
--- a/.kokoro-autosynth/build.sh
+++ b/.kokoro-autosynth/build.sh
@@ -32,10 +32,6 @@ cd /home/kbuilder/.pyenv/plugins/python-build/../.. && git pull && cd -
 pyenv install 3.6.9
 pyenv global 3.6.9
 
-# use python installed by pyenv and use python3.6 specific set of dependencies
-echo "build --extra_toolchains=@gapic_generator_python//:pyenv3_toolchain --define=gapic_gen_python=3.6" > $HOME/.bazelrc
-echo "test --extra_toolchains=@gapic_generator_python//:pyenv3_toolchain --define=gapic_gen_python=3.6" >> $HOME/.bazelrc
-
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 

--- a/autosynth/git_source.py
+++ b/autosynth/git_source.py
@@ -48,9 +48,8 @@ class GitSourceVersion(autosynth.abstract_source.AbstractSourceVersion):
             preconfig["preclonedRepos"] = precloned_repos
         precloned_repos[self.remote] = self.repo_path
         # Check out my hash.
-        executor.run(
-            ["git", "checkout", self.sha], cwd=self.repo_path
-        ).check_returncode()
+        executor.check_call(["git", "reset", "--hard", "HEAD"], cwd=self.repo_path)
+        executor.check_call(["git", "checkout", self.sha], cwd=self.repo_path)
 
     def get_comment(self) -> str:
         # Construct a comment using the text of the git commit.

--- a/synthtool/gcp/gapic_bazel.py
+++ b/synthtool/gcp/gapic_bazel.py
@@ -254,6 +254,17 @@ class GAPICBazel:
             logger.debug("Cloning googleapis.")
             self._googleapis = git.clone(GOOGLEAPIS_URL)
 
+        # Look for .kokoro/.bazelrc. If it exists, append it to the root .bazelrc file.
+        # This allows us to generate versions of googleapis prior to the python3
+        # toolchains being available
+        custom_bazel_config = self._googleapis / ".kokoro" / ".bazelrc"
+        bazel_root_config = self._googleapis / ".bazelrc"
+        if custom_bazel_config.exists() and bazel_root_config.exists():
+            logger.debug(f"Add custom bazel config: {custom_bazel_config}")
+            with open(bazel_root_config, "a") as root_config:
+                with open(custom_bazel_config, "r") as custom_config:
+                    root_config.write(custom_config.read())
+
         return self._googleapis
 
     def _clone_googleapis_private(self):

--- a/synthtool/sources/git.py
+++ b/synthtool/sources/git.py
@@ -82,6 +82,7 @@ def clone(
             cmd = ["git", "clone", "--single-branch", url, dest]
             shell.run(cmd, check=True)
         else:
+            shell.run(["git", "reset", "--hard", "HEAD"], cwd=str(dest), check=True)
             shell.run(["git", "checkout", "master"], cwd=str(dest), check=True)
             shell.run(["git", "pull"], cwd=str(dest), check=True)
         committish = committish or "master"


### PR DESCRIPTION
This allows autosynth to succeed at generating older commits of
googleapis and discovery_artifact_manager when the custom python
toolchains are not available.

Fixes: https://github.com/googleapis/java-compute/issues/146