### PR TITLE
fix: autosynth for nodejs-apiary

### DIFF
--- a/.kokoro-autosynth/node-apiary.yaml
+++ b/.kokoro-autosynth/node-apiary.yaml
@@ -1,0 +1,5 @@
+libraries:
+
+- name: all
+  repository: googleapis/google-api-nodejs-client
+  branch-suffix: all

--- a/.kokoro-autosynth/nodejs-apiary.cfg
+++ b/.kokoro-autosynth/nodejs-apiary.cfg
@@ -14,5 +14,5 @@
 
 env_vars: {
     key: "MULTISYNTH_CONFIG"
-    value: "config/nodejs-apiary.yaml"
+    value: ".kokoro-autosynth/node-apiary.yaml"
 }

--- a/config/node-apiary.yaml
+++ b/config/node-apiary.yaml
@@ -1,5 +1,0 @@
-libraries:
-
-- name: all
-  repository: googleapis/google-api-nodejs-client
-  branch-suffix: all


### PR DESCRIPTION
A configuration file was lost during the copy from gerrit to github.

Fixes https://github.com/googleapis/synthtool/issues/567