### PR TITLE
fix: fix cov_level issue

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -91,6 +91,10 @@ class CommonTemplates:
                     "system_test_python_versions"
                 ]
 
+        # If cov_level is not given, set it to None.
+        if "cov_level" not in kwargs:
+            kwargs["cov_level"] = None
+
         # Don't add samples templates if there are no samples
         if "samples" not in kwargs:
             self.excludes += ["samples/AUTHORING_GUIDE.md", "samples/CONTRIBUTING.md"]


### PR DESCRIPTION
if `cov_level` is not provided `common.py_library`, then it will be an undefined variable in [cover section in noxfile.py.j2](https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/noxfile.py.j2#L164). Therefore, `--fail-under={{ cov_level if cov_level != None else '100' }}` will become `--fail-under=` instead of `--fail-under=100`.

The fix is to set `cov_level` to None if not provided.