### PR TITLE
fix: switch back to using the PYTHONPATH statement

### DIFF
--- a/synthtool/README.md
+++ b/synthtool/README.md
@@ -17,7 +17,7 @@ This tool helps to generate and layout cloud client libraries. Synthtool runs th
 
     ```
     cd synthtool
-    python3 -m pip install -e .
+    export PYTHONPATH=`pwd`
     ```
 
 


### PR DESCRIPTION
`pip install -e .` did not work as expected on Justin's machine, and synthtool failed.