### PR TITLE
chore(java): set yoshi-java as default CODEOWNER

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/CODEOWNERS
+++ b/synthtool/gcp/templates/java_library/.github/CODEOWNERS
@@ -5,7 +5,10 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 {% if 'codeowner_team' in metadata['repo'] %}
 # The {{ metadata['repo']['codeowner_team'] }} is the default owner for changes in this repo
+*                       @googleapis/yoshi-java {{ metadata['repo']['codeowner_team'] }}
 **/*.java               {{ metadata['repo']['codeowner_team'] }}
+{% else %}
+*                       @googleapis/yoshi-java
 {% endif %}
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers


### PR DESCRIPTION
Default java repo ownership to yoshi-java.