### PR TITLE
ci(java): run dependency test on Java 8 and 11

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -36,11 +36,14 @@ jobs:
         JOB_TYPE: test
   dependencies:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: ${{matrix.java}}
     - run: java -version
     - run: .kokoro/dependencies.sh
   linkage-monitor:

--- a/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
@@ -41,6 +41,8 @@ echo "****************** DEPENDENCY LIST COMPLETENESS CHECK *******************"
 ## Run dependency list completeness check
 function completenessCheck() {
   # Output dep list with compile scope generated using the original pom
+  # Running mvn dependency:list on Java versions that support modules will also include the module of the dependency.
+  # This is stripped from the output as it is not present in the flattened pom.
   msg "Generating dependency list using original pom..."
   mvn dependency:list -f pom.xml -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | sed -e s/\\s--\\smodule.*// | grep -v ':test$' >.org-list.txt
 

--- a/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
@@ -42,7 +42,7 @@ echo "****************** DEPENDENCY LIST COMPLETENESS CHECK *******************"
 function completenessCheck() {
   # Output dep list with compile scope generated using the original pom
   msg "Generating dependency list using original pom..."
-  mvn dependency:list -f pom.xml -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | grep -v ':test$' >.org-list.txt
+  mvn dependency:list -f pom.xml -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | sed -e s/\\s--\\smodule.*// | grep -v ':test$' >.org-list.txt
 
   # Output dep list generated using the flattened pom (test scope deps are ommitted)
   msg "Generating dependency list using flattened pom..."


### PR DESCRIPTION
Executes the dependency tests on both Java 8 and Java 11 to prevent potential failures to go undetected when dependencies are only added for certain Java versions. See also https://github.com/googleapis/java-spanner/pull/281.