### PR TITLE
fix(node): don't allow generation to touch samples/

### DIFF
--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -20,6 +20,7 @@ from synthtool import shell
 from synthtool.gcp import samples, snippets
 from synthtool.log import logger
 from synthtool.sources import git
+from subprocess import CalledProcessError
 from typing import Any, Dict, List
 
 _REQUIRED_FIELDS = ["name", "repository"]
@@ -177,7 +178,11 @@ def fix(hide_output=False):
     shell.run(["npm", "run", "prelint"], check=False, hide_output=hide_output)
     logger.debug("Running fix...")
     shell.run(["npm", "run", "fix"], hide_output=hide_output)
-    shell.run(["git", "checkout", "samples"], hide_output=hide_output)
+    try:
+      shell.run(["git", "checkout", "samples"], hide_output=hide_output)
+    except CalledProcessError:
+      # Most likely a repo with no samples folder:
+      pass
 
 
 def compile_protos(hide_output=False):

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -177,6 +177,7 @@ def fix(hide_output=False):
     shell.run(["npm", "run", "prelint"], check=False, hide_output=hide_output)
     logger.debug("Running fix...")
     shell.run(["npm", "run", "fix"], hide_output=hide_output)
+    shell.run(["git", "checkout", "samples"], hide_output=hide_output)
 
 
 def compile_protos(hide_output=False):

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -179,10 +179,10 @@ def fix(hide_output=False):
     logger.debug("Running fix...")
     shell.run(["npm", "run", "fix"], hide_output=hide_output)
     try:
-      shell.run(["git", "checkout", "samples"], hide_output=hide_output)
+        shell.run(["git", "checkout", "samples"], hide_output=hide_output)
     except CalledProcessError:
-      # Most likely a repo with no samples folder:
-      pass
+        # Most likely a repo with no samples folder:
+        pass
 
 
 def compile_protos(hide_output=False):


### PR DESCRIPTION
synthtool uses the files touched during generation to decide which files to track.

linting/`npm i` sometimes update the files in `samples/`, even though they're not currently generated.

This adds a step that checks out any changes that happen in `samples/` during generation.

_Note: to fix libraries currently in a bad state, we need to remove files in `samples/` from synth.metadata, this will protect us in the future I believe._

Fixes #757 
