### PR TITLE
fix: samples tests should pass if no samples exist

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/test-samples.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/test-samples.sh
@@ -66,38 +66,41 @@ set +e
 # Use RTN to return a non-zero value if the test fails.
 RTN=0
 ROOT=$(pwd)
-# Find all requirements.txt in the samples directory (may break on whitespace).
-for file in samples/**/requirements.txt; do
+
+if [ -d "./samples" ]; then
+    # Find all requirements.txt in the samples directory (may break on whitespace).
+    for file in samples/**/requirements.txt; do
+        cd "$ROOT"
+        # Navigate to the project folder.
+        file=$(dirname "$file")
+        cd "$file"
+
+        echo "------------------------------------------------------------"
+        echo "- testing $file"
+        echo "------------------------------------------------------------"
+
+        # Use nox to execute the tests for the project.
+        python3.6 -m nox -s "$RUN_TESTS_SESSION"
+        EXIT=$?
+
+        # If this is a periodic build, send the test log to the Build Cop Bot.
+        # See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.
+        if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"periodic"* ]]; then
+          chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop
+          $KOKORO_GFILE_DIR/linux_amd64/buildcop
+        fi
+
+        if [[ $EXIT -ne 0 ]]; then
+          RTN=1
+          echo -e "\n Testing failed: Nox returned a non-zero exit code. \n"
+        else
+          echo -e "\n Testing completed.\n"
+        fi
+    done
     cd "$ROOT"
-    # Navigate to the project folder.
-    file=$(dirname "$file")
-    cd "$file"
-
-    echo "------------------------------------------------------------"
-    echo "- testing $file"
-    echo "------------------------------------------------------------"
-
-    # Use nox to execute the tests for the project.
-    python3.6 -m nox -s "$RUN_TESTS_SESSION"
-    EXIT=$?
-
-    # If this is a periodic build, send the test log to the Build Cop Bot.
-    # See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.
-    if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"periodic"* ]]; then
-      chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop
-      $KOKORO_GFILE_DIR/linux_amd64/buildcop
-    fi
-
-    if [[ $EXIT -ne 0 ]]; then
-      RTN=1
-      echo -e "\n Testing failed: Nox returned a non-zero exit code. \n"
-    else
-      echo -e "\n Testing completed.\n"
-    fi
-
-done
-cd "$ROOT"
-
+else
+  echo "No tests run. ./samples not found"
+fi
 # Workaround for Kokoro permissions issue: delete secrets
 rm testing/{test-env.sh,client-secrets.json,service-account.json}
 

--- a/synthtool/gcp/templates/python_library/.kokoro/test-samples.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/test-samples.sh
@@ -28,6 +28,12 @@ if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"periodic"* ]]; then
     git checkout $LATEST_RELEASE
 fi
 
+# Exit early if samples directory doesn't exist
+if [ ! -d "./samples" ]; then
+  echo "No tests run. `./samples` not found"
+  exit 0
+fi
+
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1
 
@@ -66,41 +72,38 @@ set +e
 # Use RTN to return a non-zero value if the test fails.
 RTN=0
 ROOT=$(pwd)
-
-if [ -d "./samples" ]; then
-    # Find all requirements.txt in the samples directory (may break on whitespace).
-    for file in samples/**/requirements.txt; do
-        cd "$ROOT"
-        # Navigate to the project folder.
-        file=$(dirname "$file")
-        cd "$file"
-
-        echo "------------------------------------------------------------"
-        echo "- testing $file"
-        echo "------------------------------------------------------------"
-
-        # Use nox to execute the tests for the project.
-        python3.6 -m nox -s "$RUN_TESTS_SESSION"
-        EXIT=$?
-
-        # If this is a periodic build, send the test log to the Build Cop Bot.
-        # See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.
-        if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"periodic"* ]]; then
-          chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop
-          $KOKORO_GFILE_DIR/linux_amd64/buildcop
-        fi
-
-        if [[ $EXIT -ne 0 ]]; then
-          RTN=1
-          echo -e "\n Testing failed: Nox returned a non-zero exit code. \n"
-        else
-          echo -e "\n Testing completed.\n"
-        fi
-    done
+# Find all requirements.txt in the samples directory (may break on whitespace).
+for file in samples/**/requirements.txt; do
     cd "$ROOT"
-else
-  echo "No tests run. ./samples not found"
-fi
+    # Navigate to the project folder.
+    file=$(dirname "$file")
+    cd "$file"
+
+    echo "------------------------------------------------------------"
+    echo "- testing $file"
+    echo "------------------------------------------------------------"
+
+    # Use nox to execute the tests for the project.
+    python3.6 -m nox -s "$RUN_TESTS_SESSION"
+    EXIT=$?
+
+    # If this is a periodic build, send the test log to the Build Cop Bot.
+    # See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.
+    if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"periodic"* ]]; then
+      chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop
+      $KOKORO_GFILE_DIR/linux_amd64/buildcop
+    fi
+
+    if [[ $EXIT -ne 0 ]]; then
+      RTN=1
+      echo -e "\n Testing failed: Nox returned a non-zero exit code. \n"
+    else
+      echo -e "\n Testing completed.\n"
+    fi
+
+done
+cd "$ROOT"
+
 # Workaround for Kokoro permissions issue: delete secrets
 rm testing/{test-env.sh,client-secrets.json,service-account.json}
 


### PR DESCRIPTION
Currently, `test-samples.sh` runs into a bug and crashes if the `./samples` directory doesn't exist in a repo. I'd argue that the check should pass automatically if there are no samples to test against. 

This would fix the issue we're running into on [python-logging](https://github.com/googleapis/python-logging), where no CI tests will pass until we merge the [PR adding samples](https://github.com/googleapis/python-logging/pull/67)

If we'd prefer having no samples to count as a test failure, I'd suggest we least add a better error message. Right now the code just crashes by trying to cd into a directory that doesn't exist