### PR TITLE
fix: don't fail when clean fails

### DIFF
--- a/autosynth/synth.py
+++ b/autosynth/synth.py
@@ -608,7 +608,7 @@ def _inner_main(temp_dir: str) -> int:
             # We're generating a single API in a single repo, and using a different
             # repo to generate the next API.  So the next synth will not be able to
             # use any of this state.  Clean it up to avoid running out of disk space.
-            executor.check_call(["git", "clean", "-fdx"], cwd=working_repo_path)
+            executor.run(["git", "clean", "-fdx"], cwd=working_repo_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In Ruby's autosynth, some files cannot be cleaned up because, well, I don't know.  But Ruby isn't leaving gigabytes of garbage around so it's not a problem.  So if if git clean is not able to clean up every last file, that should not cause autosynth to file a bug.

Fixes https://github.com/googleapis/synthtool/issues/568