### PR TITLE
feat: expose get_staging_dirs() for Python

### DIFF
--- a/docker/owlbot/python/Dockerfile
+++ b/docker/owlbot/python/Dockerfile
@@ -15,7 +15,7 @@
 # Version 0.2.0
 
 # build from the root of this repo:
-# docker build -t gcr.io/cloud-devrel-kokoro-resources/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .
+# docker build -t gcr.io/repo-automation-bots/owlbot-python -f docker/owlbot/python/Dockerfile .
 FROM python:3.6.13-buster
 
 WORKDIR /

--- a/synthtool/__init__.py
+++ b/synthtool/__init__.py
@@ -16,12 +16,25 @@
 
 import sys
 
-from synthtool.transforms import move, replace, dont_overwrite
+from synthtool.transforms import (
+    move,
+    replace,
+    dont_overwrite,
+    get_staging_dirs,
+    remove_staging_dirs,
+)
 from synthtool.log import logger
 
 copy = move
 
-__all__ = ["copy", "move", "replace", "dont_overwrite"]
+__all__ = [
+    "copy",
+    "move",
+    "replace",
+    "dont_overwrite",
+    "get_staging_dirs",
+    "remove_staging_dirs",
+]
 
 # Make sure that synthtool is being used instead of running the synth file
 # directly

--- a/synthtool/languages/python.py
+++ b/synthtool/languages/python.py
@@ -14,15 +14,15 @@
 
 import re
 import sys
-import yaml
 from pathlib import Path
 from typing import Any, Dict
 
+import yaml
+
 import synthtool as s
-from synthtool import log, shell, _tracked_paths
+from synthtool import _tracked_paths, log, shell
 from synthtool.gcp.common import CommonTemplates
 from synthtool.sources import templates
-
 
 PathOrStr = templates.PathOrStr
 
@@ -145,24 +145,3 @@ def py_samples(*, root: PathOrStr = None, skip_readmes: bool = False) -> None:
         result = t.render(subdir=sample_project_dir, **sample_readme_metadata)
         _tracked_paths.add(result)
         s.copy([result], excludes=excludes)
-
-
-def owlbot_main():
-    """Copies files from staging and template directories into current working dir.
-
-    When there is no owlbot.py file, run this function instead.  Also, when an
-    owlbot.py file is necessary, the first statement of owlbot.py should probably
-    call this function.
-    """
-
-    templated_files = CommonTemplates().py_library(cov_level=99, microgenerator=True)
-
-    # the microgenerator has a good coveragerc file
-    excludes = [".coveragerc"]
-    s.move(templated_files, excludes=excludes)
-
-    s.shell.run(["nox", "-s", "blacken"], hide_output=False)
-
-
-if __name__ == "__main__":
-    owlbot_main()

--- a/synthtool/transforms.py
+++ b/synthtool/transforms.py
@@ -56,7 +56,7 @@ def _expand_paths(paths: ListOfPathsOrStrs, root: PathOrStr = None) -> Iterable[
                 remainder = str(path.relative_to(path.anchor))
                 yield from anchor.glob(remainder)
             else:
-                yield path
+                yield from root.glob(str(path))
         else:
             yield from (
                 p

--- a/synthtool/transforms.py
+++ b/synthtool/transforms.py
@@ -14,7 +14,7 @@
 
 from pathlib import Path
 import shutil
-from typing import Callable, Iterable, Union
+from typing import Callable, Iterable, Union, List
 import os
 import re
 import sys
@@ -275,3 +275,35 @@ def replace(
             "replacement is no longer needed?"
         )
     return count_replaced
+
+
+def get_staging_dirs(default_version: str) -> List[Path]:
+    """Returns the list of directories, one per version, copied from
+    https://github.com/googleapis/googleapis-gen.
+
+    Args:
+      default_version: the default version of the API. The directory for this version
+        will be the last item in the returned list.
+
+    Returns: the empty list if no file were copied.
+    """
+
+    staging = Path("owl-bot-staging")
+    if staging.is_dir():
+        # Collect the subdirectories of the staging directory.
+        versions = [v.name for v in staging.iterdir() if v.is_dir()]
+        # Reorder the versions so the default version always comes last.
+        versions = [v for v in versions if v != default_version] + [default_version]
+        dirs = [staging / v for v in versions]
+        for dir in dirs:
+            _tracked_paths.add(dir)
+        return dirs
+    else:
+        return []
+
+
+def remove_staging_dirs():
+    """Removes all the staging directories."""
+    staging = Path("owl-bot-staging")
+    if staging.is_dir():
+        shutil.rmtree(staging)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -208,14 +208,14 @@ def test_simple_replace(expand_path_fixtures):
 
 def test_replace_one(expand_path_fixtures):
     # Lots of synth.py files pass a single string as the first argument.
-    count_replaced = transforms.replace("b.py", "b..a", "GA")
+    count_replaced = transforms.replace("*.py", "b..a", "GA")
     assert 1 == count_replaced
     assert "GA python" == open("b.py", "rt").read()
 
 
 def test_replace_one_path(expand_path_fixtures):
     # Lots of synth.py files pass a single Path as the first argument.
-    count_replaced = transforms.replace(pathlib.Path("b.py"), "b..a", "GA")
+    count_replaced = transforms.replace(pathlib.Path("*.py"), "b..a", "GA")
     assert 1 == count_replaced
     assert "GA python" == open("b.py", "rt").read()
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -23,6 +23,7 @@ import pytest
 
 from synthtool import transforms
 from synthtool import _tracked_paths
+import pathlib
 
 
 @pytest.fixture()
@@ -202,6 +203,20 @@ def test_simple_replace(expand_path_fixtures):
     count_replaced = transforms.replace(["a.txt", "b.py"], "b..a", "GA")
     assert 1 == count_replaced
     assert "alpha text" == open("a.txt", "rt").read()
+    assert "GA python" == open("b.py", "rt").read()
+
+
+def test_replace_one(expand_path_fixtures):
+    # Lots of synth.py files pass a single string as the first argument.
+    count_replaced = transforms.replace("b.py", "b..a", "GA")
+    assert 1 == count_replaced
+    assert "GA python" == open("b.py", "rt").read()
+
+
+def test_replace_one_path(expand_path_fixtures):
+    # Lots of synth.py files pass a single Path as the first argument.
+    count_replaced = transforms.replace(pathlib.Path("b.py"), "b..a", "GA")
+    assert 1 == count_replaced
     assert "GA python" == open("b.py", "rt").read()
 
 


### PR DESCRIPTION
Almost every synth.py for a Python library has naughty code.  So there's no hope of Python repos without owlbot.py files.  Instead, we'll replace the call to gapic.py_library() with a call to get_staging_dirs().