### PR TITLE
docs: add instructions for authenticating for system tests

### DIFF
--- a/synthtool/gcp/templates/node_library/CONTRIBUTING.md
+++ b/synthtool/gcp/templates/node_library/CONTRIBUTING.md
@@ -37,6 +37,15 @@ accept your pull requests.
 1.  Title your pull request following [Conventional Commits](https://www.conventionalcommits.org/) styling.
 1.  Submit a pull request.
 
+### Before you begin
+
+1.  [Select or create a Cloud Platform project][projects].{% if metadata['repo']['requires_billing'] %}
+1.  [Enable billing for your project][billing].{% endif %}
+1.  {% if metadata['repo']['api_id'] %} [Enable the {{ metadata['repo']['name_pretty'] }} API][enable_api].
+1.  [Set up authentication with a service account][auth] so you can access the
+    API from your local workstation.
+{% endif %}
+
 ## Running the tests
 
 1.  [Prepare your environment for Node.js setup][setup].
@@ -55,7 +64,6 @@ accept your pull requests.
         npm run samples-test
 
         # Run all system tests.
-        gcloud auth application-default login
         npm run system-test
 
 1.  Lint (and maybe fix) any changes:
@@ -63,3 +71,7 @@ accept your pull requests.
         npm run fix
 
 [setup]: https://cloud.google.com/nodejs/docs/setup
+[projects]: https://console.cloud.google.com/project
+[billing]: https://support.google.com/cloud/answer/6293499#enable-billing
+{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}{% endif %}
+[auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/synthtool/gcp/templates/node_library/CONTRIBUTING.md
+++ b/synthtool/gcp/templates/node_library/CONTRIBUTING.md
@@ -40,11 +40,11 @@ accept your pull requests.
 ### Before you begin
 
 1.  [Select or create a Cloud Platform project][projects].{% if metadata['repo']['requires_billing'] %}
-1.  [Enable billing for your project][billing].{% endif %}
-1.  {% if metadata['repo']['api_id'] %} [Enable the {{ metadata['repo']['name_pretty'] }} API][enable_api].
+1.  [Enable billing for your project][billing].{% endif %} {% if metadata['repo']['api_id'] %}
+1.  [Enable the {{ metadata['repo']['name_pretty'] }} API][enable_api]. {% endif %}
 1.  [Set up authentication with a service account][auth] so you can access the
     API from your local workstation.
-{% endif %}
+
 
 ## Running the tests
 

--- a/synthtool/gcp/templates/node_library/CONTRIBUTING.md
+++ b/synthtool/gcp/templates/node_library/CONTRIBUTING.md
@@ -60,7 +60,6 @@ accept your pull requests.
         npm test
 
         # Run sample integration tests.
-        gcloud auth application-default login
         npm run samples-test
 
         # Run all system tests.

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -75,8 +75,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 {% if metadata['samples']|length %}
 ## Samples
 
-Samples are in the [`samples/`](https://github.com/{{  metadata['repo']['repo'] }}/tree/master/samples) directory. The samples' `README.md`
-has instructions for running the samples.
+Samples are in the [`samples/`](https://github.com/{{  metadata['repo']['repo'] }}/tree/master/samples) directory. Each sample's `README.md` has instructions for running its sample.
 
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -163,3 +163,5 @@ See [LICENSE](https://github.com/{{ metadata['repo']['repo'] }}/blob/master/LICE
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 {% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}{% endif %}
 [auth]: https://cloud.google.com/docs/authentication/getting-started
+
+quick check

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -163,5 +163,3 @@ See [LICENSE](https://github.com/{{ metadata['repo']['repo'] }}/blob/master/LICE
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 {% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}{% endif %}
 [auth]: https://cloud.google.com/docs/authentication/getting-started
-
-quick check


### PR DESCRIPTION
Addresses this docs question: https://github.com/googleapis/nodejs-googleapis-common/issues/327
We need to add authentication instructions when running system tests as well - these docs add to that.