### PR TITLE
fix: get_staging_dirs() should return a consistent ordering

### DIFF
--- a/synthtool/transforms.py
+++ b/synthtool/transforms.py
@@ -279,7 +279,8 @@ def replace(
 
 def get_staging_dirs(default_version: Optional[str] = None) -> List[Path]:
     """Returns the list of directories, one per version, copied from
-    https://github.com/googleapis/googleapis-gen.
+    https://github.com/googleapis/googleapis-gen. Will return in lexical sorting
+    order with the exception of the default_version which will be last (if specified).
 
     Args:
       default_version: the default version of the API. The directory for this version
@@ -294,6 +295,7 @@ def get_staging_dirs(default_version: Optional[str] = None) -> List[Path]:
         versions = [v.name for v in staging.iterdir() if v.is_dir()]
         # Reorder the versions so the default version always comes last.
         versions = [v for v in versions if v != default_version]
+        versions.sort()
         if default_version is not None:
             versions += [default_version]
         dirs = [staging / v for v in versions]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -281,6 +281,4 @@ def change_test_dir():
 def test_get_staging_dirs(change_test_dir):
     assert [path.name for path in transforms.get_staging_dirs("v1")] == ["v2", "v1"]
     assert [path.name for path in transforms.get_staging_dirs("v2")] == ["v1", "v2"]
-    paths = [path.name for path in transforms.get_staging_dirs()]
-    paths.sort()
     assert [path.name for path in transforms.get_staging_dirs()] == ["v1", "v2"]


### PR DESCRIPTION
This test was previously failing flakily because the listing of directories is not guaranteed to be sorted. We should be consistent in what gets returned.

In most cases, this won't matter for synthtool users, but we should do our best to be consistent between runs.