### PR TITLE
chore(java): ignore return code 28 in README autosynth job

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/readme.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/readme.sh
@@ -28,9 +28,18 @@ echo "https://${GITHUB_TOKEN}:@github.com" >> ~/.git-credentials
 git config --global credential.helper 'store --file ~/.git-credentials'
 
 python3.6 -m pip install git+https://github.com/googleapis/synthtool.git#egg=gcp-synthtool
+
+set +e
 python3.6 -m autosynth.synth \
     --repository={{metadata['repo']['repo']}} \
     --synth-file-name=.github/readme/synth.py \
     --metadata-path=.github/readme/synth.metadata \
     --pr-title="chore: regenerate README" \
     --branch-suffix="readme"
+
+# autosynth returns 28 to signal there are no changes
+RETURN_CODE=$?
+if [[ ${RETURN_CODE} -ne 0 && ${RETURN_CODE} -ne 28 ]]
+then
+    exit ${RETURN_CODE}
+fi


### PR DESCRIPTION
Exit code 28 is returned if no changes are required and should not be considered a failure.