### PR TITLE
Revert "ci(java): run dependency test on Java 8 and 11 (#633)"

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -36,14 +36,11 @@ jobs:
         JOB_TYPE: test
   dependencies:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [8, 11]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: ${{matrix.java}}
+        java-version: 8
     - run: java -version
     - run: .kokoro/dependencies.sh
   linkage-monitor:

--- a/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
@@ -41,10 +41,8 @@ echo "****************** DEPENDENCY LIST COMPLETENESS CHECK *******************"
 ## Run dependency list completeness check
 function completenessCheck() {
   # Output dep list with compile scope generated using the original pom
-  # Running mvn dependency:list on Java versions that support modules will also include the module of the dependency.
-  # This is stripped from the output as it is not present in the flattened pom.
   msg "Generating dependency list using original pom..."
-  mvn dependency:list -f pom.xml -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | sed -e s/\\s--\\smodule.*// | grep -v ':test$' >.org-list.txt
+  mvn dependency:list -f pom.xml -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | grep -v ':test$' >.org-list.txt
 
   # Output dep list generated using the flattened pom (test scope deps are ommitted)
   msg "Generating dependency list using flattened pom..."


### PR DESCRIPTION
This reverts commit 84f8ec7ff1885e00582b32a21cd21a481d25e591.

It broke the tests:
https://source.cloud.google.com/results/invocations/5c6ddabc-c5c9-43da-b82b-0d7313fbcbeb