### PR TITLE
fix: Update apt before installing apt-transport-https

### DIFF
--- a/.kokoro-autosynth/dotnet-build.sh
+++ b/.kokoro-autosynth/dotnet-build.sh
@@ -27,8 +27,8 @@ curl -s https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > micr
 sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main" > /etc/apt/sources.list.d/dotnetdev.list'
 
-sudo apt-get -qq install -y apt-transport-https
 sudo apt-get -qq update
+sudo apt-get -qq install -y apt-transport-https
 sudo apt-get -qq install -y dotnet-sdk-2.2=2.2.105-1
 sudo apt-get -qq install -y dotnet-sdk-3.1=3.1.102-1
 


### PR DESCRIPTION
Fixes #881 (somewhat hopefully)