### PR TITLE
fix: Don't attempt to include super-long synth logs in a PR body

### DIFF
--- a/autosynth/change_pusher.py
+++ b/autosynth/change_pusher.py
@@ -176,7 +176,7 @@ def build_pr_body(synth_log: str, trailers: str = ""):
     """
     build_log_text = ""
     kokoro_build_id = os.environ.get("KOKORO_BUILD_ID")
-    if synth_log:
+    if synth_log and len(synth_log) < 40000:
         build_log_text = f"""
 <details><summary>Log from Synthtool</summary>
 


### PR DESCRIPTION
We recently had an Elixir synth fail (https://github.com/googleapis/elixir-google-api/issues/5748) because the synth log was long enough to trigger GitHub's PR body length limit of 2^16 characters. This PR just checks whether the synth log is getting long-ish, and if so it falls back to the behavior of just including a link to the log rather than including the entire log inline.