### PR TITLE
build(node): lint system-test and test

### DIFF
--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -193,7 +193,13 @@ def fix_hermetic(hide_output=False):
     )
     logger.debug("Running fix...")
     shell.run(
-        [f"{_TOOLS_DIRECTORY}/node_modules/.bin/gts", "fix", "src"],
+        [
+            f"{_TOOLS_DIRECTORY}/node_modules/.bin/gts",
+            "fix",
+            "src",
+            "test",
+            "system-test",
+        ],
         check=True,
         hide_output=hide_output,
     )


### PR DESCRIPTION
We were not linting `test`/`system-test`, which leads to linting issues, see: https://github.com/googleapis/nodejs-document-ai/pull/160