### PR TITLE
fix: update dependency list completeness check to compare strictly compile scope deps

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
@@ -42,11 +42,11 @@ echo "****************** DEPENDENCY LIST COMPLETENESS CHECK *******************"
 function completenessCheck() {
   # Output dep list with compile scope generated using the original pom
   msg "Generating dependency list using original pom..."
-  mvn dependency:list -f pom.xml -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | grep -v ':test$' >.org-list.txt
+  mvn dependency:list -f pom.xml -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | grep ':compile$' >.org-list.txt
 
   # Output dep list generated using the flattened pom (test scope deps are ommitted)
   msg "Generating dependency list using flattened pom..."
-  mvn dependency:list -f .flattened-pom.xml -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' >.new-list.txt
+  mvn dependency:list -f .flattened-pom.xml -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | grep ':compile$' >.new-list.txt
 
   # Compare two dependency lists
   msg "Comparing dependency lists..."


### PR DESCRIPTION
to address dependencies.sh failures such as 
[the one in bigquerystorage](https://github.com/googleapis/java-bigquerystorage/pull/337/checks?check_run_id=756695981)

The root cause lies in the discrepancy in resolving provided scope transitive dep between `dependency:list` and maven flatten plugin