### PR TITLE
feat(owlbot): build linter into node container

### DIFF
--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -51,7 +51,7 @@ COPY docker /synthtool/docker
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN /bin/bash -c "source /root/.nvm/nvm.sh && mkdir node_modules && npm i gts@3.1.0 google-gax@2.10.3 typescript@3.9.9"
+RUN /bin/bash -c "source /root/.nvm/nvm.sh && cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@2.10.3 typescript@3.9.9"
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -46,7 +46,10 @@ ENV SYNTHTOOL_TEMPLATES="/synthtool/synthtool/gcp/templates"
 COPY synthtool /synthtool/synthtool
 COPY autosynth /synthtool/autosynth
 COPY docker /synthtool/docker
-RUN cd /synthtool; mkdir node_modules; npm i gts@3.1.0 google-gax@2.10.3
+# Install dependencies used for post processing:
+# * gts/typescript are used for linting.
+# * google-gax is used for compiling protos.
+RUN cd /synthtool; mkdir node_modules; npm i gts@3.1.0 google-gax@2.10.3 typescript@3.9.9
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Version 0.1.0
+
 # build from the root of this repo:
 # docker build -t gcr.io/cloud-devrel-kokoro-resources/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .
-LABEL version="0.1.0"
 FROM python:3.6.12-buster
 
 WORKDIR /

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Version 0.1.0
+# Version 0.1.1
 
 # build from the root of this repo:
 # docker build -t gcr.io/cloud-devrel-kokoro-resources/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -52,6 +52,9 @@ COPY docker /synthtool/docker
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
 RUN /bin/bash -c "source /root/.nvm/nvm.sh && mkdir node_modules && npm i gts@3.1.0 google-gax@2.10.3 typescript@3.9.9"
+# Move .bashrc to a location that will still exist when running
+# Cloud Build with "dir":
+RUN /bin/bash -c "cp $HOME/.bashrc /synthtool/.bashrc"
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -51,7 +51,7 @@ COPY docker /synthtool/docker
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN cd /synthtool; mkdir node_modules; npm i gts@3.1.0 google-gax@2.10.3 typescript@3.9.9
+RUN /bin/bash -c "source /root/.nvm/nvm.sh && mkdir node_modules && npm i gts@3.1.0 google-gax@2.10.3 typescript@3.9.9"
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -52,9 +52,6 @@ COPY docker /synthtool/docker
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
 RUN /bin/bash -c "source /root/.nvm/nvm.sh && mkdir node_modules && npm i gts@3.1.0 google-gax@2.10.3 typescript@3.9.9"
-# Move .bashrc to a location that will still exist when running
-# Cloud Build with "dir":
-RUN /bin/bash -c "cp $HOME/.bashrc /synthtool/.bashrc"
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -14,6 +14,7 @@
 
 # build from the root of this repo:
 # docker build -t gcr.io/cloud-devrel-kokoro-resources/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .
+LABEL version="0.1.0"
 FROM python:3.6.12-buster
 
 WORKDIR /

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -46,6 +46,7 @@ ENV SYNTHTOOL_TEMPLATES="/synthtool/synthtool/gcp/templates"
 COPY synthtool /synthtool/synthtool
 COPY autosynth /synthtool/autosynth
 COPY docker /synthtool/docker
+RUN cd /synthtool; npm init; npm i gts@3.1.0 google-gax@2.10.3
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -46,7 +46,7 @@ ENV SYNTHTOOL_TEMPLATES="/synthtool/synthtool/gcp/templates"
 COPY synthtool /synthtool/synthtool
 COPY autosynth /synthtool/autosynth
 COPY docker /synthtool/docker
-RUN cd /synthtool; npm init; npm i gts@3.1.0 google-gax@2.10.3
+RUN cd /synthtool; mkdir node_modules; npm i gts@3.1.0 google-gax@2.10.3
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/cloudbuild.yaml
+++ b/docker/owlbot/nodejs/cloudbuild.yaml
@@ -1,10 +1,10 @@
 steps:
     - name: 'gcr.io/cloud-builders/docker'
       args: [ 'build',
-        '-t', 'gcr.io/cloud-devrel-kokoro-resources/owlbot-nodejs:$SHORT_SHA',
-        '-t', 'gcr.io/cloud-devrel-kokoro-resources/owlbot-nodejs:latest', 
+        '-t', 'gcr.io/repo-automation-bots/owlbot-nodejs:$SHORT_SHA',
+        '-t', 'gcr.io/repo-automation-bots/owlbot-nodejs:latest',
         '-f', 'docker/owlbot/nodejs/Dockerfile', '.' ]
     - name: 'gcr.io/cloud-builders/docker'
-      args: ['push', 'gcr.io/cloud-devrel-kokoro-resources/owlbot-nodejs:$SHORT_SHA']
+      args: ['push', 'gcr.io/repo-automation-bots/owlbot-nodejs:$SHORT_SHA']
     - name: 'gcr.io/cloud-builders/docker'
-      args: ['push', 'gcr.io/cloud-devrel-kokoro-resources/owlbot-nodejs:latest']            
+      args: ['push', 'gcr.io/repo-automation-bots/owlbot-nodejs:latest']

--- a/docker/owlbot/nodejs/entrypoint.sh
+++ b/docker/owlbot/nodejs/entrypoint.sh
@@ -15,6 +15,5 @@
 
 set -e
 source /root/.nvm/nvm.sh
-export PYTHONPATH="/synthtool"
 set -x
 python owlbot.py

--- a/docker/owlbot/nodejs/entrypoint.sh
+++ b/docker/owlbot/nodejs/entrypoint.sh
@@ -16,6 +16,6 @@
 set -e
 # Doesn't get sourced in a login shell, according to bash's man page and confirmed
 # via experiment, so we have to source it manually.
-source "$HOME/.bashrc"
+source "/.bashrc"
 set -x
 python owlbot.py

--- a/docker/owlbot/nodejs/entrypoint.sh
+++ b/docker/owlbot/nodejs/entrypoint.sh
@@ -13,12 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-# Doesn't get sourced in a login shell, according to bash's man page and confirmed
-# via experiment, so we have to source it manually.
-echo "ATTEMPT TO SOURCE .bashrc"
-source "/root/.bashrc"
-echo "FINISHED SOURCING"
 set -x
-echo "ATTEMPT TO RUN PYTHON"
+export PYTHONPATH="/synthtool"
 python owlbot.py

--- a/docker/owlbot/nodejs/entrypoint.sh
+++ b/docker/owlbot/nodejs/entrypoint.sh
@@ -16,6 +16,9 @@
 set -e
 # Doesn't get sourced in a login shell, according to bash's man page and confirmed
 # via experiment, so we have to source it manually.
+echo "ATTEMPT TO SOURCE .bashrc"
 source "/root/.bashrc"
+echo "FINISHED SOURCING"
 set -x
+echo "ATTEMPT TO RUN PYTHON"
 python owlbot.py

--- a/docker/owlbot/nodejs/entrypoint.sh
+++ b/docker/owlbot/nodejs/entrypoint.sh
@@ -16,6 +16,6 @@
 set -e
 # Doesn't get sourced in a login shell, according to bash's man page and confirmed
 # via experiment, so we have to source it manually.
-source "/.bashrc"
+source "/synthtool/.bashrc"
 set -x
 python owlbot.py

--- a/docker/owlbot/nodejs/entrypoint.sh
+++ b/docker/owlbot/nodejs/entrypoint.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
+set -e
+source /root/.nvm/nvm.sh
 export PYTHONPATH="/synthtool"
+set -x
 python owlbot.py

--- a/docker/owlbot/nodejs/entrypoint.sh
+++ b/docker/owlbot/nodejs/entrypoint.sh
@@ -16,6 +16,6 @@
 set -e
 # Doesn't get sourced in a login shell, according to bash's man page and confirmed
 # via experiment, so we have to source it manually.
-source "/synthtool/.bashrc"
+source "/root/.bashrc"
 set -x
 python owlbot.py

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -23,6 +23,7 @@ from synthtool.sources import git
 from typing import Any, Dict, List
 
 _REQUIRED_FIELDS = ["name", "repository"]
+_TOOLS_DIRECTORY = "/synthtool"
 
 
 def read_metadata():
@@ -179,6 +180,22 @@ def fix(hide_output=False):
     shell.run(["npm", "run", "fix"], hide_output=hide_output)
 
 
+def fix_hermetic(hide_output=False):
+    """
+    Fixes the formatting in the current Node.js library. It assumes that gts
+    is already installed in a well known location on disk:
+    """
+    logger.debug("Copy eslint config")
+    shell.run(
+        ["cp", "-r", f"{_TOOLS_DIRECTORY}/node_modules", "."], hide_output=hide_output
+    )
+    logger.debug("Running fix...")
+    shell.run(
+        [f"{_TOOLS_DIRECTORY}/node_modules/.bin/gts", "fix", "src"],
+        hide_output=hide_output,
+    )
+
+
 def compile_protos(hide_output=False):
     """
     Compiles protos into .json, .js, and .d.ts files using
@@ -188,9 +205,28 @@ def compile_protos(hide_output=False):
     shell.run(["npx", "compileProtos", "src"], hide_output=hide_output)
 
 
+def compile_protos_hermetic(hide_output=False):
+    """
+    Compiles protos into .json, .js, and .d.ts files using
+    compileProtos script from google-gax.
+    """
+    logger.debug("Compiling protos...")
+    shell.run(
+        [f"{_TOOLS_DIRECTORY}/node_modules/.bin/compileProtos", "src"],
+        hide_output=hide_output,
+    )
+
+
 def postprocess_gapic_library(hide_output=False):
     logger.debug("Post-processing GAPIC library...")
     install(hide_output=hide_output)
     fix(hide_output=hide_output)
     compile_protos(hide_output=hide_output)
+    logger.debug("Post-processing completed")
+
+
+def postprocess_gapic_library_hermetic(hide_output=False):
+    logger.debug("Post-processing GAPIC library...")
+    fix_hermetic(hide_output=hide_output)
+    compile_protos_hermetic(hide_output=hide_output)
     logger.debug("Post-processing completed")

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -189,7 +189,7 @@ def fix_hermetic(hide_output=False):
     shell.run(
         ["cp", "-r", f"{_TOOLS_DIRECTORY}/node_modules", "."],
         check=True,
-        hide_output=hide_output
+        hide_output=hide_output,
     )
     logger.debug("Running fix...")
     shell.run(

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -187,11 +187,14 @@ def fix_hermetic(hide_output=False):
     """
     logger.debug("Copy eslint config")
     shell.run(
-        ["cp", "-r", f"{_TOOLS_DIRECTORY}/node_modules", "."], hide_output=hide_output
+        ["cp", "-r", f"{_TOOLS_DIRECTORY}/node_modules", "."],
+        check=True,
+        hide_output=hide_output
     )
     logger.debug("Running fix...")
     shell.run(
         [f"{_TOOLS_DIRECTORY}/node_modules/.bin/gts", "fix", "src"],
+        check=True,
         hide_output=hide_output,
     )
 
@@ -213,6 +216,7 @@ def compile_protos_hermetic(hide_output=False):
     logger.debug("Compiling protos...")
     shell.run(
         [f"{_TOOLS_DIRECTORY}/node_modules/.bin/compileProtos", "src"],
+        check=True,
         hide_output=hide_output,
     )
 


### PR DESCRIPTION
1. install linter when docker container is created.
2. introduce `postprocess_gapic_library_hermetic` which allows post processing to be run without an `npm install` step.