### PR TITLE
fix: Use a non-flag arg for the ruby-apiary-clean synth job

### DIFF
--- a/autosynth/providers/ruby_apiary.py
+++ b/autosynth/providers/ruby_apiary.py
@@ -34,7 +34,7 @@ def list_repositories():
             "name": "clean",
             "repository": "googleapis/google-api-ruby-client",
             "branch-suffix": "clean",
-            "args": ["--clean"],
+            "args": ["clean"],
             "pr-title": "feat: Automated removal of obsolete clients",
         }
     )


### PR DESCRIPTION
This is an update to #802. The original idea was to pass a "flag" argument (`--clean`) down through synth to the underlying build script, for the one special synth job that deletes obsolete directories from the client. However, this confuses synthtool, which tries to parse the `--clean` argument itself (see https://github.com/googleapis/google-api-ruby-client/issues/1207). So instead I updated the build script to take `clean` as a non-flag argument, and we'll pass that instead. (An alternative approach might have been to pass `--` first, but I'm not sure if Python's arg parser recognizes that form, so I'll just go with the current approach that I know will work.)