### PR TITLE
fix: Listing apiary libraries correctly parses versions with dots

### DIFF
--- a/autosynth/providers/apiary.py
+++ b/autosynth/providers/apiary.py
@@ -18,7 +18,7 @@ import re
 from autosynth import github
 from typing import Dict, List
 
-VERSION_REGEX = re.compile("(.*)\\.(.*)\\.json")
+VERSION_REGEX = re.compile(r"([^\.]+)\.(.+)\.json")
 
 
 def list_apis() -> Dict[str, List[str]]:

--- a/tests/test_autosynth_apiary_provider.py
+++ b/tests/test_autosynth_apiary_provider.py
@@ -47,6 +47,18 @@ def test_list_all_libraries_admin_snowflakes(mock_list_files):
 
 @patch.object(GitHub, "list_files")
 @patch.dict(os.environ, {"GITHUB_TOKEN": "unused"})
+def test_list_all_libraries_dotted_versions(mock_list_files):
+    mock_list_files.return_value = [
+        {"name": "adexchangebuyer.v1.2.json"},
+        {"name": "adexchangebuyer.v1.3.json"},
+    ]
+    apis = apiary.list_apis()
+    assert len(apis) == 1
+    assert apis["adexchangebuyer"] == ["v1.2", "v1.3"]
+
+
+@patch.object(GitHub, "list_files")
+@patch.dict(os.environ, {"GITHUB_TOKEN": "unused"})
 def test_list_all_libraries_skips_non_clients(mock_list_files):
     mock_list_files.return_value = [
         {"name": "synth-metadata.json"},


### PR DESCRIPTION
The Apiary provider was incorrectly interpreting discovery docs with names that have a version with a dot. For example [adexchangebuyer.v1.2.json](https://github.com/googleapis/discovery-artifact-manager/blob/master/discoveries/adexchangebuyer.v1.2.json). The current incorrect behavior would yield a library name of `adexchangebuyer.v1` and a version of `2` (because of the greedy nature of the regex). This was causing Ruby apiary synth to malfunction for these libraries.

Fixed by adjusting the regex to insist that the service name never has a period. Added a test.

/cc @chingor13 because this might affect Java Apiary synth as well.