### PR TITLE
fix: enable masterIssue for node so we get a renovate dashboard for each node repo

### DIFF
--- a/synthtool/gcp/templates/node_library/renovate.json
+++ b/synthtool/gcp/templates/node_library/renovate.json
@@ -15,5 +15,6 @@
       "groupName": "linters"
     }
   ],
-  "ignoreDeps": ["typescript"]
+  "ignoreDeps": ["typescript"],
+  "masterIssue": true
 }


### PR DESCRIPTION
This would enable an automatic (persistent) issue that looks like this:

https://github.com/GoogleCloudPlatform/python-docs-samples/issues/2653

Right now it's just an RFC, but if we like this, we can go ahead with it.

I'm also happy to manually test it on nodejs-pubsub to start with.
