### PR TITLE
chore(ci): fix typo in restrict presubmit samples ITs to only snapshot

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.sh
@@ -78,7 +78,7 @@ samples)
 
     if [[ -f ${SAMPLES_DIR}/pom.xml ]]
     then
-        pushd {SAMPLES_DIR}
+        pushd ${SAMPLES_DIR}
         mvn -B \
           -Penable-samples \
           -DtrimStackTrace=false \


### PR DESCRIPTION
Fixes below error in Java repos when https://github.com/googleapis/synthtool/pull/804 was merged:
```
github/java-bigquerystorage/.kokoro/build.sh: line 81: pushd: {SAMPLES_DIR}: No such file or directory
```

Thanks @kolea2 for spotting this in Fusion build logs.

cc @chingor13 