### PR TITLE
build(java): use yoshi-approver token for auto-approve

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/auto-release.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/auto-release.yaml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/github-script@v3.0.0
       with:
-        github-token: {{ '${{secrets.GITHUB_TOKEN}}' }}
+        github-token: {{ '${{secrets.YOSHI_APPROVER_TOKEN}}' }}
         debug: true
         script: |
           // only approve PRs from release-please[bot]


### PR DESCRIPTION
With required CODEOWNERS, use a bot user for approving PRs.