### PR TITLE
docs: add proto-plus to intersphinx mapping

### DIFF
--- a/synthtool/gcp/templates/python_library/docs/conf.py.j2
+++ b/synthtool/gcp/templates/python_library/docs/conf.py.j2
@@ -352,6 +352,7 @@ intersphinx_mapping = {
         None,
     ),
     "grpc": ("https://grpc.io/grpc/python/", None),
+    "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     {% if intersphinx_dependencies %}
         {% for name, url in intersphinx_dependencies.items() %}
             "{{ name }}": ("{{ url }}", None),


### PR DESCRIPTION
The generated code was recently updated to show that messages inherit from proto-plus https://github.com/googleapis/gapic-generator-python/issues/685 This PR ensures that the link to the proto-plus documentation will be clickable.

Towards https://github.com/googleapis/gapic-generator-python/issues/685