### PR TITLE
test(python): fix template defaults for noxfile default py versions

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -216,7 +216,7 @@ class CommonTemplates:
 
         # Set default Python versions for noxfile.py
         if "default_python_version" not in kwargs:
-            kwargs["default_python_version"] = "3.9"
+            kwargs["default_python_version"] = "3.8"
         if "unit_test_python_versions" not in kwargs:
             kwargs["unit_test_python_versions"] = ["3.6", "3.7", "3.8", "3.9"]
             if "microgenerator" not in kwargs:

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -225,7 +225,7 @@ class CommonTemplates:
                 ]
 
         if "system_test_python_versions" not in kwargs:
-            kwargs["system_test_python_versions"] = ["3.9"]
+            kwargs["system_test_python_versions"] = ["3.8"]
             if "microgenerator" not in kwargs:
                 kwargs["system_test_python_versions"] = ["2.7"] + kwargs[
                     "system_test_python_versions"

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -216,16 +216,16 @@ class CommonTemplates:
 
         # Set default Python versions for noxfile.py
         if "default_python_version" not in kwargs:
-            kwargs["default_python_version"] = "3.8"
+            kwargs["default_python_version"] = "3.9"
         if "unit_test_python_versions" not in kwargs:
-            kwargs["unit_test_python_versions"] = ["3.6", "3.7", "3.8"]
+            kwargs["unit_test_python_versions"] = ["3.6", "3.7", "3.8", "3.9"]
             if "microgenerator" not in kwargs:
-                kwargs["unit_test_python_versions"] = ["2.7", "3.5"] + kwargs[
+                kwargs["unit_test_python_versions"] = ["2.7"] + kwargs[
                     "unit_test_python_versions"
                 ]
 
         if "system_test_python_versions" not in kwargs:
-            kwargs["system_test_python_versions"] = ["3.8"]
+            kwargs["system_test_python_versions"] = ["3.9"]
             if "microgenerator" not in kwargs:
                 kwargs["system_test_python_versions"] = ["2.7"] + kwargs[
                     "system_test_python_versions"

--- a/tests/test_python_library.py
+++ b/tests/test_python_library.py
@@ -39,7 +39,7 @@ def test_split_system_tests():
         assert "RUN_SYSTEM_TESTS" in contents
         assert "false" in contents
 
-    assert os.path.exists(templated_files / ".kokoro/presubmit/system-3.8.cfg")
-    with open(templated_files / ".kokoro/presubmit/system-3.8.cfg", "r") as f:
+    assert os.path.exists(templated_files / ".kokoro/presubmit/system-3.9.cfg")
+    with open(templated_files / ".kokoro/presubmit/system-3.9.cfg", "r") as f:
         contents = f.read()
-        assert "system-3.8" in contents
+        assert "system-3.9" in contents

--- a/tests/test_python_library.py
+++ b/tests/test_python_library.py
@@ -39,7 +39,7 @@ def test_split_system_tests():
         assert "RUN_SYSTEM_TESTS" in contents
         assert "false" in contents
 
-    assert os.path.exists(templated_files / ".kokoro/presubmit/system-3.9.cfg")
-    with open(templated_files / ".kokoro/presubmit/system-3.9.cfg", "r") as f:
+    assert os.path.exists(templated_files / ".kokoro/presubmit/system-3.8.cfg")
+    with open(templated_files / ".kokoro/presubmit/system-3.8.cfg", "r") as f:
         contents = f.read()
-        assert "system-3.9" in contents
+        assert "system-3.8" in contents


### PR DESCRIPTION
The python versions in the template have fallen behind the current versions of python. see https://python.org/downloads