### PR TITLE
build(python): update docfx job to use new plugin

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -257,9 +257,7 @@ def docfx(session):
     """Build the docfx yaml files for this library."""
 
     session.install("-e", ".")
-    # sphinx-docfx-yaml supports up to sphinx version 1.5.5.
-    # https://github.com/docascode/sphinx-docfx-yaml/issues/97
-    session.install("sphinx==1.5.5", "alabaster", "recommonmark", "sphinx-docfx-yaml")
+    session.install("sphinx", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(


### PR DESCRIPTION
The restriction for sphinx version on `sphinx-docfx-yaml` is now removed with `gcp-sphinx-docfx-yaml`. The new plugin has no changes from the original plugin other than allowing newer Sphinx version to be used, thus we can safely update client libraries to make use of the new plugin.

Fixes https://github.com/googleapis/doc-templates/issues/94