### PR TITLE
chore(java): default samples/snippets pom should not use libraries-bom

### DIFF
--- a/synthtool/gcp/templates/java_library/samples/snippets/pom.xml
+++ b/synthtool/gcp/templates/java_library/samples/snippets/pom.xml
@@ -25,26 +25,13 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-
-  <!-- [START {{metadata['repo']['name']}}_install_with_bom] -->
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>{{ metadata['latest_bom_version'] }}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
+    <!-- TODO: switch to libraries-bom after this artifact is included -->
     <dependency>
       <groupId>{{ group_id }}</groupId>
       <artifactId>{{ artifact_id }}</artifactId>
+      <version>{{ metadata['latest_version'] }}</version>
     </dependency>
-    <!-- [END {{metadata['repo']['name']}}_install_with_bom] -->
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
We are now only adding clients to libraries-bom once the client is
1.0.0. Since this template is created at repository creation time, we
don't want to include the libraries-bom installation method here.

Note: that this template is only added the first time - if a samples/snippets/pom.xml file exists, we leave the current file.