### PR TITLE
ci(java): fix jinja syntax for escaping curly braces

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: ${{matrix.java}}
+        java-version: ${{'{{matrix.java}}'}}
     - run: java -version
     - run: .kokoro/dependencies.sh
   linkage-monitor:


### PR DESCRIPTION
The file output needs `{{matrix.java}}`, but `{{` is being interpreted as variable interpolation for jinja.