### PR TITLE
fix: load flags from the specified synth.py file

### DIFF
--- a/autosynth/synth.py
+++ b/autosynth/synth.py
@@ -617,7 +617,7 @@ def _inner_main(temp_dir: str) -> int:
 
         metadata_path = os.path.join(args.metadata_path or "", "synth.metadata")
 
-        flags = autosynth.flags.parse_flags()
+        flags = autosynth.flags.parse_flags(synth_file_name)
         # Override flags specified in synth.py with flags specified in environment vars.
         for key in flags.keys():
             env_value = os.environ.get(key, "")


### PR DESCRIPTION
Fixes #793 

When we specify a custom synth.py file, we should parse the AST from that file when determining which flags to set. Note that the parse_flags method already supported picking a file, we just need to use the user input.