### PR TITLE
chore(python): use BUILD_SPECIFIC_GCLOUD_PROJECT for samples

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/common.cfg
@@ -13,6 +13,12 @@ env_vars: {
     value: "py-3.6"
 }
 
+# Declare build specific Cloud project.
+env_vars: {
+    key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
+    value: "python-docs-samples-tests-py36"
+}
+
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.7/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.7/common.cfg
@@ -13,6 +13,12 @@ env_vars: {
     value: "py-3.7"
 }
 
+# Declare build specific Cloud project.
+env_vars: {
+    key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
+    value: "python-docs-samples-tests-py37"
+}
+
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/common.cfg
@@ -13,6 +13,12 @@ env_vars: {
     value: "py-3.8"
 }
 
+# Declare build specific Cloud project.
+env_vars: {
+    key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
+    value: "python-docs-samples-tests-py38"
+}
+
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"


### PR DESCRIPTION
https://github.com/googleapis/python-talent/blob/ef045e8eb348db36d7a2a611e6f26b11530d273b/samples/snippets/noxfile_config.py#L27-L32

`BUILD_SPECIFIC_GCLOUD_PROJECT` is an alternate project used for sample tests that do poorly with concurrent runs on the same project.