### PR TITLE
fix: re-enable obsolete tracking with a new strategy

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -37,6 +37,6 @@ def lint(session):
 
 @nox.session(python=['3.6', '3.8'])
 def test(session):
-    session.install('pytest', 'pytest-cov', 'requests_mock')
+    session.install('pytest', 'pytest-cov', 'requests_mock', 'watchdog')
     session.run('pip', 'install', '-e', '.')
     session.run('pytest', '--cov-report', 'term-missing', '--cov', 'autosynth', 'synthtool', 'tests', *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@
 
 import nox
 
-@nox.session(python=['3.6', '3.8'])
+@nox.session(python=['3.6'])
 def generate_protos(session):
     session.install("grpcio-tools")
     session.run(

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pyyaml
 jinja2
 deprecation
 protobuf
+watchdog
 
 # some java processing requires xml handling
 lxml

--- a/synthtool/metadata.py
+++ b/synthtool/metadata.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import deprecation
 import locale
 import os
 import pathlib
@@ -20,15 +19,26 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import List, Iterable, Dict
+import time
+import threading
+from typing import Dict, Iterable, List
 
 import google.protobuf.json_format
+import watchdog.events
+import watchdog.observers
 
 from synthtool.log import logger
 from synthtool.protos import metadata_pb2
 
-
 _metadata = metadata_pb2.Metadata()
+
+
+def get_environment_bool(var_name: str) -> bool:
+    val = os.environ.get(var_name)
+    return False if not val or val.lower() == "false" else True
+
+
+_track_obsolete_files = get_environment_bool("SYNTHTOOL_TRACK_OBSOLETE_FILES")
 
 
 def reset() -> None:
@@ -61,38 +71,9 @@ def add_client_destination(**kwargs) -> None:
     _metadata.destinations.add(client=metadata_pb2.ClientDestination(**kwargs))
 
 
-def _add_new_files(files: Iterable[str]) -> None:
-    for filepath in sorted(files):
-        new_file = _metadata.new_files.add()
-        new_file.path = _git_slashes(filepath)
-
-
 def _git_slashes(path: str):
     # git speaks only forward slashes
     return path.replace("\\", "/") if sys.platform == "win32" else path
-
-
-def _get_new_files(newer_than: float) -> List[str]:
-    """Searchs current directory for new files and returns them in a list.
-
-    Parameters:
-        newer_than: any file modified after this timestamp (from time.time())
-            will be added to the metadata
-    """
-    new_files = []
-    for (root, dirs, files) in os.walk(os.getcwd()):
-        for filename in files:
-            filepath = os.path.join(root, filename)
-            try:
-                mtime = os.path.getmtime(filepath)
-            except FileNotFoundError:
-                logger.warning(
-                    f"FileNotFoundError while getting modified time for {filepath}."
-                )
-                continue
-            if mtime >= newer_than:
-                new_files.append(os.path.relpath(filepath))
-    return new_files
 
 
 def _read_or_empty(path: str = "synth.metadata"):
@@ -115,7 +96,26 @@ def write(outfile: str = "synth.metadata") -> None:
     logger.debug(f"Wrote metadata to {outfile}.")
 
 
-@deprecation.deprecated(deprecated_in="2020.02.04")
+def _remove_obsolete_files(old_metadata):
+    """Remove obsolete files from the file system.
+
+    Call add_new_files() before this function or it will remove all generated
+    files.
+
+    Parameters:
+        old_metadata:  old metadata loaded from a call to read_or_empty().
+    """
+    old_files = set(old_metadata.generated_files)
+    new_files = set(_metadata.generated_files)
+    obsolete_files = old_files - new_files
+    for file_path in git_ignore(obsolete_files):
+        try:
+            logger.info(f"Removing obsolete file {file_path}...")
+            os.unlink(file_path)
+        except FileNotFoundError:
+            pass  # Already deleted.  That's OK.
+
+
 def git_ignore(file_paths: Iterable[str]):
     """Returns a new list of the same files, with ignored files removed."""
     # Surprisingly, git check-ignore doesn't ignore .git directories, take those
@@ -153,14 +153,48 @@ def git_ignore(file_paths: Iterable[str]):
     ]
 
 
-@deprecation.deprecated(deprecated_in="2020.02.04")
-def set_track_obsolete_files(ignored=True):
-    pass
+def set_track_obsolete_files(track_obsolete_files=True):
+    """Instructs synthtool to track and remove obsolete files."""
+    global _track_obsolete_files
+    _track_obsolete_files = track_obsolete_files
 
 
-@deprecation.deprecated(deprecated_in="2020.02.04")
 def should_track_obsolete_files():
-    return False
+    return _track_obsolete_files
+
+
+class FileSystemEventHandler(watchdog.events.FileSystemEventHandler):
+    """Records all the files that were touched."""
+
+    def __init__(self, watch_dir: pathlib.Path):
+        super().__init__()
+        self._touched_file_paths: List[str] = list()
+        self._touched_lock = threading.Lock()
+        self._watch_dir = watch_dir
+
+    def on_any_event(self, event):
+        if event.is_directory:
+            return
+        if event.event_type in (
+            watchdog.events.EVENT_TYPE_MODIFIED,
+            watchdog.events.EVENT_TYPE_CREATED,
+        ):
+            touched_path = event.src_path
+        elif event.event_type == watchdog.events.EVENT_TYPE_MOVED:
+            touched_path = event.dest_path
+        else:
+            return
+        touched_path = pathlib.Path(touched_path).relative_to(self._watch_dir)
+        with self._touched_lock:
+            self._touched_file_paths.append(str(touched_path))
+
+    def get_touched_file_paths(self) -> List[str]:
+        # deduplicate and sort
+        with self._touched_lock:
+            paths = set(self._touched_file_paths)
+        result = list(paths)
+        result.sort()
+        return result
 
 
 class MetadataTrackerAndWriter:
@@ -172,8 +206,22 @@ class MetadataTrackerAndWriter:
     def __enter__(self):
         self.old_metadata = _read_or_empty(self.metadata_file_path)
         _add_self_git_source()
+        watch_dir = pathlib.Path(self.metadata_file_path).parent
+        self.handler = FileSystemEventHandler(watch_dir)
+        self.observer = watchdog.observers.Observer()
+        self.observer.schedule(self.handler, str(watch_dir), recursive=True)
+        self.observer.start()
 
     def __exit__(self, type, value, traceback):
+        if should_track_obsolete_files():
+            time.sleep(2)  # Finish collecting observations about modified files.
+            self.observer.stop()
+            self.observer.join()
+            for path in git_ignore(self.handler.get_touched_file_paths()):
+                _metadata.generated_files.append(path)
+            _remove_obsolete_files(self.old_metadata)
+        else:
+            self.observer.stop()
         _clear_local_paths(get())
         _metadata.sources.sort(key=_source_key)
         if _enable_write_metadata:

--- a/synthtool/protos/metadata.proto
+++ b/synthtool/protos/metadata.proto
@@ -25,6 +25,7 @@ message Metadata {
     repeated Source sources = 2;
     repeated Destination destinations = 3;
     repeated NewFile new_files = 4 [deprecated=true];
+    repeated string generated_files = 5;
 }
 
 message Source {

--- a/synthtool/protos/metadata_pb2.py
+++ b/synthtool/protos/metadata_pb2.py
@@ -20,7 +20,8 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     package="yoshi.synth.metadata",
     syntax="proto3",
     serialized_options=None,
-    serialized_pb=b'\n\x0emetadata.proto\x12\x14yoshi.synth.metadata\x1a\x1fgoogle/protobuf/timestamp.proto"\xdd\x01\n\x08Metadata\x12\x33\n\x0bupdate_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.TimestampB\x02\x18\x01\x12-\n\x07sources\x18\x02 \x03(\x0b\x32\x1c.yoshi.synth.metadata.Source\x12\x37\n\x0c\x64\x65stinations\x18\x03 \x03(\x0b\x32!.yoshi.synth.metadata.Destination\x12\x34\n\tnew_files\x18\x04 \x03(\x0b\x32\x1d.yoshi.synth.metadata.NewFileB\x02\x18\x01"\xb8\x01\n\x06Source\x12.\n\x03git\x18\x01 \x01(\x0b\x32\x1f.yoshi.synth.metadata.GitSourceH\x00\x12:\n\tgenerator\x18\x02 \x01(\x0b\x32%.yoshi.synth.metadata.GeneratorSourceH\x00\x12\x38\n\x08template\x18\x03 \x01(\x0b\x32$.yoshi.synth.metadata.TemplateSourceH\x00\x42\x08\n\x06source"m\n\tGitSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06remote\x18\x02 \x01(\t\x12\x0b\n\x03sha\x18\x03 \x01(\t\x12\x14\n\x0cinternal_ref\x18\x04 \x01(\t\x12\x12\n\nlocal_path\x18\x05 \x01(\t\x12\x0b\n\x03log\x18\x06 \x01(\t"F\n\x0fGeneratorSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x14\n\x0c\x64ocker_image\x18\x03 \x01(\t"?\n\x0eTemplateSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06origin\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t"\x94\x01\n\x0b\x44\x65stination\x12\x39\n\x06\x63lient\x18\x01 \x01(\x0b\x32\'.yoshi.synth.metadata.ClientDestinationH\x00\x12;\n\x07\x66ileset\x18\x02 \x01(\x0b\x32(.yoshi.synth.metadata.FileSetDestinationH\x00\x42\r\n\x0b\x44\x65stination"\x17\n\x07NewFile\x12\x0c\n\x04path\x18\x01 \x01(\t"\x7f\n\x11\x43lientDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x10\n\x08\x61pi_name\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_version\x18\x03 \x01(\t\x12\x10\n\x08language\x18\x04 \x01(\t\x12\x11\n\tgenerator\x18\x05 \x01(\t\x12\x0e\n\x06\x63onfig\x18\x06 \x01(\t"3\n\x12\x46ileSetDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\r\n\x05\x66iles\x18\x02 \x03(\tb\x06proto3',
+    create_key=_descriptor._internal_create_key,
+    serialized_pb=b'\n\x0emetadata.proto\x12\x14yoshi.synth.metadata\x1a\x1fgoogle/protobuf/timestamp.proto"\xf6\x01\n\x08Metadata\x12\x33\n\x0bupdate_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.TimestampB\x02\x18\x01\x12-\n\x07sources\x18\x02 \x03(\x0b\x32\x1c.yoshi.synth.metadata.Source\x12\x37\n\x0c\x64\x65stinations\x18\x03 \x03(\x0b\x32!.yoshi.synth.metadata.Destination\x12\x34\n\tnew_files\x18\x04 \x03(\x0b\x32\x1d.yoshi.synth.metadata.NewFileB\x02\x18\x01\x12\x17\n\x0fgenerated_files\x18\x05 \x03(\t"\xb8\x01\n\x06Source\x12.\n\x03git\x18\x01 \x01(\x0b\x32\x1f.yoshi.synth.metadata.GitSourceH\x00\x12:\n\tgenerator\x18\x02 \x01(\x0b\x32%.yoshi.synth.metadata.GeneratorSourceH\x00\x12\x38\n\x08template\x18\x03 \x01(\x0b\x32$.yoshi.synth.metadata.TemplateSourceH\x00\x42\x08\n\x06source"m\n\tGitSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06remote\x18\x02 \x01(\t\x12\x0b\n\x03sha\x18\x03 \x01(\t\x12\x14\n\x0cinternal_ref\x18\x04 \x01(\t\x12\x12\n\nlocal_path\x18\x05 \x01(\t\x12\x0b\n\x03log\x18\x06 \x01(\t"F\n\x0fGeneratorSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x14\n\x0c\x64ocker_image\x18\x03 \x01(\t"?\n\x0eTemplateSource\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06origin\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\t"\x94\x01\n\x0b\x44\x65stination\x12\x39\n\x06\x63lient\x18\x01 \x01(\x0b\x32\'.yoshi.synth.metadata.ClientDestinationH\x00\x12;\n\x07\x66ileset\x18\x02 \x01(\x0b\x32(.yoshi.synth.metadata.FileSetDestinationH\x00\x42\r\n\x0b\x44\x65stination"\x17\n\x07NewFile\x12\x0c\n\x04path\x18\x01 \x01(\t"\x7f\n\x11\x43lientDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\x10\n\x08\x61pi_name\x18\x02 \x01(\t\x12\x13\n\x0b\x61pi_version\x18\x03 \x01(\t\x12\x10\n\x08language\x18\x04 \x01(\t\x12\x11\n\tgenerator\x18\x05 \x01(\t\x12\x0e\n\x06\x63onfig\x18\x06 \x01(\t"3\n\x12\x46ileSetDestination\x12\x0e\n\x06source\x18\x01 \x01(\t\x12\r\n\x05\x66iles\x18\x02 \x03(\tb\x06proto3',
     dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,],
 )
 
@@ -31,6 +32,7 @@ _METADATA = _descriptor.Descriptor(
     filename=None,
     file=DESCRIPTOR,
     containing_type=None,
+    create_key=_descriptor._internal_create_key,
     fields=[
         _descriptor.FieldDescriptor(
             name="update_time",
@@ -49,6 +51,7 @@ _METADATA = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=b"\030\001",
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="sources",
@@ -67,6 +70,7 @@ _METADATA = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="destinations",
@@ -85,6 +89,7 @@ _METADATA = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="new_files",
@@ -103,6 +108,26 @@ _METADATA = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=b"\030\001",
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="generated_files",
+            full_name="yoshi.synth.metadata.Metadata.generated_files",
+            index=4,
+            number=5,
+            type=9,
+            cpp_type=9,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
     ],
     extensions=[],
@@ -114,7 +139,7 @@ _METADATA = _descriptor.Descriptor(
     extension_ranges=[],
     oneofs=[],
     serialized_start=74,
-    serialized_end=295,
+    serialized_end=320,
 )
 
 
@@ -124,6 +149,7 @@ _SOURCE = _descriptor.Descriptor(
     filename=None,
     file=DESCRIPTOR,
     containing_type=None,
+    create_key=_descriptor._internal_create_key,
     fields=[
         _descriptor.FieldDescriptor(
             name="git",
@@ -142,6 +168,7 @@ _SOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="generator",
@@ -160,6 +187,7 @@ _SOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="template",
@@ -178,6 +206,7 @@ _SOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
     ],
     extensions=[],
@@ -193,11 +222,12 @@ _SOURCE = _descriptor.Descriptor(
             full_name="yoshi.synth.metadata.Source.source",
             index=0,
             containing_type=None,
+            create_key=_descriptor._internal_create_key,
             fields=[],
         ),
     ],
-    serialized_start=298,
-    serialized_end=482,
+    serialized_start=323,
+    serialized_end=507,
 )
 
 
@@ -207,6 +237,7 @@ _GITSOURCE = _descriptor.Descriptor(
     filename=None,
     file=DESCRIPTOR,
     containing_type=None,
+    create_key=_descriptor._internal_create_key,
     fields=[
         _descriptor.FieldDescriptor(
             name="name",
@@ -225,6 +256,7 @@ _GITSOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="remote",
@@ -243,6 +275,7 @@ _GITSOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="sha",
@@ -261,6 +294,7 @@ _GITSOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="internal_ref",
@@ -279,6 +313,7 @@ _GITSOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="local_path",
@@ -297,6 +332,7 @@ _GITSOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="log",
@@ -315,6 +351,7 @@ _GITSOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
     ],
     extensions=[],
@@ -325,8 +362,8 @@ _GITSOURCE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=484,
-    serialized_end=593,
+    serialized_start=509,
+    serialized_end=618,
 )
 
 
@@ -336,6 +373,7 @@ _GENERATORSOURCE = _descriptor.Descriptor(
     filename=None,
     file=DESCRIPTOR,
     containing_type=None,
+    create_key=_descriptor._internal_create_key,
     fields=[
         _descriptor.FieldDescriptor(
             name="name",
@@ -354,6 +392,7 @@ _GENERATORSOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="version",
@@ -372,6 +411,7 @@ _GENERATORSOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="docker_image",
@@ -390,6 +430,7 @@ _GENERATORSOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
     ],
     extensions=[],
@@ -400,8 +441,8 @@ _GENERATORSOURCE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=595,
-    serialized_end=665,
+    serialized_start=620,
+    serialized_end=690,
 )
 
 
@@ -411,6 +452,7 @@ _TEMPLATESOURCE = _descriptor.Descriptor(
     filename=None,
     file=DESCRIPTOR,
     containing_type=None,
+    create_key=_descriptor._internal_create_key,
     fields=[
         _descriptor.FieldDescriptor(
             name="name",
@@ -429,6 +471,7 @@ _TEMPLATESOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="origin",
@@ -447,6 +490,7 @@ _TEMPLATESOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="version",
@@ -465,6 +509,7 @@ _TEMPLATESOURCE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
     ],
     extensions=[],
@@ -475,8 +520,8 @@ _TEMPLATESOURCE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=667,
-    serialized_end=730,
+    serialized_start=692,
+    serialized_end=755,
 )
 
 
@@ -486,6 +531,7 @@ _DESTINATION = _descriptor.Descriptor(
     filename=None,
     file=DESCRIPTOR,
     containing_type=None,
+    create_key=_descriptor._internal_create_key,
     fields=[
         _descriptor.FieldDescriptor(
             name="client",
@@ -504,6 +550,7 @@ _DESTINATION = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="fileset",
@@ -522,6 +569,7 @@ _DESTINATION = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
     ],
     extensions=[],
@@ -537,11 +585,12 @@ _DESTINATION = _descriptor.Descriptor(
             full_name="yoshi.synth.metadata.Destination.Destination",
             index=0,
             containing_type=None,
+            create_key=_descriptor._internal_create_key,
             fields=[],
         ),
     ],
-    serialized_start=733,
-    serialized_end=881,
+    serialized_start=758,
+    serialized_end=906,
 )
 
 
@@ -551,6 +600,7 @@ _NEWFILE = _descriptor.Descriptor(
     filename=None,
     file=DESCRIPTOR,
     containing_type=None,
+    create_key=_descriptor._internal_create_key,
     fields=[
         _descriptor.FieldDescriptor(
             name="path",
@@ -569,6 +619,7 @@ _NEWFILE = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
     ],
     extensions=[],
@@ -579,8 +630,8 @@ _NEWFILE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=883,
-    serialized_end=906,
+    serialized_start=908,
+    serialized_end=931,
 )
 
 
@@ -590,6 +641,7 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
     filename=None,
     file=DESCRIPTOR,
     containing_type=None,
+    create_key=_descriptor._internal_create_key,
     fields=[
         _descriptor.FieldDescriptor(
             name="source",
@@ -608,6 +660,7 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="api_name",
@@ -626,6 +679,7 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="api_version",
@@ -644,6 +698,7 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="language",
@@ -662,6 +717,7 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="generator",
@@ -680,6 +736,7 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="config",
@@ -698,6 +755,7 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
     ],
     extensions=[],
@@ -708,8 +766,8 @@ _CLIENTDESTINATION = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=908,
-    serialized_end=1035,
+    serialized_start=933,
+    serialized_end=1060,
 )
 
 
@@ -719,6 +777,7 @@ _FILESETDESTINATION = _descriptor.Descriptor(
     filename=None,
     file=DESCRIPTOR,
     containing_type=None,
+    create_key=_descriptor._internal_create_key,
     fields=[
         _descriptor.FieldDescriptor(
             name="source",
@@ -737,6 +796,7 @@ _FILESETDESTINATION = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="files",
@@ -755,6 +815,7 @@ _FILESETDESTINATION = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
     ],
     extensions=[],
@@ -765,8 +826,8 @@ _FILESETDESTINATION = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=1037,
-    serialized_end=1088,
+    serialized_start=1062,
+    serialized_end=1113,
 )
 
 _METADATA.fields_by_name[

--- a/synthtool/protos/preconfig_pb2.py
+++ b/synthtool/protos/preconfig_pb2.py
@@ -17,6 +17,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     package="yoshi.synth.preconfig",
     syntax="proto3",
     serialized_options=None,
+    create_key=_descriptor._internal_create_key,
     serialized_pb=b'\n\x0fpreconfig.proto\x12\x15yoshi.synth.preconfig"\x91\x01\n\tPreconfig\x12M\n\x0fprecloned_repos\x18\x01 \x03(\x0b\x32\x34.yoshi.synth.preconfig.Preconfig.PreclonedReposEntry\x1a\x35\n\x13PreclonedReposEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x62\x06proto3',
 )
 
@@ -27,6 +28,7 @@ _PRECONFIG_PRECLONEDREPOSENTRY = _descriptor.Descriptor(
     filename=None,
     file=DESCRIPTOR,
     containing_type=None,
+    create_key=_descriptor._internal_create_key,
     fields=[
         _descriptor.FieldDescriptor(
             name="key",
@@ -45,6 +47,7 @@ _PRECONFIG_PRECLONEDREPOSENTRY = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
             name="value",
@@ -63,6 +66,7 @@ _PRECONFIG_PRECLONEDREPOSENTRY = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
     ],
     extensions=[],
@@ -83,6 +87,7 @@ _PRECONFIG = _descriptor.Descriptor(
     filename=None,
     file=DESCRIPTOR,
     containing_type=None,
+    create_key=_descriptor._internal_create_key,
     fields=[
         _descriptor.FieldDescriptor(
             name="precloned_repos",
@@ -101,6 +106,7 @@ _PRECONFIG = _descriptor.Descriptor(
             extension_scope=None,
             serialized_options=None,
             file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
         ),
     ],
     extensions=[],

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -15,9 +15,11 @@
 import json
 import os
 import pathlib
-import pytest
 import shutil
 import subprocess
+import sys
+
+import pytest
 
 from synthtool import metadata
 from synthtool.tmp import tmpdir
@@ -134,6 +136,105 @@ def source_tree():
     os.chdir(cwd)
 
 
+def test_new_files_found(source_tree, preserve_track_obsolete_file_flag):
+    metadata.set_track_obsolete_files(True)
+    source_tree.write("a")
+    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
+        source_tree.write("code/b")
+
+    # Confirm add_new_files found the new files and ignored the old one.
+    new_file_paths = [path for path in metadata.get().generated_files]
+    assert ["code/b"] == new_file_paths
+
+
+def test_gitignored_files_ignored(source_tree, preserve_track_obsolete_file_flag):
+    metadata.set_track_obsolete_files(True)
+    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
+        source_tree.write("code/b")
+        source_tree.write("code/c")
+        source_tree.write(".gitignore", "code/c\n")
+
+    # Confirm add_new_files found the new files and ignored one.
+    new_file_paths = [path for path in metadata.get().generated_files]
+    assert [".gitignore", "code/b"] == new_file_paths
+
+
+def test_old_file_removed(source_tree, preserve_track_obsolete_file_flag):
+    metadata.set_track_obsolete_files(True)
+
+    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
+        source_tree.write("code/b")
+        source_tree.write("code/c")
+
+    metadata.reset()
+    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
+        source_tree.write("code/c")
+
+    assert 1 == len(metadata.get().generated_files)
+    assert "code/c" == metadata.get().generated_files[0]
+
+    # Confirm remove_obsolete_files deletes b but not c.
+    assert not os.path.exists("code/b")
+    assert os.path.exists("code/c")
+
+
+def test_nothing_happens_when_disabled(source_tree, preserve_track_obsolete_file_flag):
+    metadata.set_track_obsolete_files(True)
+
+    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
+        source_tree.write("code/b")
+        source_tree.write("code/c")
+
+    metadata.reset()
+    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
+        source_tree.write("code/c")
+        metadata.set_track_obsolete_files(False)
+
+    assert 0 == len(metadata.get().new_files)
+
+    # Confirm no files were deleted.
+    assert os.path.exists("code/b")
+    assert os.path.exists("code/c")
+
+
+def test_old_file_ignored_by_git_not_removed(
+    source_tree, preserve_track_obsolete_file_flag
+):
+    metadata.set_track_obsolete_files(True)
+
+    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
+        source_tree.write(".bin")
+
+    metadata.reset()
+    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
+        source_tree.write(".gitignore", ".bin")
+
+    # Confirm remove_obsolete_files didn't remove the .bin file.
+    assert os.path.exists(".bin")
+
+
+def test_add_new_files_with_bad_file(source_tree, preserve_track_obsolete_file_flag):
+    metadata.set_track_obsolete_files(True)
+
+    metadata.reset()
+    tmpdir = source_tree.tmpdir
+    dne = "does-not-exist"
+    source_tree.git_add(dne)
+
+    try:
+        os.symlink(tmpdir / dne, tmpdir / "badlink")
+    except OSError:
+        # On Windows, creating a symlink requires Admin priveleges, which
+        # should never be granted to test runners.
+        assert "win32" == sys.platform
+        return
+    # Confirm this doesn't throw an exception.
+    with metadata.MetadataTrackerAndWriter(source_tree.tmpdir / "synth.metadata"):
+        pass
+    # And a bad link does not exist and shouldn't be recorded as a new file.
+    assert 0 == len(metadata.get().new_files)
+
+
 def test_read_metadata(tmpdir):
     metadata.reset()
     add_sample_client_destination()
@@ -158,6 +259,13 @@ def preserve_track_obsolete_file_flag():
 
 def test_track_obsolete_files_defaults_to_false(preserve_track_obsolete_file_flag):
     assert not metadata.should_track_obsolete_files()
+
+
+def test_set_track_obsolete_files(preserve_track_obsolete_file_flag):
+    metadata.set_track_obsolete_files(False)
+    assert not metadata.should_track_obsolete_files()
+    metadata.set_track_obsolete_files(True)
+    assert metadata.should_track_obsolete_files()
 
 
 def test_used_to_append_git_log_to_metadata(source_tree):


### PR DESCRIPTION
old strategy: observe file timestamps to see which files were touched
new strategy: use watchdog to observe every file system event

Control tracking obsolete files with an environment variable.

Fixes https://github.com/googleapis/synthtool/issues/216