### PR TITLE
fix: set idle timeout for bazel to 240 seconds

### DIFF
--- a/synthtool/gcp/gapic_bazel.py
+++ b/synthtool/gcp/gapic_bazel.py
@@ -171,7 +171,7 @@ class GAPICBazel:
 
         bazel_run_args = [
             "bazel",
-            "--max_idle_secs=60",
+            "--max_idle_secs=240",
             "build",
             bazel_target,
         ]


### PR DESCRIPTION
For Node.js builds, postprocessing takes longer than a minute (`npm install`, linting, and formatting can be slow), so let's bump this idle timeout to 4 minutes to make sure the Bazel instance is reused. I'm not aware of any possible negative consequence of having this bumped.