### PR TITLE
fix: Ensure watch_dir exists

### DIFF
--- a/synthtool/metadata.py
+++ b/synthtool/metadata.py
@@ -231,6 +231,7 @@ class MetadataTrackerAndWriter:
         self.old_metadata = _read_or_empty(self.metadata_file_path)
         _add_self_git_source()
         watch_dir = pathlib.Path(self.metadata_file_path).parent
+        os.makedirs(watch_dir, exist_ok=True)
         self.handler = FileSystemEventHandler(watch_dir)
         self.observer = watchdog.observers.Observer()
         self.observer.schedule(self.handler, str(watch_dir), recursive=True)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -417,3 +417,15 @@ def test_disable_writing_metadata(source_tree: SourceTree):
         assert not metadata_path.exists()
     finally:
         metadata.enable_write_metadata(True)
+
+
+def test_watch_dir_does_not_exist_yet(source_tree):
+    new_dir_path = source_tree.tmpdir / "blahblah"
+    metadata_path = new_dir_path / "synth.metadata"
+
+    assert not os.path.exists(new_dir_path)
+
+    with metadata.MetadataTrackerAndWriter(metadata_path):
+        pass
+
+    assert os.path.exists(new_dir_path)


### PR DESCRIPTION
Elixir synth is failing for newly added libraries because synthtool is trying to start watchdog on a directory that doesn't exist yet because synth hasn't created it yet (see e.g. https://github.com/googleapis/elixir-google-api/issues/6174). This PR ensures the directory exists.