### PR TITLE
fix(owl-bot): add script that reverts license year changes

### DIFF
--- a/docker/owlbot/nodejs/entrypoint.sh
+++ b/docker/owlbot/nodejs/entrypoint.sh
@@ -17,3 +17,6 @@ set -e
 source /root/.nvm/nvm.sh
 set -x
 python owlbot.py
+
+# put back any modified license years
+/synthtool/docker/owlbot/nodejs/restore_license_headers.sh

--- a/docker/owlbot/nodejs/restore_license_headers.sh
+++ b/docker/owlbot/nodejs/restore_license_headers.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# list the modified files in the current commit
+last_commit_files=$(git diff-tree --no-commit-id -r $(git rev-parse HEAD) --name-only --diff-filter=M)
+
+# list the modified, uncommited files
+current_modified_files=$(git diff --name-only HEAD)
+
+# join and deduplicate the list
+all_files=$(echo ${last_commit_files} ${current_modified_files} | sort -u)
+
+for file in ${all_files}
+do
+  # look for the Copyright YYYY line within the first 10 lines
+  old_copyright=$(git show HEAD~1:${file} | head -n 10 | egrep -o -e "Copyright ([[:digit:]]{4})")
+  new_copyright=$(cat ${file} | head -n 10 | egrep -o -e "Copyright ([[:digit:]]{4})")
+  # if the header year changed in the last diff, then restore the previous year
+  if [ ! -z "${old_copyright}" ] && [ ! -z "${new_copyright}" ] && [ "${old_copyright}" != "${new_copyright}" ]
+  then
+    echo "Restoring copyright in ${file} to '${old_copyright}'"
+    # replace the first instance of the old copyright header with the new
+    sed -i "s/${new_copyright}/${old_copyright}/1" ${file}
+  fi
+done

--- a/docker/owlbot/nodejs/restore_license_headers.sh
+++ b/docker/owlbot/nodejs/restore_license_headers.sh
@@ -27,8 +27,8 @@ all_files=$(echo ${last_commit_files} ${current_modified_files} | sort -u)
 for file in ${all_files}
 do
   # look for the Copyright YYYY line within the first 10 lines
-  old_copyright=$(git show HEAD~1:${file} | head -n 10 | egrep -o -e "Copyright ([[:digit:]]{4})")
-  new_copyright=$(cat ${file} | head -n 10 | egrep -o -e "Copyright ([[:digit:]]{4})")
+  old_copyright=$(git show HEAD~1:${file} | head -n 10 | egrep -o -e "Copyright ([[:digit:]]{4})" || echo "")
+  new_copyright=$(cat ${file} | head -n 10 | egrep -o -e "Copyright ([[:digit:]]{4})" || echo "")
   # if the header year changed in the last diff, then restore the previous year
   if [ ! -z "${old_copyright}" ] && [ ! -z "${new_copyright}" ] && [ "${old_copyright}" != "${new_copyright}" ]
   then


### PR DESCRIPTION
This script looks at the previous commit and current changes to see if any license headers changed. The heuristic for detecting the license header is a regex: `Copyright \d{4}` in the first 10 lines of the file. We compare the current version of the file against the version in the previous commit. If we find a copyright year in both versions and they have changed, we replace the copyright year with the one from the previous commit.

For now, this script can be included directly in the owl-bot post processor, but in the future could be put into its own dedicated post-processor if owl-bot supports multiple post processors.