### PR TITLE
fix: export clients as both const and type

### DIFF
--- a/synthtool/gcp/templates/node_split_library/index.ts.j2
+++ b/synthtool/gcp/templates/node_split_library/index.ts.j2
@@ -17,7 +17,8 @@
 // ** All changes to this file may be overwritten. **
 
 {% for version in versions %}import * as {{ version }} from './{{ version}}';{{ "\n" }}{% endfor %}
-{% for client in clients %}const {{ client }} = {{ default_version }}.{{ client }};{{ "\n" }}{% endfor %}
+{% for client in clients %}const {{ client }} = {{ default_version }}.{{ client }};
+type {{ client }} = {{ default_version }}.{{ client }};{{ "\n" }}{% endfor %}
 export {{ "{" }}{{ versions|join(', ')}}, {{ clients|join(', ')}}{{ "}" }};
 export default {{ "{" }}{{ versions|join(', ')}}, {{ clients|join(', ')}}{{ "}" }};
 import * as protos from '../protos/protos';

--- a/tests/fixtures/node_templates/index_samples/sample_index.ts
+++ b/tests/fixtures/node_templates/index_samples/sample_index.ts
@@ -20,6 +20,7 @@ import * as v1 from './v1';
 import * as v1beta1 from './v1beta1';
 
 const TextToSpeechClient = v1.TextToSpeechClient;
+type TextToSpeechClient = v1.TextToSpeechClient;
 
 export {v1, v1beta1, TextToSpeechClient};
 export default {v1, v1beta1, TextToSpeechClient};

--- a/tests/fixtures/node_templates/index_samples/src/index.ts
+++ b/tests/fixtures/node_templates/index_samples/src/index.ts
@@ -20,6 +20,7 @@ import * as v1 from './v1';
 import * as v1beta1 from './v1beta1';
 
 const TextToSpeechClient = v1.TextToSpeechClient;
+type TextToSpeechClient = v1.TextToSpeechClient;
 
 export {v1, v1beta1, TextToSpeechClient};
 export default {v1, v1beta1, TextToSpeechClient};


### PR DESCRIPTION
The generator now generates the same code (both `const` and `type` to allow declaration merging), so we need to update it here as well. The idea is to have the same `src/index.ts` as in https://github.com/googleapis/nodejs-secret-manager/pull/184/files. 