### PR TITLE
test(python): give filesystem paths to pytest-cov

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -85,9 +85,8 @@ def default(session):
     session.run(
         "py.test",
         "--quiet",
-        "--cov=google.cloud{% if metadata['repo']['name'] %}.{{ metadata['repo']['name'] }}{% endif %}",
-        "--cov=google.cloud",
-        "--cov=tests.unit",
+        "--cov=google/cloud",
+        "--cov=tests/unit",
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",


### PR DESCRIPTION
https://pytest-cov.readthedocs.io/en/latest/config.html

The pytest-cov docs seem to suggest a filesystem path is expected.