### PR TITLE
build(node): cleanup production deps before installing dev/production

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
@@ -19,7 +19,9 @@ jobs:
       # The first installation step ensures that all of our production
       # dependencies work on the given Node.js version, this helps us find
       # dependencies that don't match our engines field:
-      - run: npm install --production --engine-strict --ignore-scripts
+      - run: npm install --production --engine-strict --ignore-scripts --no-package-lock
+      # Clean up the production install, before installing dev/production:
+      - run: rm -rf node_modules
       - run: npm install
       - run: npm test
       - name: coverage


### PR DESCRIPTION
The `compileProtos` step throws an exception on `npm i`, if and only if `npm i --production` has been run first, see: https://github.com/googleapis/nodejs-secret-manager/pull/178

This change stops generating a `package-lock.json` and cleans the `node_modules` folder, before running `npm i`.

---

_I will reject the prior update to `ci.yaml`, and run `synthtool` manually Monday to land this._