### PR TITLE
chore: Use python 3.6.13-buster for owlbot post-processor

### DIFF
--- a/docker/owlbot/python/Dockerfile
+++ b/docker/owlbot/python/Dockerfile
@@ -16,7 +16,7 @@
 
 # build from the root of this repo:
 # docker build -t gcr.io/cloud-devrel-kokoro-resources/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .
-FROM python:3.9.4-buster
+FROM python:3.6.13-buster
 
 WORKDIR /
 


### PR DESCRIPTION
The owlbot post processor is failing in googleapis/python-artifact-registry/pull/11 with the following error:
```
nox > Running session blacken
nox > Session blacken failed: Python interpreter 3.6 not found.
2021-04-05 21:15:39,278 synthtool > Failed executing nox -s blacken:

None
```
If I change the base image to `python:3.6.13-buster` in the Dockerfile, I no longer see the failure. Python 3.6 is required for the nox blacken session.
https://github.com/googleapis/python-artifact-registry/blob/master/noxfile.py#L65