### PR TITLE
fix(node): use nvm to install node in autosynth

### DIFF
--- a/.kokoro-autosynth/nodejs-build.sh
+++ b/.kokoro-autosynth/nodejs-build.sh
@@ -17,16 +17,17 @@ set -eo pipefail
 
 cd ${KOKORO_ARTIFACTS_DIR}/github/synthtool
 
-# Install Node 12, as the Kokoro image
-# uses an older version by default
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-sudo apt-get install -y nodejs
+# Use `nvm` to bootstrap the installation of node.js and npm.
+# To learn more: https://github.com/nvm-sh/nvm
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 
-sudo rm /usr/local/bin/node
-sudo ln -s /usr/bin/nodejs /usr/local/bin/node
+# Use the latest LTS version of nodejs.  This can change over time, but
+# should prevent the need to modify this file every year.
+nvm install --lts
 
-# Verify Node 12 is being used
+# Verify expected versions of nodejs and npm
 node --version
+npm --version
 
 # Run the normal autosynth build
 ${KOKORO_ARTIFACTS_DIR}/github/synthtool/.kokoro-autosynth/build.sh

--- a/.kokoro-autosynth/nodejs-build.sh
+++ b/.kokoro-autosynth/nodejs-build.sh
@@ -17,9 +17,16 @@ set -eo pipefail
 
 cd ${KOKORO_ARTIFACTS_DIR}/github/synthtool
 
+# Ensure `curl` is available
+sudo apt-get update && sudo apt-get -y install curl
+
 # Use `nvm` to bootstrap the installation of node.js and npm.
 # To learn more: https://github.com/nvm-sh/nvm
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+
+# Activate `nvm` so the binary is available on the path
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
 # Use the latest LTS version of nodejs.  This can change over time, but
 # should prevent the need to modify this file every year.

--- a/.kokoro-autosynth/nodejs-build.sh
+++ b/.kokoro-autosynth/nodejs-build.sh
@@ -17,9 +17,6 @@ set -eo pipefail
 
 cd ${KOKORO_ARTIFACTS_DIR}/github/synthtool
 
-# Ensure `curl` is available
-sudo apt-get update && sudo apt-get -y install curl
-
 # Use `nvm` to bootstrap the installation of node.js and npm.
 # To learn more: https://github.com/nvm-sh/nvm
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash


### PR DESCRIPTION
This updates the build script to use `nvm` to always install the latest LTS releases of node.js and npm.  It's unclear if this will work in the kokoro environment and docker image, so we will need to iterate here.