### PR TITLE
fix: truncate new PR titles at 250 characters

### DIFF
--- a/autosynth/change_pusher.py
+++ b/autosynth/change_pusher.py
@@ -102,7 +102,7 @@ class ChangePusher(AbstractChangePusher):
             pr = self._gh.create_pull_request(
                 self._repository,
                 branch=branch,
-                title=pr_title,
+                title=pr_title[0:250],
                 body=new_body,
             )
 


### PR DESCRIPTION
This prevents autosynth from failing if the public description yields a PR title that is too long for github. (See #848)