### PR TITLE
build(java): update autorelease script

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/auto-release.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/auto-release.yaml
@@ -4,7 +4,7 @@ name: auto-release
 jobs:
   approve:
     runs-on: ubuntu-latest
-    if: contains(github.head_ref, 'release-v')
+    if: contains(github.head_ref, 'release-please')
     steps:
     - uses: actions/github-script@v3
       with:
@@ -16,7 +16,7 @@ jobs:
             return;
           }
 
-          // only approve PRs like "chore: release <release version>"
+          // only approve PRs like "chore(master): release <release version>"
           if ( !context.payload.pull_request.title.startsWith("chore(master): release") ) {
             return;
           }


### PR DESCRIPTION
Noticed the workflow was getting skipped on all the release PRs. Updating due to recent update in release-please branch name.