### PR TITLE
fix(python_library): fix external unit test dependencies

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -76,7 +76,7 @@ def default(session):
     {%- if microgenerator %}
     session.install("asyncmock", "pytest-asyncio")
     {% endif %}
-    session.install("mock", "pytest", "pytest-cov" {% for d in unit_test_external_dependencies %}"{{d}}"{% if not loop.last %},{% endif %}{% endfor %})
+    session.install("mock", "pytest", "pytest-cov", {% for d in unit_test_external_dependencies %}"{{d}}"{% if not loop.last %},{% endif %}{% endfor %})
     session.install("-e", ".")
     {% for dependency in unit_test_local_dependencies %}session.install("-e", "{{dependency}}"){% endfor %}
     {% for dependency in unit_test_dependencies %}session.install("-e", "{{dependency}}"){% endfor %}


### PR DESCRIPTION
I recently submitted https://github.com/googleapis/synthtool/pull/811/files, allowing external dependencies for unit tests. This fixes a small missing comma bug