### PR TITLE
chore(ci): skip autorelease workflow on non-release PRs

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/auto-release.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/auto-release.yaml
@@ -4,6 +4,7 @@ name: auto-release
 jobs:
   approve:
     runs-on: ubuntu-latest
+    if: contains(github.head_ref, 'release-v')
     steps:
     - uses: actions/github-script@v3.0.0
       with:


### PR DESCRIPTION
since only release PRs should be evaluated for autorelease and also YOSHI_APPROVER_TOKEN cannot be shared on forked PRs.