### PR TITLE
fix: pin setuptools to 49.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Ensure latest setuptools to avoid any package resources issues.
+# Pin to less than 49.6.0 as a workaround for https://github.com/pypa/setuptools/issues/2353
 setuptools==49.6.0
 
 nox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Ensure latest setuptools to avoid any package resources issues.
-setuptools
+setuptools==49.6.0
 
 nox
 requests


### PR DESCRIPTION
Suggested solution for broken autosynth. https://github.com/googleapis/gapic-generator/issues/3271#issuecomment-686139564