### PR TITLE
chore(python): fix line breaks in template and use newer black version

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -75,7 +75,7 @@ def default(session):
 
     {%- if microgenerator %}
     session.install("asyncmock", "pytest-asyncio")
-    {% endif -%}
+    {% endif %}
     session.install("mock", "pytest", "pytest-cov")
     session.install("-e", "."){% for dependency in unit_test_dependencies %}
     session.install("-e", "{{dependency}}"){% endfor %}

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -23,7 +23,7 @@ import shutil
 import nox
 
 
-BLACK_VERSION = "black==19.3b0"
+BLACK_VERSION = "black==19.10b0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 DEFAULT_PYTHON_VERSION="{{ default_python_version }}" 


### PR DESCRIPTION
`session.install("mock", "pytest", "pytest-cov")` gets appended onto the previous line

It also appears we need to bump the black version to avoid running into https://github.com/psf/black/issues/875