### PR TITLE
ci(java): ignore bot users for generate-files-bot

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/generated-files-bot.yml
+++ b/synthtool/gcp/templates/java_library/.github/generated-files-bot.yml
@@ -5,3 +5,7 @@ externalManifests:
 - type: json
   file: '.github/readme/synth.metadata/synth.metadata'
   jsonpath: '$.generatedFiles[*]'
+ignoreAuthors:
+- 'renovate-bot'
+- 'yoshi-automation'
+- 'release-please[bot]'


### PR DESCRIPTION
Depends on https://github.com/googleapis/repo-automation-bots/pull/1254

Fixes https://github.com/googleapis/repo-automation-bots/issues/1096