### PR TITLE
fix: extend nodejs autosynth timeout by 2 hours

### DIFF
--- a/.kokoro-autosynth/nodejs.cfg
+++ b/.kokoro-autosynth/nodejs.cfg
@@ -27,6 +27,6 @@ env_vars: {
     value: "true"
 }
 
-timeout_mins: 300
+timeout_mins: 420
 
 build_file: "synthtool/.kokoro-autosynth/nodejs-build.sh"


### PR DESCRIPTION
Recent kokoro jobs have been timing out after completing about 90% of the APIs.