### PR TITLE
samples(java): fix bad character in samples.cfg from copy/paste

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/nightly/samples.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/nightly/samples.cfg
@@ -28,9 +28,9 @@ env_vars: {
 }
 
 env_vars: {
-￼  key: "SECRET_MANAGER_KEYS"
-￼  value: "java-docs-samples-service-account"
-￼}
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-docs-samples-service-account"
+}
 
 env_vars: {
   key: "ENABLE_BUILD_COP"

--- a/synthtool/gcp/templates/java_library/.kokoro/presubmit/samples.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/presubmit/samples.cfg
@@ -28,6 +28,6 @@ env_vars: {
 }
 
 env_vars: {
-￼  key: "SECRET_MANAGER_KEYS"
-￼  value: "java-docs-samples-service-account"
-￼}
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-docs-samples-service-account"
+}


### PR DESCRIPTION
Somehow an invisible character was copy/pasted into the file and Kokoro
cannot parse the file.