### PR TITLE
chore: enable obsolete file tracking for Ruby

### DIFF
--- a/.kokoro-autosynth/ruby.cfg
+++ b/.kokoro-autosynth/ruby.cfg
@@ -22,4 +22,9 @@ env_vars: {
     value: "true"
 }
 
+env_vars: {
+    key: "SYNTHTOOL_TRACK_OBSOLETE_FILES"
+    value: "true"
+}
+
 build_file: "synthtool/.kokoro-autosynth/ruby-build.sh"


### PR DESCRIPTION
After this PR is merged, Autosynth will generate a pull request for every synth.py in google-cloud-ruby.  That means roughly 80 PRs will arrive the next day.  Each PR will have the title "chore: start tracking obsolete files" and it will only contain changes to synth.metadata.

This will be a one-time nuisance.  After the 80 PRs are merged, no more such PRs will be generated.