### PR TITLE
fix: Properly underscore elixir directory names with digits in the middle

### DIFF
--- a/autosynth/providers/elixir.py
+++ b/autosynth/providers/elixir.py
@@ -46,7 +46,7 @@ def list_repositories():
 
 def _underscore(name: str) -> str:
     name = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", name)
-    name = re.sub(r"([a-z])([A-Z])", r"\1_\2", name)
+    name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
     return name.lower()
 
 


### PR DESCRIPTION
This is affecting the area120tables client, which Elixir is generating into the directory `area120_tables` but synthtool is trying to write the metadata file into `area120tables`, resulting in a synth failure (https://github.com/googleapis/elixir-google-api/issues/6707)