### PR TITLE
chore: turn on renovate-bot master issue for java repos

### DIFF
--- a/synthtool/gcp/templates/java_library/renovate.json
+++ b/synthtool/gcp/templates/java_library/renovate.json
@@ -76,5 +76,6 @@
       "groupName": "jackson dependencies"
     }
   ],
-  "semanticCommits": true
+  "semanticCommits": true,
+  "masterIssue": true
 }


### PR DESCRIPTION
to track renovate-bot status