### PR TITLE
fix: pin black lint tool version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -22,13 +22,13 @@ def generate_protos(session):
 
 @nox.session(python=['3.6', '3.8'])
 def blacken(session):
-    session.install('black')
+    session.install('black==19.10b0')
     session.run('black', 'synthtool', 'tests', 'autosynth', 'integration_tests')
 
 
 @nox.session(python=['3.6', '3.8'])
 def lint(session):
-    session.install('mypy', 'flake8', 'black')
+    session.install('mypy', 'flake8', 'black==19.10b0')
     session.run('pip', 'install', '-e', '.')
     session.run('black', '--check', 'synthtool', 'tests')
     session.run('flake8', 'synthtool', 'tests', 'autosynth', 'integration_tests')


### PR DESCRIPTION
A recent release of the black linting tool broke our automated lint.  Pin the version so it doesn't break periodically.