### PR TITLE
meta: add  @googleapis/github-automation as owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*   @SurferJeffAtGoogle @chingor13 @bcoe
+*   @SurferJeffAtGoogle @chingor13 @bcoe @googleapis/github-automation
 
 # assign templates to the language team that owns them
 synthtool/gcp/templates/java_library/          @googleapis/yoshi-java


### PR DESCRIPTION
Add the additional `@googleapis/github-automation` team as owner.