### PR TITLE
fix(python): change autodoc_default_flags to autodoc_default_options in python doc template

### DIFF
--- a/synthtool/gcp/templates/python_library/docs/conf.py.j2
+++ b/synthtool/gcp/templates/python_library/docs/conf.py.j2
@@ -43,7 +43,7 @@ extensions = [
 
 # autodoc/autosummary flags
 autoclass_content = "both"
-autodoc_default_flags = ["members"]
+autodoc_default_options = {"members": True}
 autosummary_generate = True
 
 


### PR DESCRIPTION
-> Sphinx has  deprecated  the flag `autodoc_default_flags` in 1.8 version and now they are going to remove in `4.0` version and suggest alternative `autodoc_default_options`, found in their documentation   https://readthedocs.org/projects/sphinx/downloads/pdf/master/  and module is `7.5.13 Deprecated APIs`

-> This change is needed to solve Bigquey documentation issue https://github.com/googleapis/python-bigquery/issues/138 