### PR TITLE
feat: add a dont_overwrite() function

### DIFF
--- a/synthtool/__init__.py
+++ b/synthtool/__init__.py
@@ -16,12 +16,12 @@
 
 import sys
 
-from synthtool.transforms import move, replace
+from synthtool.transforms import move, replace, dont_overwrite
 from synthtool.log import logger
 
 copy = move
 
-__all__ = ["copy", "move", "replace"]
+__all__ = ["copy", "move", "replace", "dont_overwrite"]
 
 # Make sure that synthtool is being used instead of running the synth file
 # directly

--- a/synthtool/transforms.py
+++ b/synthtool/transforms.py
@@ -138,6 +138,23 @@ def _copy_dir_to_existing_dir(
     return copied
 
 
+def dont_overwrite(patterns: ListOfPathsOrStrs,) -> Callable[[str, str, Path], str]:
+    """Returns a merge function that doesn't overwrite the specified files.
+
+    Pass the return value to move() or copy() to avoid overwriting existing
+    files.
+    """
+
+    def merge(source_text: str, destinaton_text: str, file_path: Path) -> str:
+        for pattern in patterns:
+            if file_path.match(str(pattern)):
+                logger.debug(f"Preserving existing contents of {file_path}.")
+                return destinaton_text
+        return source_text
+
+    return merge
+
+
 def move(
     sources: ListOfPathsOrStrs,
     destination: PathOrStr = None,


### PR DESCRIPTION
to make it easy to preserve existing file contents

Use it like this:
```py
    transforms.move(yada, yada, merge=transforms.dont_overwrite(["*.md"]))
```

Fixes https://github.com/googleapis/synthtool/issues/607

