### PR TITLE
feat: add excludes and patch callback arguments to owlbot_main

### DIFF
--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -15,7 +15,7 @@
 # Version 0.2.0
 
 # build from the root of this repo:
-# docker build -t gcr.io/cloud-devrel-kokoro-resources/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .
+# docker build -t gcr.io/repo-automation-bots/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .
 FROM python:3.9.4-buster
 
 WORKDIR /

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -16,6 +16,7 @@ import json
 import os
 import re
 import shutil
+import fnmatch
 from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -278,8 +279,9 @@ class CommonTemplates:
         kwargs["metadata"] = node.template_metadata()
         kwargs["publish_token"] = node.get_publish_token(kwargs["metadata"]["name"])
 
+        ignore_src_index = ["yes" for f in self.excludes if fnmatch.fnmatch("src/index.ts", f)]
         # generate root-level `src/index.ts` to export multiple versions and its default clients
-        if "versions" in kwargs and "default_version" in kwargs:
+        if "versions" in kwargs and "default_version" in kwargs and not ignore_src_index:
             node.generate_index_ts(
                 versions=kwargs["versions"], default_version=kwargs["default_version"]
             )

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -279,9 +279,15 @@ class CommonTemplates:
         kwargs["metadata"] = node.template_metadata()
         kwargs["publish_token"] = node.get_publish_token(kwargs["metadata"]["name"])
 
-        ignore_src_index = ["yes" for f in self.excludes if fnmatch.fnmatch("src/index.ts", f)]
+        ignore_src_index = [
+            "yes" for f in self.excludes if fnmatch.fnmatch("src/index.ts", f)
+        ]
         # generate root-level `src/index.ts` to export multiple versions and its default clients
-        if "versions" in kwargs and "default_version" in kwargs and not ignore_src_index:
+        if (
+            "versions" in kwargs
+            and "default_version" in kwargs
+            and not ignore_src_index
+        ):
             node.generate_index_ts(
                 versions=kwargs["versions"], default_version=kwargs["default_version"]
             )

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -287,7 +287,8 @@ def owlbot_main(
 
     Args:
         template_path: path to template directory; omit except in tests.
-        ignores: paths to ignore when copying files from staging and from templates.
+        staging_excludes: paths to ignore when copying from the staging directory
+        templates_excludes: paths to ignore when copying generated templates
         patch_staging: callback function runs on each staging directory before
           copying it into repo root.  Add your regular expression substitution code
           here.

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -270,7 +270,7 @@ def postprocess_gapic_library_hermetic(hide_output=False):
 
 
 default_staging_excludes = ["README.md", "package.json", "src/index.ts"]
-default_templates_excludes = []
+default_templates_excludes: List[str] = []
 
 
 def _noop(library: Path) -> None:

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -344,6 +344,7 @@ def owlbot_main(
         versions = [v for v in versions if v != default_version] + [default_version]
 
     common_templates = gcp.CommonTemplates(template_path)
+    common_templates.excludes.extend(ignore_templates)
     templates = common_templates.node_library(
         source_location="build/src", versions=versions, default_version=default_version
     )

--- a/tests/fixtures/nodejs-dlp-with-staging/owl-bot-staging/v2/src/index.ts
+++ b/tests/fixtures/nodejs-dlp-with-staging/owl-bot-staging/v2/src/index.ts
@@ -23,3 +23,5 @@ export {v2, DlpServiceClient};
 export default {v2, DlpServiceClient};
 import * as protos from '../protos/protos';
 export {protos}
+
+// This file originated in the staging directory.

--- a/tests/fixtures/nodejs-dlp-with-staging/src/index.ts
+++ b/tests/fixtures/nodejs-dlp-with-staging/src/index.ts
@@ -25,3 +25,5 @@ export {v2, DlpServiceClient};
 export default {v2, DlpServiceClient};
 import * as protos from '../protos/protos';
 export {protos};
+
+// This is the original index.ts found in nodejs-dlp-with-staging/src.

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import filecmp
+import os
+import pathlib
+import shutil
+import tempfile
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
-import os
-from pathlib import Path
-from synthtool.languages import node
-import pathlib
-import filecmp
+
 import pytest
-import tempfile
-import shutil
+
+import synthtool as s
+from synthtool.languages import node
 
 FIXTURES = Path(__file__).parent / "fixtures"
 TEMPLATES = Path(__file__).parent.parent / "synthtool" / "gcp" / "templates"
@@ -234,10 +237,20 @@ def nodejs_dlp():
 
 @patch("synthtool.languages.node.postprocess_gapic_library_hermetic")
 def test_owlbot_main_with_staging(hermetic_mock, nodejs_dlp):
-    original_text = open(FIXTURES / "nodejs-dlp-with-staging" / "src" / "index.ts", "rt").read()
+    original_text = open(
+        FIXTURES / "nodejs-dlp-with-staging" / "src" / "index.ts", "rt"
+    ).read()
     node.owlbot_main(TEMPLATES)
     # confirm index.ts was overwritten by template-generated index.ts.
-    staging_text = open(FIXTURES / "nodejs-dlp-with-staging" / "owl-bot-staging" / "v2" / "src" / "index.ts", "rt").read()
+    staging_text = open(
+        FIXTURES
+        / "nodejs-dlp-with-staging"
+        / "owl-bot-staging"
+        / "v2"
+        / "src"
+        / "index.ts",
+        "rt",
+    ).read()
     text = open("./src/index.ts", "rt").read()
     assert staging_text != text
     assert original_text != text
@@ -245,20 +258,61 @@ def test_owlbot_main_with_staging(hermetic_mock, nodejs_dlp):
 
 @patch("synthtool.languages.node.postprocess_gapic_library_hermetic")
 def test_owlbot_main_with_staging_index_from_staging(hermetic_mock, nodejs_dlp):
-    node.owlbot_main(TEMPLATES, ignore_staging=["README.md", "package.json"], ignore_templates=["src/index.ts"])
+    node.owlbot_main(
+        TEMPLATES,
+        ignore_staging=["README.md", "package.json"],
+        ignore_templates=["src/index.ts"],
+    )
     # confirm index.ts was overwritten by staging index.ts.
-    staging_text = open(FIXTURES / "nodejs-dlp-with-staging" / "owl-bot-staging" / "v2" / "src" / "index.ts", "rt").read()
+    staging_text = open(
+        FIXTURES
+        / "nodejs-dlp-with-staging"
+        / "owl-bot-staging"
+        / "v2"
+        / "src"
+        / "index.ts",
+        "rt",
+    ).read()
     text = open("./src/index.ts", "rt").read()
     assert staging_text == text
 
 
 @patch("synthtool.languages.node.postprocess_gapic_library_hermetic")
 def test_owlbot_main_with_staging_ignore_index(hermetic_mock, nodejs_dlp):
-    original_text = open(FIXTURES / "nodejs-dlp-with-staging" / "src" / "index.ts", "rt").read()
+    original_text = open(
+        FIXTURES / "nodejs-dlp-with-staging" / "src" / "index.ts", "rt"
+    ).read()
     node.owlbot_main(TEMPLATES, ignore_templates=["src/index.ts"])
     # confirm index.ts was overwritten by staging index.ts.
     text = open("./src/index.ts", "rt").read()
     assert original_text == text
+
+
+@patch("synthtool.languages.node.postprocess_gapic_library_hermetic")
+def test_owlbot_main_with_staging_patch_staging(hermetic_mock, nodejs_dlp):
+    def patch(library: Path):
+        s.replace(library / "src" / "index.ts", "import", "export")
+
+    node.owlbot_main(
+        TEMPLATES,
+        ignore_staging=["README.md", "package.json"],
+        ignore_templates=["src/index.ts"],
+        patch_staging=patch,
+    )
+    # confirm index.ts was overwritten by staging index.ts.
+    staging_text = open(
+        FIXTURES
+        / "nodejs-dlp-with-staging"
+        / "owl-bot-staging"
+        / "v2"
+        / "src"
+        / "index.ts",
+        "rt",
+    ).read()
+    text = open("./src/index.ts", "rt").read()
+    assert "import * as v2" in staging_text
+    assert "export * as v2" not in staging_text
+    assert "export * as v2" in text
 
 
 def test_detect_versions_src():

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -234,20 +234,31 @@ def nodejs_dlp():
 
 @patch("synthtool.languages.node.postprocess_gapic_library_hermetic")
 def test_owlbot_main_with_staging(hermetic_mock, nodejs_dlp):
+    original_text = open(FIXTURES / "nodejs-dlp-with-staging" / "src" / "index.ts", "rt").read()
     node.owlbot_main(TEMPLATES)
     # confirm index.ts was overwritten by template-generated index.ts.
     staging_text = open(FIXTURES / "nodejs-dlp-with-staging" / "owl-bot-staging" / "v2" / "src" / "index.ts", "rt").read()
     text = open("./src/index.ts", "rt").read()
     assert staging_text != text
+    assert original_text != text
+
+
+@patch("synthtool.languages.node.postprocess_gapic_library_hermetic")
+def test_owlbot_main_with_staging_index_from_staging(hermetic_mock, nodejs_dlp):
+    node.owlbot_main(TEMPLATES, ignore_staging=["README.md", "package.json"], ignore_templates=["src/index.ts"])
+    # confirm index.ts was overwritten by staging index.ts.
+    staging_text = open(FIXTURES / "nodejs-dlp-with-staging" / "owl-bot-staging" / "v2" / "src" / "index.ts", "rt").read()
+    text = open("./src/index.ts", "rt").read()
+    assert staging_text == text
 
 
 @patch("synthtool.languages.node.postprocess_gapic_library_hermetic")
 def test_owlbot_main_with_staging_ignore_index(hermetic_mock, nodejs_dlp):
-    node.owlbot_main(TEMPLATES, ignore_staging=["README.md", "package.json"], ignore_templates=["src/index.ts"])
-    # confirm index.ts wasn't overwritten by template-generated index.ts.
-    staging_text = open(FIXTURES / "nodejs-dlp-with-staging" / "owl-bot-staging" / "v2" / "src" / "index.ts", "rt").read()
+    original_text = open(FIXTURES / "nodejs-dlp-with-staging" / "src" / "index.ts", "rt").read()
+    node.owlbot_main(TEMPLATES, ignore_templates=["src/index.ts"])
+    # confirm index.ts was overwritten by staging index.ts.
     text = open("./src/index.ts", "rt").read()
-    assert staging_text == text
+    assert original_text == text
 
 
 def test_detect_versions_src():

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -243,7 +243,7 @@ def test_owlbot_main_with_staging(hermetic_mock, nodejs_dlp):
 
 @patch("synthtool.languages.node.postprocess_gapic_library_hermetic")
 def test_owlbot_main_with_staging_ignore_index(hermetic_mock, nodejs_dlp):
-    node.owlbot_main(TEMPLATES, ignore_templates=["src/index.ts"])
+    node.owlbot_main(TEMPLATES, ignore_staging=["README.md", "package.json"], ignore_templates=["src/index.ts"])
     # confirm index.ts wasn't overwritten by template-generated index.ts.
     staging_text = open(FIXTURES / "nodejs-dlp-with-staging" / "owl-bot-staging" / "v2" / "src" / "index.ts", "rt").read()
     text = open("./src/index.ts", "rt").read()

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -260,8 +260,8 @@ def test_owlbot_main_with_staging(hermetic_mock, nodejs_dlp):
 def test_owlbot_main_with_staging_index_from_staging(hermetic_mock, nodejs_dlp):
     node.owlbot_main(
         TEMPLATES,
-        ignore_staging=["README.md", "package.json"],
-        ignore_templates=["src/index.ts"],
+        staging_excludes=["README.md", "package.json"],
+        templates_excludes=["src/index.ts"],
     )
     # confirm index.ts was overwritten by staging index.ts.
     staging_text = open(
@@ -282,7 +282,7 @@ def test_owlbot_main_with_staging_ignore_index(hermetic_mock, nodejs_dlp):
     original_text = open(
         FIXTURES / "nodejs-dlp-with-staging" / "src" / "index.ts", "rt"
     ).read()
-    node.owlbot_main(TEMPLATES, ignore_templates=["src/index.ts"])
+    node.owlbot_main(TEMPLATES, templates_excludes=["src/index.ts"])
     # confirm index.ts was overwritten by staging index.ts.
     text = open("./src/index.ts", "rt").read()
     assert original_text == text
@@ -295,8 +295,8 @@ def test_owlbot_main_with_staging_patch_staging(hermetic_mock, nodejs_dlp):
 
     node.owlbot_main(
         TEMPLATES,
-        ignore_staging=["README.md", "package.json"],
-        ignore_templates=["src/index.ts"],
+        staging_excludes=["README.md", "package.json"],
+        templates_excludes=["src/index.ts"],
         patch_staging=patch,
     )
     # confirm index.ts was overwritten by staging index.ts.

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -234,12 +234,20 @@ def nodejs_dlp():
 
 @patch("synthtool.languages.node.postprocess_gapic_library_hermetic")
 def test_owlbot_main_with_staging(hermetic_mock, nodejs_dlp):
-    # just confirm it doesn't throw an exception.
     node.owlbot_main(TEMPLATES)
     # confirm index.ts was overwritten by template-generated index.ts.
     staging_text = open(FIXTURES / "nodejs-dlp-with-staging" / "owl-bot-staging" / "v2" / "src" / "index.ts", "rt").read()
     text = open("./src/index.ts", "rt").read()
     assert staging_text != text
+
+
+@patch("synthtool.languages.node.postprocess_gapic_library_hermetic")
+def test_owlbot_main_with_staging_ignore_index(hermetic_mock, nodejs_dlp):
+    node.owlbot_main(TEMPLATES, ignore_templates=["src/index.ts"])
+    # confirm index.ts wasn't overwritten by template-generated index.ts.
+    staging_text = open(FIXTURES / "nodejs-dlp-with-staging" / "owl-bot-staging" / "v2" / "src" / "index.ts", "rt").read()
+    text = open("./src/index.ts", "rt").read()
+    assert staging_text == text
 
 
 def test_detect_versions_src():


### PR DESCRIPTION
Should greatly simplify migrations.

Used the word "excludes" instead of "ignores" because existing synth.py files already use the term "excludes", so using the word "ignores" would make migrating more tedious, error-prone, and confusing.

Example of a migrated repo:
https://github.com/googleapis/nodejs-ai-platform/compare/owl-bot?expand=1

Also fixed a bug where `generate_index_ts()` was called even when `"src/index.ts"` was in the exclude list.