### PR TITLE
fix(autosynth): apiary provider should include admin clients

### DIFF
--- a/autosynth/providers/apiary.py
+++ b/autosynth/providers/apiary.py
@@ -18,7 +18,7 @@ import re
 from autosynth import github
 from typing import Dict, List
 
-VERSION_REGEX = re.compile("(.*)\\.(v.*).json")
+VERSION_REGEX = re.compile("(.*)\\.(.*)\\.json")
 
 
 def list_apis() -> Dict[str, List[str]]:

--- a/tests/test_autosynth_apiary_provider.py
+++ b/tests/test_autosynth_apiary_provider.py
@@ -43,3 +43,14 @@ def test_list_all_libraries_admin_snowflakes(mock_list_files):
     apis = apiary.list_apis()
     assert len(apis) == 1
     assert apis["admin"] == ["directory_v1", "reports_v1"]
+
+
+@patch.object(GitHub, "list_files")
+@patch.dict(os.environ, {"GITHUB_TOKEN": "unused"})
+def test_list_all_libraries_skips_non_clients(mock_list_files):
+    mock_list_files.return_value = [
+        {"name": "synth-metadata.json"},
+        {"name": "foo.metadata"},
+    ]
+    apis = apiary.list_apis()
+    assert len(apis) == 0

--- a/tests/test_autosynth_apiary_provider.py
+++ b/tests/test_autosynth_apiary_provider.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest.mock import patch
+
+from autosynth.github import GitHub
+from autosynth.providers import apiary
+
+
+@patch.object(GitHub, "list_files")
+@patch.dict(os.environ, {"GITHUB_TOKEN": "unused"})
+def test_list_all_libraries(mock_list_files):
+    mock_list_files.return_value = [
+        {"name": "foo.v1.json"},
+        {"name": "foo.v1beta1.json"},
+        {"name": "bar.v2.json"},
+    ]
+    apis = apiary.list_apis()
+    assert len(apis) == 2
+    assert apis["foo"] == ["v1", "v1beta1"]
+    assert apis["bar"] == ["v2"]
+
+
+@patch.object(GitHub, "list_files")
+@patch.dict(os.environ, {"GITHUB_TOKEN": "unused"})
+def test_list_all_libraries_admin_snowflakes(mock_list_files):
+    mock_list_files.return_value = [
+        {"name": "admin.directory_v1.json"},
+        {"name": "admin.reports_v1.json"},
+    ]
+    apis = apiary.list_apis()
+    assert len(apis) == 1
+    assert apis["admin"] == ["directory_v1", "reports_v1"]


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-api-java-client-services/issues/6646