### PR TITLE
build: only check --engine-strict for production deps

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
@@ -16,7 +16,11 @@ jobs:
         with:
           node-version: ${{ '{{' }} matrix.node {{ '}}' }}
       - run: node --version
-      - run: npm install --engine-strict
+      # The first installation step ensures that all of our production
+      # dependencies work on the given Node.js version, this helps us find
+      # dependencies that don't match our engines field:
+      - run: npm install --production --engine-strict
+      - run: npm install
       - run: npm test
       - name: coverage
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Perform an installation of our `--production` dependencies first, with `--engine-strict`, so that we can detect dependencies that have dropped support for our supported Node.js version.