### PR TITLE
chore: exclude `.nox` directories from linting

### DIFF
--- a/synthtool/gcp/templates/python_library/.flake8
+++ b/synthtool/gcp/templates/python_library/.flake8
@@ -26,6 +26,7 @@ exclude =
   *_pb2.py
 
   # Standard linting exemptions.
+  **/.nox/**
   __pycache__,
   .git,
   *.pyc,


### PR DESCRIPTION
The samples tests create `.nox` directories
with all dependencies installed. These directories
should be excluded from linting.

I've tested this change locally, and it significantly
speeds up linting on my machine.