### PR TITLE
build(python): install google-api-core for python generator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ deprecation
 protobuf==3.14.0
 watchdog
 
+# https://github.com/googleapis/gapic-generator/issues/3334
 # temporarily install google-api-core for gapic-generator-python
 # Bazel should install this, but there is currently a bug
 # that causes the package to be skipped

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-# Pin to less than 49.6.0 as a workaround for https://github.com/pypa/setuptools/issues/2353
 setuptools==50.3.2
 
 nox
@@ -8,6 +7,11 @@ jinja2
 deprecation
 protobuf==3.14.0
 watchdog
+
+# temporarily install google-api-core for gapic-generator-python
+# Bazel should install this, but there is currently a bug
+# that causes the package to be skipped
+google-api-core<2.0.0
 
 # some java processing requires xml handling
 lxml


### PR DESCRIPTION
Temporary fix for the broken python autosynth builds. (https://github.com/googleapis/gapic-generator/issues/3334)


The python microgenerator requires `google-api-core`. Because of a package import issue `google-api-core` is not being installed and Python autosynth jobs are failing. The workaround is to install the python generator [requirements](https://github.com/googleapis/gapic-generator-python/blob/master/requirements.txt) on the Python version that will be used by bazel.


From @vam-google:
> it is a really sophisticated python package import issue, which arises when multiple https://packaging.python.org/guides/packaging-namespace-packages/#pkg-resources-style-namespace-packages packages with the same namespace are used from bazel, and unfortunately gogole.api_core and protobuf are like that (with google namespace)
