### PR TITLE
fix: update noxfile.py.j2

### DIFF
--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -17,6 +17,7 @@ from __future__ import print_function
 import os
 from pathlib import Path
 import sys
+from typing import Callable, Dict, List, Optional
 
 import nox
 
@@ -68,7 +69,7 @@ except ImportError as e:
 TEST_CONFIG.update(TEST_CONFIG_OVERRIDE)
 
 
-def get_pytest_env_vars():
+def get_pytest_env_vars() -> Dict[str, str]:
     """Returns a dict for pytest invocation."""
     ret = {}
 
@@ -97,7 +98,7 @@ INSTALL_LIBRARY_FROM_SOURCE = bool(os.environ.get("INSTALL_LIBRARY_FROM_SOURCE",
 #
 
 
-def _determine_local_import_names(start_dir):
+def _determine_local_import_names(start_dir: str) -> List[str]:
     """Determines all import names that should be considered "local".
 
     This is used when running the linter to insure that import order is
@@ -135,7 +136,7 @@ FLAKE8_COMMON_ARGS = [
 
 
 @nox.session
-def lint(session):
+def lint(session> nox.sessions.Session) -> None:
     if not TEST_CONFIG['enforce_type_hints']:
         session.install("flake8", "flake8-import-order")
     else:
@@ -154,7 +155,7 @@ def lint(session):
 
 
 @nox.session
-def blacken(session):
+def blacken(session: nox.sessions.Session) -> None:
     session.install("black")
     python_files = [path for path in os.listdir(".") if path.endswith(".py")]
 
@@ -168,7 +169,7 @@ def blacken(session):
 PYTEST_COMMON_ARGS = ["--junitxml=sponge_log.xml"]
 
 
-def _session_tests(session, post_install=None):
+def _session_tests(session: nox.sessions.Session, post_install: Callable = None) -> None:
     """Runs py.test for a particular project."""
     if os.path.exists("requirements.txt"):
         session.install("-r", "requirements.txt")
@@ -194,7 +195,7 @@ def _session_tests(session, post_install=None):
 
 
 @nox.session(python=ALL_VERSIONS)
-def py(session):
+def py(session: nox.sessions.Session) -> None:
     """Runs py.test for a sample using the specified version of Python."""
     if session.python in TESTED_VERSIONS:
         _session_tests(session)
@@ -209,7 +210,7 @@ def py(session):
 #
 
 
-def _get_repo_root():
+def _get_repo_root() -> Optional[str]:
     """ Returns the root folder of the project. """
     # Get root of this repository. Assume we don't have directories nested deeper than 10 items.
     p = Path(os.getcwd())
@@ -232,7 +233,7 @@ GENERATED_READMES = sorted([x for x in Path(".").rglob("*.rst.in")])
 
 @nox.session
 @nox.parametrize("path", GENERATED_READMES)
-def readmegen(session, path):
+def readmegen(session: nox.sessions.Session, path: str) -> None:
     """(Re-)generates the readme for a sample."""
     session.install("jinja2", "pyyaml")
     dir_ = os.path.dirname(path)

--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -136,7 +136,7 @@ FLAKE8_COMMON_ARGS = [
 
 
 @nox.session
-def lint(session> nox.sessions.Session) -> None:
+def lint(session: nox.sessions.Session) -> None:
     if not TEST_CONFIG['enforce_type_hints']:
         session.install("flake8", "flake8-import-order")
     else:


### PR DESCRIPTION
add changes from @glasnt to the template template to ensure that enforcing type hinting doesn't fail for repos with the sample noxfile (aka all samples repos)
See https://github.com/GoogleCloudPlatform/python-docs-samples/pull/4869/files for context