### PR TITLE
feat: add googleapis-gen as a tracked source

### DIFF
--- a/synthtool/gcp/pregenerated.py
+++ b/synthtool/gcp/pregenerated.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 import os
 
 from synthtool.log import logger

--- a/synthtool/gcp/pregenerated.py
+++ b/synthtool/gcp/pregenerated.py
@@ -19,20 +19,20 @@ import os
 from synthtool.log import logger
 from synthtool.sources import git
 
-GOOGLEAPIS_GEN_URL: str = git.make_repo_clone_url("googleapis/googleapis-gen")
-LOCAL_GOOGLEAPIS_GEN: Optional[str] = os.environ.get("SYNTHTOOL_GOOGLEAPIS_GEN")
-
 
 class Pregenerated:
     """A synthtool component that copies pregenerated bazel code."""
 
     def __init__(self):
-        if LOCAL_GOOGLEAPIS_GEN:
-            self._googleapis_gen = Path(LOCAL_GOOGLEAPIS_GEN).expanduser()
+        local_clone = os.environ.get("SYNTHTOOL_GOOGLEAPIS_GEN")
+        if local_clone:
+            self._googleapis_gen = Path(local_clone).expanduser()
             logger.debug(f"Using local googleapis-gen at {self._googleapis_gen}")
         else:
             logger.debug("Cloning googleapis-gen.")
-            self._googleapis_gen = git.clone(GOOGLEAPIS_GEN_URL)
+            self._googleapis_gen = git.clone(
+                git.make_repo_clone_url("googleapis/googleapis-gen")
+            )
 
     def generate(self, path: str) -> Path:
         return self._googleapis_gen / path

--- a/synthtool/gcp/pregenerated.py
+++ b/synthtool/gcp/pregenerated.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Optional, Union
+import os
+
+from synthtool.log import logger
+from synthtool.sources import git
+
+GOOGLEAPIS_GEN_URL: str = git.make_repo_clone_url("googleapis/googleapis-gen")
+LOCAL_GOOGLEAPIS_GEN: Optional[str] = os.environ.get("SYNTHTOOL_GOOGLEAPIS_GEN")
+
+
+class Pregenerated:
+    """A synthtool component that copies pregenerated bazel code."""
+
+    def __init__(self):
+        if LOCAL_GOOGLEAPIS_GEN:
+            self._googleapis_gen = Path(LOCAL_GOOGLEAPIS_GEN).expanduser()
+            logger.debug(f"Using local googleapis-gen at {self._googleapis_gen}")
+        else:
+            logger.debug("Cloning googleapis-gen.")
+            self._googleapis_gen = git.clone(GOOGLEAPIS_GEN_URL)
+
+    def generate(self, path: str) -> Path:
+        return self._googleapis_gen / path

--- a/synthtool/gcp/pregenerated.py
+++ b/synthtool/gcp/pregenerated.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Optional
 import os
 
 from synthtool.log import logger

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -20,7 +20,7 @@ import requests
 import synthtool as s
 import synthtool.gcp as gcp
 from synthtool import cache, shell
-from synthtool.gcp import common, partials, samples, snippets
+from synthtool.gcp import common, partials, pregenerated, samples, snippets
 from synthtool.log import logger
 from pathlib import Path
 from typing import Any, Optional, Dict, List
@@ -316,6 +316,46 @@ def bazel_library(
         destination_name=destination_name,
         cloud_api=cloud_api,
         diregapic=diregapic,
+    )
+
+    return library
+
+
+def pregenerated_library(
+    path: str,
+    service: str,
+    version: str,
+    destination_name: str = None,
+    cloud_api: bool = True,
+) -> Path:
+    """Generate a Java library using the gapic-generator via bazel.
+
+    Generates code into a temp directory, fixes missing header fields, and
+    copies into the expected locations.
+
+    Args:
+        path (str): Path in googleapis-gen to un-versioned generated code.
+        service (str): Name of the service.
+        version (str): Service API version.
+        destination_name (str, optional): Override the service name for the
+            destination of the output code. Defaults to the service name.
+        cloud_api (bool, optional): Whether or not this is a cloud API (for naming)
+
+    Returns:
+        The path to the temp directory containing the generated client.
+    """
+    generator = pregenerated.Pregenerated()
+    library = generator.generate(path)
+
+    cloud_prefix = "cloud-" if cloud_api else ""
+    _common_generation(
+        service=service,
+        version=version,
+        library=library / f"google-{cloud_prefix}{service}-{version}-java",
+        package_pattern="unused",
+        suffix="-java",
+        destination_name=destination_name,
+        cloud_api=cloud_api,
     )
 
     return library

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -306,11 +306,10 @@ def bazel_library(
         service=service, version=version, diregapic=diregapic, **kwargs
     )
 
-    cloud_prefix = "cloud-" if cloud_api else ""
     _common_generation(
         service=service,
         version=version,
-        library=library / f"google-{cloud_prefix}{service}-{version}-java",
+        library=library / f"google-cloud-{service}-{version}-java",
         package_pattern=package_pattern,
         suffix="-java",
         destination_name=destination_name,


### PR DESCRIPTION
Adds the ability to copy pregenerated code directly from `googleapis/googleapis-gen` rather than building it at runtime via bazel. This correctly can track the git source in synth.metadata and should allow autosynth to correctly binary search through history for context-aware-commits (googleapis and googleapis-gen have a 1:[0-1] relationship so history should be preserved).

Example `synth.py` for Java:

```python3
import synthtool.languages.java as java

service = 'domains'
versions = ['v1beta1']

for version in versions:
  java.pregenerated_library(
    service=service,
    version=version,
    path=f'google/cloud/{service}/{version}',
  )

java.common_templates()
```