### PR TITLE
fix: typo in nodejs .gitattribute

### DIFF
--- a/synthtool/gcp/templates/node_library/.gitattributes
+++ b/synthtool/gcp/templates/node_library/.gitattributes
@@ -1,3 +1,3 @@
 *.ts text eol=lf
-*.js test eol=lf
+*.js text eol=lf
 protos/* linguist-generated


### PR DESCRIPTION
replace `test` to `text`