### PR TITLE
build: track flaky tests for "nightly", add new secrets for tagging

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/release/publish.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/release/publish.cfg
@@ -49,7 +49,7 @@ before_action {
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "npm_publish_token"
+  value: "npm_publish_token,releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
 }
 
 # Download trampoline resources.

--- a/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
@@ -41,7 +41,7 @@ if [ -f samples/package.json ]; then
     cd ..
     # If tests are running against master, configure Build Cop
     # to open issues on failures:
-    if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+    if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
       export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
       export MOCHA_REPORTER=xunit
       cleanup() {

--- a/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
@@ -35,7 +35,7 @@ npm install
 
 # If tests are running against master, configure Build Cop
 # to open issues on failures:
-if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
   export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
   export MOCHA_REPORTER=xunit
   cleanup() {

--- a/synthtool/gcp/templates/node_library/.kokoro/test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/test.sh
@@ -23,7 +23,7 @@ cd $(dirname $0)/..
 npm install
 # If tests are running against master, configure Build Cop
 # to open issues on failures:
-if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
   export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
   export MOCHA_REPORTER=xunit
   cleanup() {


### PR DESCRIPTION
Update build scripts:

* we will now report nightly build failures  as flaky tests .
* secrets are updated such that tagging/commenting should begin working: see: https://github.com/googleapis/releasetool/pull/262

_Note: combined these two updates so that I only face one mass PR tomorrow._