### PR TITLE
chore: add pre-commit-config to renovate ignore paths

### DIFF
--- a/synthtool/gcp/templates/python_library/renovate.json
+++ b/synthtool/gcp/templates/python_library/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base",  ":preserveSemverRanges"
-  ]
+  ],
+  "ignorePaths": [".pre-commit-config.yaml"]
 }


### PR DESCRIPTION
Disable renovate PRs on the .preo-commit-config.yaml which is templated from synthtool. https://docs.renovatebot.com/configuration-options/#ignorepaths