### PR TITLE
fix: fix log path for single-commit, single-branch executions

### DIFF
--- a/autosynth/synth.py
+++ b/autosynth/synth.py
@@ -548,11 +548,15 @@ def _inner_main(temp_dir: str) -> int:
             if change_pusher.check_if_pr_already_exists(branch):
                 return 0
 
+            synth_log_path = base_synth_log_path
+            for arg in args.extra_args:
+                synth_log_path = synth_log_path / arg
+
             synth_log = Synthesizer(
                 metadata_path,
                 args.extra_args,
                 deprecated_execution=args.deprecated_execution,
-            ).synthesize(base_synth_log_path)
+            ).synthesize(synth_log_path / "sponge_log.log")
 
             if not has_changes():
                 logger.info("No changes. :)")

--- a/autosynth/synthesizer.py
+++ b/autosynth/synthesizer.py
@@ -101,6 +101,7 @@ class Synthesizer(AbstractSynthesizer):
             command = [sys.executable, self.synth_py_path]
 
         logger.info(command)
+        logger.debug(f"log_file_path: {log_file_path}")
 
         # Ensure the logfile directory exists
         log_file_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes #612 

For the non-multiple commit, non-multiple pull request autosynth runs (Java and Elixir apiaries), we were incorrectly using the base directory as the log file. Now we write to the base_log_directory and optionally expand the path for additional args (used to specify which client we're generating in the Java/Elixir case) and finally specify sponge_log.log as the output file name.