### PR TITLE
feat: Update Ruby Apiary metadata path to match Repo reorganization

### DIFF
--- a/autosynth/providers/ruby_apiary.py
+++ b/autosynth/providers/ruby_apiary.py
@@ -23,7 +23,7 @@ def list_repositories():
             "repository": "googleapis/google-api-ruby-client",
             "branch-suffix": f"{name}-{version}",
             "args": [name, version],
-            "metadata-path": f"generated/google/apis/{_client_dir(name, version)}",
+            "metadata-path": f"google-api-client/generated/google/apis/{_client_dir(name, version)}",
             "pr-title": f"feat: Automated regeneration of {name} {version} client",
         }
         for name, versions in apiary.list_apis().items() for version in versions


### PR DESCRIPTION
The Ruby Apiary repo is moving the main google-api-client gem into a subdirectory as a first step toward splitting the monopackage. (See https://github.com/googleapis/google-api-ruby-client/pull/1821) This means the metadata files are also moving.