### PR TITLE
fix(deps): add watchdog as declared dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ dependencies = [
     "PyYAML",
     "requests",
     "protobuf",
+    "watchdog",
 ]
 
 packages = setuptools.find_packages()


### PR DESCRIPTION
#669 introduced watchdog, but did not add it to the list of dependencies installed when you install synthtool