### PR TITLE
chore(py_library): add some excludes in docs/conf.py

### DIFF
--- a/synthtool/gcp/templates/python_library/docs/conf.py.j2
+++ b/synthtool/gcp/templates/python_library/docs/conf.py.j2
@@ -21,6 +21,7 @@ import shlex
 sys.path.insert(0, os.path.abspath(".."))
 
 # For plugins that can not read conf.py.
+# See also: https://github.com/docascode/sphinx-docfx-yaml/issues/85
 sys.path.insert(0, os.path.abspath("."))
 
 __version__ = "{{ metadata['version'] }}"
@@ -93,7 +94,12 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+exclude_patterns = [
+    "_build",
+    "samples/AUTHORING_GUIDE.md",
+    "samples/CONTRIBUTING.md",
+    "samples/snippets/README.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
This should fix build failures in python-bigquery.
Example:
https://github.com/googleapis/python-bigquery/pull/205

* also add a comment