### PR TITLE
feat: allow injecting template path as an argument

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -31,10 +31,12 @@ LOCAL_TEMPLATES: Optional[str] = os.environ.get("SYNTHTOOL_TEMPLATES")
 
 
 class CommonTemplates:
-    def __init__(self):
-        if LOCAL_TEMPLATES:
+    def __init__(self, template_path: Optional[Path] = None):
+        if template_path:
+            self._template_root = template_path
+        elif LOCAL_TEMPLATES:
             logger.debug(f"Using local templates at {LOCAL_TEMPLATES}")
-            self._template_root = LOCAL_TEMPLATES
+            self._template_root = Path(LOCAL_TEMPLATES)
         else:
             templates_git = git.clone(TEMPLATES_URL)
             self._template_root = templates_git / DEFAULT_TEMPLATES_PATH
@@ -51,9 +53,7 @@ class CommonTemplates:
             if "samples" not in kwargs["metadata"] or not kwargs["metadata"]["samples"]:
                 self.excludes.append("samples/README.md")
 
-        t = templates.TemplateGroup(
-            Path(self._template_root) / directory, self.excludes
-        )
+        t = templates.TemplateGroup(self._template_root / directory, self.excludes)
         result = t.render(**kwargs)
         _tracked_paths.add(result)
 

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -333,7 +333,9 @@ def _merge_common_templates(
     return source_text
 
 
-def common_templates(excludes: List[str] = [], **kwargs) -> None:
+def common_templates(
+    excludes: List[str] = [], template_path: Optional[Path] = None, **kwargs
+) -> None:
     """Generate common templates for a Java Library
 
     Fetches information about the repository from the .repo-metadata.json file,
@@ -368,5 +370,5 @@ def common_templates(excludes: List[str] = [], **kwargs) -> None:
         metadata["min_java_version"] = DEFAULT_MIN_SUPPORTED_JAVA_VERSION
 
     kwargs["metadata"] = metadata
-    templates = gcp.CommonTemplates().java_library(**kwargs)
+    templates = gcp.CommonTemplates(template_path=template_path).java_library(**kwargs)
     s.copy([templates], excludes=excludes, merge=_merge_common_templates)

--- a/tests/test_language_java.py
+++ b/tests/test_language_java.py
@@ -23,6 +23,7 @@ import requests_mock
 import pytest
 
 FIXTURES = Path(__file__).parent / "fixtures"
+TEMPLATES_PATH = Path(__file__).parent.parent / "synthtool" / "gcp" / "templates"
 
 SAMPLE_METADATA = """
 <metadata>
@@ -91,7 +92,7 @@ def test_working_common_templates():
 
         try:
             # generate the common templates
-            java.common_templates()
+            java.common_templates(template_path=TEMPLATES_PATH)
             assert os.path.isfile("README.md")
 
             # ensure pom.xml files are valid XML


### PR DESCRIPTION
This also fixes the Java template test to use local templates for the test.