### PR TITLE
fix: Fix java generation.

### DIFF
--- a/synthtool/gcp/gapic_bazel.py
+++ b/synthtool/gcp/gapic_bazel.py
@@ -190,7 +190,7 @@ class GAPICBazel:
             "tar",
             "-C",
             str(output_dir),
-            "--strip-components=1",
+            "--strip-components={}".format("0" if language == "java" else "1"),
             "-xzf",
             tar_file,
         ]


### PR DESCRIPTION
We had to update packaging rules in bazel build recently. The change was supposed to be backward-compatible, but the way synth was unpacking the tar made it backward-incompatible.

Specifically, previously the final `.tar.gz` file produced by bazel packaged files in the following format (i.e. this is how the output of `tar -tvf google-cloud-oslogin-v1-java.tar.gz` would look like, using oslogin as an example):
```
./google-cloud-oslogin-v1-java/gapic-google-cloud-oslogin-v1-java/some/files/here1
./google-cloud-oslogin-v1-java/proto-google-cloud-oslogin-v1-java/some/files/here2
./google-cloud-oslogin-v1-java/grpc-google-cloud-oslogin-v1-java/some/files/here2
./google-cloud-oslogin-v1-java/build/scripts
```

Witht the recent change the output of the same build target will look like:
```
google-cloud-oslogin-v1-java/gapic-google-cloud-oslogin-v1-java/some/files/here1
google-cloud-oslogin-v1-java/proto-google-cloud-oslogin-v1-java/some/files/here2
google-cloud-oslogin-v1-java/grpc-google-cloud-oslogin-v1-java/some/files/here2
google-cloud-oslogin-v1-java/build/scripts
```

I.e. they should be identical essentially, because the `./` prefix in the first example is a no-op component in the path when you unpack tar normally. But it still counts as a "component" if `"--strip-component=1"` command line arg is used.

Due to technical reasons adding back the `./` prefix in bazel is difficult and would make the rules inconsistent, adding it to synthtool instead (since the bug is essentially reproducible only if `--strip-component` arg is used).