### PR TITLE
build: use PyPI API token in secret manager

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/release.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/release.sh
@@ -26,7 +26,7 @@ python3 -m pip install --upgrade twine wheel setuptools
 export PYTHONUNBUFFERED=1
 
 # Move into the package, build the distribution and upload.
-TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google_cloud_pypi_password")
+TWINE_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/secret_manager/google-cloud-pypi-password")
 cd github/{{ metadata['repo']['repo'].split('/')[1] }}
 python3 setup.py sdist bdist_wheel
-twine upload --username gcloudpypi --password "${TWINE_PASSWORD}" dist/*
+twine upload --username __token__ --password "${TWINE_PASSWORD}" dist/*

--- a/synthtool/gcp/templates/python_library/.kokoro/release.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/release.sh
@@ -26,7 +26,7 @@ python3 -m pip install --upgrade twine wheel setuptools
 export PYTHONUNBUFFERED=1
 
 # Move into the package, build the distribution and upload.
-TWINE_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/secret_manager/google-cloud-pypi-password")
+TWINE_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/secret_manager/google-cloud-pypi-token")
 cd github/{{ metadata['repo']['repo'].split('/')[1] }}
 python3 setup.py sdist bdist_wheel
 twine upload --username __token__ --password "${TWINE_PASSWORD}" dist/*

--- a/synthtool/gcp/templates/python_library/.kokoro/release/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/release/common.cfg
@@ -26,5 +26,5 @@ env_vars: {
 # Tokens needed to report release status back to GitHub
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,google-cloud-pypi-password"
+  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,google-cloud-pypi-token"
 }

--- a/synthtool/gcp/templates/python_library/.kokoro/release/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/release/common.cfg
@@ -23,18 +23,8 @@ env_vars: {
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/release.sh"
 }
 
-# Fetch PyPI password	
-before_action {	
-  fetch_keystore {	
-    keystore_resource {	
-      keystore_config_id: 73713	
-      keyname: "google_cloud_pypi_password"	
-    }	
-  }	
-}
-
 # Tokens needed to report release status back to GitHub
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
+  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,google-cloud-pypi-password"
 }


### PR DESCRIPTION
Migrate python libraries onto the PyPI API token stored in secret manager.

A PyPI API token is limited in scope to uploading new releases. https://pypi.org/help/#apitoken

Verified that this works with [build](https://fusion2.corp.google.com/invocations/14bae126-83fa-4328-8da9-d390ed99315c/targets/cloud-devrel%2Fclient-libraries%2Fpython%2Fgoogleapis%2Fpython-vision%2Frelease%2Frelease;config=default/log) on https://github.com/googleapis/python-vision/pull/136