### PR TITLE
chore: remove leading newline from LICENSE

### DIFF
--- a/synthtool/gcp/templates/java_library/LICENSE
+++ b/synthtool/gcp/templates/java_library/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
According to GitHub support, our Java repositories aren't detected as Apache-2.0 in their tooling due to the newline at the beginning of our LICENSE files:
https://github.com/googleapis/java-firestore/blob/master/LICENSE

This is annoying, but should get the GitHub API (and the UI) to report the correct license type. 