### PR TITLE
ci(java): restrict presubmit samples ITs to only snapshot

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.sh
@@ -69,9 +69,16 @@ integration)
     RETURN_CODE=$?
     ;;
 samples)
-    if [[ -f samples/pom.xml ]]
+    SAMPLES_DIR=samples
+    # only run ITs in snapshot/ on presubmit PRs. run ITs in all 3 samples/ subdirectories otherwise.
+    if [[ ! -z ${KOKORO_GITHUB_PULL_REQUEST_NUMBER} ]]
     then
-        pushd samples
+      SAMPLES_DIR=samples/snapshot
+    fi
+
+    if [[ -f ${SAMPLES_DIR}/pom.xml ]]
+    then
+        pushd {SAMPLES_DIR}
         mvn -B \
           -Penable-samples \
           -DtrimStackTrace=false \


### PR DESCRIPTION
This is to reduce resource consumption since we often times hit resource quota limit in samples testing.
e.g. https://github.com/googleapis/java-bigquerydatatransfer/issues/410