### PR TITLE
chore(java): allow overriding minimum supported Java version in templates

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [7, 8, 11]
+        java: [{% if metadata['min_java_version'] <= 7 %}7, {% endif %}8, 11]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1

--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -114,7 +114,7 @@ To get help, follow the instructions in the [shared Troubleshooting document][tr
 
 ## Java Versions
 
-Java 7 or above is required for using this client.
+Java {{ metadata['min_java_version'] }} or above is required for using this client.
 
 ## Versioning
 
@@ -148,7 +148,7 @@ Apache 2.0 - See [LICENSE][license] for more information.
 
 Java Version | Status
 ------------ | ------
-Java 7 | [![Kokoro CI][kokoro-badge-image-1]][kokoro-badge-link-1]
+{% if metadata['min_java_version'] <= 7 %}Java 7 | [![Kokoro CI][kokoro-badge-image-1]][kokoro-badge-link-1]{% endif -%}
 Java 8 | [![Kokoro CI][kokoro-badge-image-2]][kokoro-badge-link-2]
 Java 8 OSX | [![Kokoro CI][kokoro-badge-image-3]][kokoro-badge-link-3]
 Java 8 Windows | [![Kokoro CI][kokoro-badge-image-4]][kokoro-badge-link-4]

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -58,6 +58,7 @@ BAD_LICENSE = """/\\*
  \\* the License.
  \\*/
 """
+DEFAULT_MIN_SUPPORTED_JAVA_VERSION = 7
 
 
 def format_code(
@@ -361,6 +362,10 @@ def common_templates(excludes: List[str] = [], **kwargs) -> None:
     metadata["snippets"] = snippets.all_snippets(
         ["samples/**/src/main/java/**/*.java", "samples/**/pom.xml"]
     )
+    if repo_metadata and "min_java_version" in repo_metadata:
+        metadata["min_java_version"] = repo_metadata["min_java_version"]
+    else:
+        metadata["min_java_version"] = DEFAULT_MIN_SUPPORTED_JAVA_VERSION
 
     kwargs["metadata"] = metadata
     templates = gcp.CommonTemplates().java_library(**kwargs)


### PR DESCRIPTION
Allows a repo maintainer to add a `min_java_version` in `.repo-metadata.json` which will:
* only run ci on Java 8+
* update the README accordingly