### PR TITLE
fix(owlbot-java): run owlboy.py directly rather than via synthtool module

### DIFF
--- a/docker/owlbot/java/bin/write_templates.sh
+++ b/docker/owlbot/java/bin/write_templates.sh
@@ -28,5 +28,5 @@ fi
 
 if [ -f "owlbot.py" ]
 then
-  python3 -m synthtool owlbot.py
+  python3 owlbot.py
 fi


### PR DESCRIPTION
Should prevent owl-bot from making "empty" synth.metadata updates