### PR TITLE
build(node): don't run prepare during smoke test

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       # The first installation step ensures that all of our production
       # dependencies work on the given Node.js version, this helps us find
       # dependencies that don't match our engines field:
-      - run: npm install --production --engine-strict
+      - run: npm install --production --engine-strict --ignore-scripts
       - run: npm install
       - run: npm test
       - name: coverage


### PR DESCRIPTION
`npm@7` appears to now run `prepare` when you run `npm i --production`, this caused issues for our `posinstall` script, which expects `gts` to be available.

I've confirmed this fix here:

https://github.com/googleapis/nodejs-phishing-protection/pull/214