### PR TITLE
fix: only show link to output log for successful builds in sponge_log.xml

### DIFF
--- a/autosynth/multi.py
+++ b/autosynth/multi.py
@@ -96,6 +96,7 @@ def synthesize_library(
         "output": output.decode("utf-8"),
         "error": error,
         "skipped": skipped,
+        "log_url": _get_sponge_log_url(library["repository"]),
     }
 
 

--- a/report.xml.j2
+++ b/report.xml.j2
@@ -6,7 +6,7 @@
             {% if result.error %}
             <failure>{{result.output|e}}</failure>
             {% else %}
-            <system-out>{{result.output|e}}</system-out>
+            <system-out>Full log can be found at {{result.log_url}}</system-out>
             {% endif %}
         </testcase>
     </testsuite>

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -45,6 +45,7 @@ def test_synthesize_library_success():
     assert result["output"] == "success"
     assert result["error"] is False
     assert result["skipped"] is False
+    assert "test1" in result["log_url"]
 
 
 def test_synthesize_library_failure():
@@ -98,18 +99,21 @@ def test_make_report():
                 "output": "some output data",
                 "error": False,
                 "skipped": False,
+                "log_url": "http://sponge2/test1",
             },
             {
                 "name": "test2",
                 "output": "something failed",
                 "error": True,
                 "skipped": False,
+                "log_url": "http://sponge2/test2",
             },
             {
                 "name": "test3",
                 "output": "something skipped",
                 "error": False,
                 "skipped": True,
+                "log_url": "http://sponge2/test3",
             },
         ],
     )

--- a/tests/testdata/sponge-log-golden.xml
+++ b/tests/testdata/sponge-log-golden.xml
@@ -4,7 +4,7 @@
     <testsuite name="test1" tests="1" errors="0" failures="0" skipped="0">
         <testcase classname="test1" name="synthesize">
             
-            <system-out>some output data</system-out>
+            <system-out>Full log can be found at http://sponge2/test1</system-out>
             
         </testcase>
     </testsuite>
@@ -20,7 +20,7 @@
     <testsuite name="test3" tests="1" errors="0" failures="0" skipped="1">
         <testcase classname="test3" name="synthesize">
             
-            <system-out>something skipped</system-out>
+            <system-out>Full log can be found at http://sponge2/test3</system-out>
             
         </testcase>
     </testsuite>


### PR DESCRIPTION
This should prevent the log from getting too big. It's still possible if every build fails with a large log that we can hit the file size limit.