### PR TITLE
build(ci): enable auto-release for dependency-update-only releases

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/auto-release.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/auto-release.yaml
@@ -1,0 +1,69 @@
+on:
+  pull_request:
+name: auto-release
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@v3.0.0
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        debug: true
+        script: |
+          // only approve PRs from release-please[bot]
+          if (context.payload.pull_request.user.login !== "release-please[bot]") {
+            return;
+          }
+
+          // only approve PRs like "chore: release <release version>"
+          if ( !context.payload.pull_request.title.startsWith("chore: release") ) {
+            return;
+          }
+
+          // trigger auto-release when
+          // 1) it is a SNAPSHOT release (auto-generated post regular release)
+          // 2) there are dependency updates only
+          // 3) there are no open dependency update PRs in this repo (to avoid multiple releases)
+          if (
+            context.payload.pull_request.body.includes("Fix") ||
+            context.payload.pull_request.body.includes("Build") ||
+            context.payload.pull_request.body.includes("Documentation") ||
+            context.payload.pull_request.body.includes("BREAKING CHANGES") ||
+            context.payload.pull_request.body.includes("Features")
+          ) {
+            console.log( "Not auto-releasing since it is not a dependency-update-only release." );
+            return;
+          }
+
+          const promise = github.pulls.list.endpoint({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open'
+          });
+          const open_pulls = await github.paginate(promise)
+
+          if ( open_pulls.length > 1 && !context.payload.pull_request.title.includes("SNAPSHOT") ) {
+            for ( const pull of open_pulls ) {
+              if ( pull.title.startsWith("deps: update dependency") ) {
+                console.log( "Not auto-releasing yet since there are dependency update PRs open in this repo." );
+                return;
+              }
+            }
+          }
+
+          // approve release PR
+          await github.pulls.createReview({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'Rubber stamped release!',
+            pull_number: context.payload.pull_request.number,
+            event: 'APPROVE'
+          });
+
+          // attach kokoro:force-run and automerge labels
+          await github.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.pull_request.number,
+            labels: ['kokoro:force-run', 'automerge']
+          });


### PR DESCRIPTION
Automatically perform a Java client library release when:
1. Only dependency updates are going out in the release since any releases containing bug fixes, build changes or new features should be supervised;
2. There are no outstanding/open dependency update pull requests in the repo. This is to avoid multiple/redundant releases;
3. It is a SNAPSHOT release which is automatically generated post regular release -- this requires no human supervision.
