### PR TITLE
chore(java_templates): add default CODEOWNERS files for samples reviews

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/CODEOWNERS
+++ b/synthtool/gcp/templates/java_library/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+# The java-samples-reviewers team is the default owner for samples changes
+samples/**/*.java       @googleapis/java-samples-reviewers

--- a/synthtool/gcp/templates/java_library/.github/CODEOWNERS
+++ b/synthtool/gcp/templates/java_library/.github/CODEOWNERS
@@ -4,5 +4,10 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
+{% if 'codeowner_team' in metadata['repo'] %}
+# The {{ metadata['repo']['codeowner_team'] }} is the default owner for changes in this repo
+**/*.java               {{ metadata['repo']['codeowner_team'] }}
+{% endif %}
+
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers

--- a/synthtool/gcp/templates/java_library/.github/CODEOWNERS
+++ b/synthtool/gcp/templates/java_library/.github/CODEOWNERS
@@ -3,11 +3,9 @@
 
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
-
 {% if 'codeowner_team' in metadata['repo'] %}
 # The {{ metadata['repo']['codeowner_team'] }} is the default owner for changes in this repo
 **/*.java               {{ metadata['repo']['codeowner_team'] }}
 {% endif %}
-
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers


### PR DESCRIPTION
This should automatically request reviews from the googleapis/java-samples-reviewers team for changes to samples Java code.

If you provide a `codeowner_team` in the `.repo-metadata.json` configuration file, it also adds an entry for any Java code. Note that later entries in the file take precedence over earlier ones so samples Java code will only require reviews by the samples team.