### PR TITLE
build(java): use actions/github-script v3 tag rather than full semver

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/approve-readme.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/approve-readme.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'googleapis' && github.head_ref == 'autosynth-readme'
     steps:
-      - uses: actions/github-script@v3.0.0
+      - uses: actions/github-script@v3
         with:
           github-token: {{ '${{secrets.YOSHI_APPROVER_TOKEN}}' }}
           script: |

--- a/synthtool/gcp/templates/java_library/.github/workflows/auto-release.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/auto-release.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.head_ref, 'release-v')
     steps:
-    - uses: actions/github-script@v3.0.0
+    - uses: actions/github-script@v3
       with:
         github-token: {{ '${{secrets.YOSHI_APPROVER_TOKEN}}' }}
         debug: true


### PR DESCRIPTION
So that renovate-bot stops proposing PRs like [this](https://github.com/googleapis/java-bigquerydatatransfer/pull/515/files)!