### PR TITLE
deps(java): update code-suggester to 1.8.1

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/formatting.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/formatting.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           java-version: 11
       - run: "mvn com.coveo:fmt-maven-plugin:format"
-      - uses: googleapis/code-suggester@v1.8.0
+      - uses: googleapis/code-suggester@v1.8.1
         with:
           command: review
           pull_number: {{ '${{ github.event.pull_request.number }}' }}


### PR DESCRIPTION
Updating here instead of: https://github.com/googleapis/java-bigtable/pull/526

Should this have been picked up as a renovate PR in this repo?