### PR TITLE
build(python): make `NOX_SESSION` optional

### DIFF
--- a/synthtool/gcp/templates/python_library/.trampolinerc
+++ b/synthtool/gcp/templates/python_library/.trampolinerc
@@ -18,7 +18,6 @@
 required_envvars+=(
     "STAGING_BUCKET"
     "V2_STAGING_BUCKET"
-    "NOX_SESSION"
 )
 
 # Add env vars which are passed down into the container here.


### PR DESCRIPTION
I added this accidentally in #889. `NOX_SESSION` should be passed down if it is set but not marked required.