### PR TITLE
fix: longer autosynth timeouts for php and python

### DIFF
--- a/.kokoro-autosynth/php.cfg
+++ b/.kokoro-autosynth/php.cfg
@@ -21,3 +21,6 @@ env_vars: {
     key: "AUTOSYNTH_MULTIPLE_COMMITS"
     value: "true"
 }
+
+# bump the timeout for this job to 6 hours
+timeout_mins: 360

--- a/.kokoro-autosynth/python.cfg
+++ b/.kokoro-autosynth/python.cfg
@@ -16,3 +16,6 @@ env_vars: {
     key: "MULTISYNTH_CONFIG"
     value: "autosynth.providers.python"
 }
+
+# bump the timeout for this job to 6 hours
+timeout_mins: 360


### PR DESCRIPTION
both have recently timed out