### PR TITLE
chore(java_templates): add lint/static analysis presubmit checks for samples

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/samples.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/samples.yaml
@@ -1,0 +1,25 @@
+on:
+  pull_request:
+name: samples
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Run checkstyle
+        run: mvn -P lint --quiet --batch-mode checkstyle:check
+        working-directory: samples/snippets
+  static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Run PMD & Spotbugs
+        run: mvn -P lint --quiet --batch-mode compile pmd:cpd-check spotbugs:check
+        working-directory: samples/snippets
+  

--- a/synthtool/gcp/templates/java_library/.github/workflows/samples.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/samples.yaml
@@ -22,4 +22,3 @@ jobs:
       - name: Run PMD & Spotbugs
         run: mvn -P lint --quiet --batch-mode compile pmd:cpd-check spotbugs:check
         working-directory: samples/snippets
-  


### PR DESCRIPTION
Presubmit checks on GoogleCloudPlatform/java-docs-samples run these checks as optional checks.