### PR TITLE
build(python): install google-api-core on default python

### DIFF
--- a/.kokoro-autosynth/build.sh
+++ b/.kokoro-autosynth/build.sh
@@ -52,10 +52,10 @@ git config --global credential.helper 'store --file ~/.git-credentials'
 # https://github.com/googleapis/gapic-generator/issues/3334
 # temporarily install google-api-core for gapic-generator-python
 # Bazel should install this, but there is currently a bug
-# that causes the package to be skipped
-# This is installed outside the virtualenv because Bazel seems to
-# install packages into its own directory.
-python3 -m pip install google-api-core==1.25.1 protobuf==1.14.0
+# that causes the package to be skipped.
+# This is intentionally installed *outside* the virtualenv
+# so Bazel can find and use it.
+python3 -m pip install google-api-core==1.25.1 protobuf==3.14.0
 
 python3 -m venv env
 source env/bin/activate

--- a/.kokoro-autosynth/build.sh
+++ b/.kokoro-autosynth/build.sh
@@ -49,6 +49,14 @@ export GITHUB_TOKEN=$(cat ${KOKORO_KEYSTORE_DIR}/73713_yoshi-automation-github-k
 echo "https://${GITHUB_TOKEN}:@github.com" >> ~/.git-credentials
 git config --global credential.helper 'store --file ~/.git-credentials'
 
+# https://github.com/googleapis/gapic-generator/issues/3334
+# temporarily install google-api-core for gapic-generator-python
+# Bazel should install this, but there is currently a bug
+# that causes the package to be skipped
+# This is installed outside the virtualenv because Bazel seems to
+# install packages into its own directory.
+python3 -m pip install google-api-core==1.25.1 protobuf==1.14.0
+
 python3 -m venv env
 source env/bin/activate
 python3 -m pip install --upgrade --quiet -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,3 @@
-# https://github.com/googleapis/gapic-generator/issues/3334
-# temporarily install google-api-core for gapic-generator-python
-# Bazel should install this, but there is currently a bug
-# that causes the package to be skipped
-google-api-core==1.25.1
 setuptools==50.3.2
 
 nox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+# https://github.com/googleapis/gapic-generator/issues/3334
+# temporarily install google-api-core for gapic-generator-python
+# Bazel should install this, but there is currently a bug
+# that causes the package to be skipped
+google-api-core==1.25.1
 setuptools==50.3.2
 
 nox
@@ -7,12 +12,6 @@ jinja2
 deprecation
 protobuf==3.14.0
 watchdog
-
-# https://github.com/googleapis/gapic-generator/issues/3334
-# temporarily install google-api-core for gapic-generator-python
-# Bazel should install this, but there is currently a bug
-# that causes the package to be skipped
-google-api-core==1.25.1
 
 # some java processing requires xml handling
 lxml


### PR DESCRIPTION
Bazel needs `google-api-core` installed on the default Python to use it. (I forgot that synthtool creates and uses a virtualenv which means #916 *did not* fix the autosynth builds). 

This time I tried running autosynth on my branch and it [succeeded](https://fusion.corp.google.com/runanalysis/info/prod:cloud-devrel%2Fclient-libraries%2Fautosynth%2Fpython/prod:cloud-devrel%2Fclient-libraries%2Fautosynth%2Fpython/KOKORO/6490b6f9-79ee-41b3-8813-ec1cd161dafb/1611802736080/build%20%231051/Targets). :) 

This is a temporary workaround until the namespace issues described in https://github.com/googleapis/gapic-generator/issues/3334 are sorted out.