### PR TITLE
fix: set default timeout to 5 hours

### DIFF
--- a/.kokoro-autosynth/common.cfg
+++ b/.kokoro-autosynth/common.cfg
@@ -45,3 +45,6 @@ env_vars: {
     key: "GITHUB_EMAIL"
     value: "yoshi-automation@google.com"
 }
+
+# Bump the default timeout up to 5 hours.
+timeout_mins: 300


### PR DESCRIPTION
nodejs timed-out last night after 3 hours