### PR TITLE
ci: linkage monitor CI job to use build.sh 

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -55,17 +55,10 @@ jobs:
         java-version: 8
     - run: java -version
     - name: Install artifacts to local Maven repository
-      run: |
-        source .kokoro/common.sh
-        retry_with_backoff 3 10 \
-            mvn install -B -V \
-                -Dmaven.test.skip -DskipTests=true \
-                -Dclirr.skip=true \
-                -Denforcer.skip=true \
-                -Dmaven.javadoc.skip=true \
-                -Dgcloud.download.skip=true
+      run: .kokoro/build.sh
       shell: bash
-    - uses: GoogleCloudPlatform/cloud-opensource-java/linkage-monitor@v1-linkagemonitor
+    - name: Validate any conflicts with regard to com.google.cloud:libraries-bom (latest release)
+      uses: GoogleCloudPlatform/cloud-opensource-java/linkage-monitor@v1-linkagemonitor
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR updates the GitHub Actions configuration for Linkage Monitor. Before this change, the CI configuration has "mvn install" command with 6 options. It turned out that a slight difference in the command line option from "build.sh" fails the build in google-auth-library-java repository (https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/1941). (@Neenu1995 found the build failure. Thanks!) 

Therefore, this change updates the configuration so that Linkage Monitor job just uses "build.sh" to install the artifacts into local Maven repository.

# How did I test?

I tested this change in java-spanner repository with this draft PR: https://github.com/googleapis/java-spanner/pull/868

<img width="889" alt="Screen Shot 2021-02-12 at 16 54 18" src="https://user-images.githubusercontent.com/28604/107826467-f3cd5c80-6d52-11eb-86f1-1a8053326978.png">

It succeeded.