### PR TITLE
fix: release scripts from issuing overlapping phases

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/release/snapshot.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/snapshot.sh
@@ -25,7 +25,7 @@ grep SNAPSHOT versions.txt
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
-mvn clean install deploy -B \
+mvn clean deploy -B \
   --settings ${MAVEN_SETTINGS_FILE} \
   -DperformRelease=true \
   -Dgpg.executable=gpg \

--- a/synthtool/gcp/templates/java_library/.kokoro/release/stage.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/stage.sh
@@ -29,7 +29,7 @@ create_settings_xml_file "settings.xml"
 
 # attempt to stage 3 times with exponential backoff (starting with 10 seconds)
 retry_with_backoff 3 10 \
-  mvn clean install deploy -B \
+  mvn clean deploy -B \
     --settings ${MAVEN_SETTINGS_FILE} \
     -DskipTests=true \
     -DperformRelease=true \


### PR DESCRIPTION
`mvn deploy` will run `mvn install` so specifying `mvn install deploy` is redundant at best. At worst, it will cause plugins like maven-shade-plugin to be executed twice re-shading itself