### PR TITLE
build(node): add KOKORO_BUILD_ARTIFACTS_SUBDIR to env

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/trampoline_v2.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/trampoline_v2.sh
@@ -125,6 +125,8 @@ pass_down_envvars=(
     "TRAMPOLINE_CI"
     # Indicates the version of the script.
     "TRAMPOLINE_VERSION"
+    # Contains path to build artifacts being executed.
+    "KOKORO_BUILD_ARTIFACTS_SUBDIR"
 )
 
 log_yellow "Building with Trampoline ${TRAMPOLINE_VERSION}"


### PR DESCRIPTION
The `KOKORO_BUILD_ARTIFACTS_SUBDIR` variable is used to determine what type of build is running (_and to in turn report flaky test information_).