### PR TITLE
fix: pin mypy to version 0.790

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ def blacken(session):
 
 @nox.session(python=['3.6', '3.8'])
 def lint(session):
-    session.install('mypy', 'flake8', 'black==19.10b0')
+    session.install('mypy==0.790', 'flake8', 'black==19.10b0')
     session.run('pip', 'install', '-e', '.')
     session.run('black', '--check', 'synthtool', 'tests')
     session.run('flake8', 'synthtool', 'tests', 'autosynth', 'integration_tests')


### PR DESCRIPTION
so our presubmit doesn't spontaneously break when mypy releases a new version.

Fixes:
https://github.com/googleapis/synthtool/issues/920
https://github.com/googleapis/synthtool/issues/919