### PR TITLE
fix(owlbot-java): after copying code, fix the license headers

### DIFF
--- a/docker/owlbot/java/bin/entrypoint.sh
+++ b/docker/owlbot/java/bin/entrypoint.sh
@@ -30,6 +30,11 @@ echo "Generating clirr-ignored-differences.xml..."
 /owlbot/bin/write_clirr_ignore.sh
 echo "...done"
 
+# fix license headers
+echo "Fixing missing license headers..."
+/owlbot/bin/fix_license_headers.sh
+echo "...done"
+
 # TODO: re-enable this once we resolve thrashing
 # restore license headers years
 # echo "Restoring copyright years..."

--- a/docker/owlbot/java/bin/fix_license_headers.sh
+++ b/docker/owlbot/java/bin/fix_license_headers.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+python3 /owlbot/src/fix-license-headers.py

--- a/docker/owlbot/java/src/fix-license-headers.py
+++ b/docker/owlbot/java/src/fix-license-headers.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+import glob
+from synthtool.languages import java
+
+
+root = Path(".").resolve()
+
+# Until the generator generates license headers on generated proto
+# classes, add the license headers in
+for path in glob.glob("proto-google-*"):
+    java.fix_proto_headers(root / path)
+
+# Until the generator generates license headers on generated grpc
+# classes, add the license headers in
+for path in glob.glob("grpc-google-*"):
+    java.fix_grpc_headers(root / path, "unused")


### PR DESCRIPTION
Note this requires #1008 or if run after synthtool generation, we will duplicate license headers.