### PR TITLE
chore(java): retry staging portion of the release with backoff

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/common.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/common.sh
@@ -25,7 +25,6 @@ function retry_with_backoff {
     
     # allow a failures to continue
     set +e
-    echo "${command}"
     ${command}
     exit_code=$?
 


### PR DESCRIPTION
Tested: https://github.com/googleapis/java-container/pull/299 + https://github.com/googleapis/java-container/pull/303

It will now retry the staging portion of the release build up to 3 times.

Fixes https://github.com/googleapis/java-cloud-bom/issues/1241