### PR TITLE
build(python): enable flakybot on library unit and system tests

### DIFF
--- a/synthtool/gcp/templates/python_library/.gitignore
+++ b/synthtool/gcp/templates/python_library/.gitignore
@@ -50,8 +50,10 @@ docs.metadata
 
 # Virtual environment
 env/
+
+# Test logs
 coverage.xml
-sponge_log.xml
+*sponge_log.xml
 
 # System test environment variables.
 system_tests/local_test_setup

--- a/synthtool/gcp/templates/python_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/build.sh
@@ -40,6 +40,16 @@ python3 -m pip uninstall --yes --quiet nox-automation
 python3 -m pip install --upgrade --quiet nox
 python3 -m nox --version
 
+# If this is a continuous build, send the test log to the FlakyBot.
+# See https://github.com/googleapis/repo-automation-bots/tree/master/packages/flakybot.
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+  cleanup() {
+    chmod +x $KOKORO_GFILE_DIR/linux_amd64/flakybot
+    $KOKORO_GFILE_DIR/linux_amd64/flakybot
+  }
+  trap cleanup EXIT HUP
+fi
+
 # If NOX_SESSION is set, it only runs the specified session,
 # otherwise run all the sessions.
 if [[ -n "${NOX_SESSION:-}" ]]; then

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -108,6 +108,7 @@ def default(session):
     session.run(
         "py.test",
         "--quiet",
+        f"--junitxml=unit_{session.python}_sponge_log.xml",
         "--cov=google/cloud",
         "--cov=tests/unit",
         "--cov-append",
@@ -169,9 +170,21 @@ def system(session):
 
     # Run py.test against the system tests.
     if system_test_exists:
-        session.run("py.test", "--quiet", system_test_path, *session.posargs)
+        session.run(
+            "py.test",
+            "--quiet",
+            f"--junitxml=system_{session.python}_sponge_log.xml",
+            system_test_path,
+            *session.posargs
+        )
     if system_test_folder_exists:
-        session.run("py.test", "--quiet", system_test_folder_path, *session.posargs)
+        session.run(
+            "py.test",
+            "--quiet",
+            f"--junitxml=system_{session.python}_sponge_log.xml",
+            system_test_folder_path,
+            *session.posargs
+        )
 
 {% if samples_test %}
 @nox.session(python=["2.7", "3.7"])


### PR DESCRIPTION
Enable flakybot reporting on library unit and system tests for Python.

See https://github.com/googleapis/python-grafeas/pull/58 (PR) and https://github.com/googleapis/python-grafeas/issues/59 (flakybot issue) for an example of this in action.