### PR TITLE
ci(java): switch to secret manager from keystore

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.sh
@@ -39,7 +39,7 @@ retry_with_backoff 3 10 \
 
 # if GOOGLE_APPLICATION_CREDIENTIALS is specified as a relative path prepend Kokoro root directory onto it
 if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
-    export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_ROOT}/src/${GOOGLE_APPLICATION_CREDENTIALS})
+    export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
 fi
 
 RETURN_CODE=0

--- a/synthtool/gcp/templates/java_library/.kokoro/nightly/samples.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/nightly/samples.cfg
@@ -24,19 +24,15 @@ env_vars: {
 
 env_vars: {
   key: "GOOGLE_APPLICATION_CREDENTIALS"
-  value: "keystore/73713_java_it_service_account"
+  value: "secret_manager/java-docs-samples-service-account"
 }
+
+env_vars: {
+￼  key: "SECRET_MANAGER_KEYS"
+￼  value: "java-docs-samples-service-account"
+￼}
 
 env_vars: {
   key: "ENABLE_BUILD_COP"
   value: "true"
-}
-
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "java_it_service_account"
-    }
-  }
 }

--- a/synthtool/gcp/templates/java_library/.kokoro/populate-secrets.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/populate-secrets.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function now { date +"%Y-%m-%d %H:%M:%S" | tr -d '\n' ;}
+function msg { println "$*" >&2 ;}
+function println { printf '%s\n' "$(now) $*" ;}
+
+
+# Populates requested secrets set in SECRET_MANAGER_KEYS from service account:
+# kokoro-trampoline@cloud-devrel-kokoro-resources.iam.gserviceaccount.com
+SECRET_LOCATION="${KOKORO_GFILE_DIR}/secret_manager"
+msg "Creating folder on disk for secrets: ${SECRET_LOCATION}"
+mkdir -p ${SECRET_LOCATION}
+for key in $(echo ${SECRET_MANAGER_KEYS} | sed "s/,/ /g")
+do
+  msg "Retrieving secret ${key}"
+  docker run --entrypoint=gcloud \
+    --volume=${KOKORO_GFILE_DIR}:${KOKORO_GFILE_DIR} \
+    gcr.io/google.com/cloudsdktool/cloud-sdk \
+    secrets versions access latest \
+    --credential-file-override=${KOKORO_GFILE_DIR}/kokoro-trampoline.service-account.json \
+    --project cloud-devrel-kokoro-resources \
+    --secret ${key} > \
+    "${SECRET_LOCATION}/${key}"
+  if [[ $? == 0 ]]; then
+    msg "Secret written to ${SECRET_LOCATION}/${key}"
+  else
+    msg "Error retrieving secret ${key}"
+  fi
+done

--- a/synthtool/gcp/templates/java_library/.kokoro/populate-secrets.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/populate-secrets.sh
@@ -32,7 +32,6 @@ do
     --volume=${KOKORO_GFILE_DIR}:${KOKORO_GFILE_DIR} \
     gcr.io/google.com/cloudsdktool/cloud-sdk \
     secrets versions access latest \
-    --credential-file-override=${KOKORO_GFILE_DIR}/kokoro-trampoline.service-account.json \
     --project cloud-devrel-kokoro-resources \
     --secret ${key} > \
     "${SECRET_LOCATION}/${key}"

--- a/synthtool/gcp/templates/java_library/.kokoro/presubmit/samples.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/presubmit/samples.cfg
@@ -24,14 +24,10 @@ env_vars: {
 
 env_vars: {
   key: "GOOGLE_APPLICATION_CREDENTIALS"
-  value: "keystore/73713_java_it_service_account"
+  value: "secret_manager/java-docs-samples-service-account"
 }
 
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "java_it_service_account"
-    }
-  }
-}
+env_vars: {
+￼  key: "SECRET_MANAGER_KEYS"
+￼  value: "java-docs-samples-service-account"
+￼}

--- a/synthtool/gcp/templates/java_library/.kokoro/trampoline.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/trampoline.sh
@@ -21,4 +21,6 @@ function cleanup() {
     echo "cleanup";
 }
 trap cleanup EXIT
+
+$(dirname $0)/populate-secrets.sh # Secret Manager secrets.
 python3 "${KOKORO_GFILE_DIR}/trampoline_v1.py"


### PR DESCRIPTION
Also use java-docs-samples user for samples tests.

Prototyped in https://github.com/googleapis/java-document-ai/pull/100. This API requires that the service account be owned by the project that is owns the resources.