### PR TITLE
chore: remove `*` from owned dirs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 *   @SurferJeffAtGoogle @chingor13 @bcoe
 
 # assign templates to the language team that owns them
-synthtool/gcp/templates/java_library/*          @googleapis/yoshi-java
-synthtool/gcp/templates/node_library/*          @googleapis/yoshi-nodejs
-synthtool/gcp/templates/node_split_library/*    @googleapis/yoshi-nodejs
-synthtool/gcp/templates/php_library/*           @googleapis/yoshi-php
-synthtool/gcp/templates/python_library/*        @googleapis/yoshi-python
-synthtool/gcp/templates/python_samples/*        @googleapis/yoshi-python
-synthtool/gcp/templates/ruby_library/*          @googleapis/yoshi-ruby
+synthtool/gcp/templates/java_library/          @googleapis/yoshi-java
+synthtool/gcp/templates/node_library/          @googleapis/yoshi-nodejs
+synthtool/gcp/templates/node_split_library/    @googleapis/yoshi-nodejs
+synthtool/gcp/templates/php_library/           @googleapis/yoshi-php
+synthtool/gcp/templates/python_library/        @googleapis/yoshi-python
+synthtool/gcp/templates/python_samples/        @googleapis/yoshi-python
+synthtool/gcp/templates/ruby_library/          @googleapis/yoshi-ruby


### PR DESCRIPTION
Ending a path in star will only match files in that directory.