### PR TITLE
refactor(test): add util.chdir, util.copied_fixtures_dir contextmanagers to clean up tests

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -20,6 +20,7 @@ import requests_mock
 import synthtool as s
 import tempfile
 import shutil
+from . import util
 
 
 MOCK = Path(__file__).parent / "generationmock"
@@ -55,34 +56,24 @@ def test_py_samples_clientlib():
     path_to_gen = MOCK / "client_library"
     with tempfile.TemporaryDirectory() as tempdir:
         workdir = shutil.copytree(path_to_gen, Path(tempdir) / "client_library")
-        cwd = os.getcwd()
-        os.chdir(workdir)
-
-        try:
+        with util.chdir(workdir):
             sample_files = common.py_samples(
                 unit_cov_level=97, cov_level=99, samples=True
             )
             s.move(sample_files, excludes=["noxfile.py"])
             assert os.path.isfile(workdir / "samples" / "README.md")
-        finally:
-            os.chdir(cwd)
 
 
 def test_py_samples_custom_path():
     path_to_gen = MOCK / "custom_path"
     with tempfile.TemporaryDirectory() as tempdir:
         workdir = shutil.copytree(path_to_gen, Path(tempdir) / "custom_path")
-        cwd = os.getcwd()
-        os.chdir(workdir)
-
-        try:
+        with util.chdir(workdir):
             sample_files = common.py_samples(
                 unit_cov_level=97, cov_level=99, samples=True
             )
             s.move(sample_files, excludes=["noxfile.py"])
             assert os.path.isfile(workdir / "custom_samples_folder" / "README.md")
-        finally:
-            os.chdir(cwd)
 
 
 def test_py_samples_custom_path_DNE():
@@ -90,10 +81,7 @@ def test_py_samples_custom_path_DNE():
         workdir = shutil.copytree(
             MOCK / "custom_path_DNE", Path(tempdir) / "custom_path_DNE"
         )
-        cwd = os.getcwd()
-        os.chdir(workdir)
-
-        try:
+        with util.chdir(workdir):
             with raises(Exception) as e:
                 os.chdir(workdir / "custom_path_DNE")
                 sample_files = common.py_samples(
@@ -101,35 +89,25 @@ def test_py_samples_custom_path_DNE():
                 )
                 s.move(sample_files, excludes=["noxfile.py"])
                 assert "'nonexistent_folder' does not exist" in str(e.value)
-        finally:
-            os.chdir(cwd)
 
 
 def test_py_samples_samples_folder():
     path_to_gen = MOCK / "samples_folder"
     with tempfile.TemporaryDirectory() as tempdir:
         workdir = shutil.copytree(path_to_gen, Path(tempdir) / "samples_folder")
-        cwd = os.getcwd()
-        os.chdir(workdir)
-
-        try:
+        with util.chdir(workdir):
             sample_files = common.py_samples(
                 unit_cov_level=97, cov_level=99, samples=True
             )
             s.move(sample_files, excludes=["noxfile.py"])
             assert os.path.isfile(workdir / "README.md")
-        finally:
-            os.chdir(cwd)
 
 
 def test_py_samples_override():
     path_to_gen = MOCK / "override_path"
     with tempfile.TemporaryDirectory() as tempdir:
         workdir = shutil.copytree(path_to_gen, Path(tempdir) / "override_path")
-        cwd = os.getcwd()
-        os.chdir(workdir)
-
-        try:
+        with util.chdir(workdir):
             sample_files = common.py_samples(
                 unit_cov_level=97, cov_level=99, samples=True
             )
@@ -137,18 +115,13 @@ def test_py_samples_override():
                 s.move(path, excludes=["noxfile.py"])
             assert os.path.isfile(workdir / "README.md")
             assert os.path.isfile(workdir / "override" / "README.md")
-        finally:
-            os.chdir(cwd)
 
 
 def test_py_samples_override_content():
     path_to_gen = MOCK / "override_path"
     with tempfile.TemporaryDirectory() as tempdir:
         workdir = shutil.copytree(path_to_gen, Path(tempdir) / "override_path")
-        cwd = os.getcwd()
-        os.chdir(workdir)
-
-        try:
+        with util.chdir(workdir):
             sample_files = common.py_samples(
                 unit_cov_level=97, cov_level=99, samples=True
             )
@@ -164,18 +137,13 @@ def test_py_samples_override_content():
                 result = f.read()
                 assert "Hello World" not in result
                 assert "Quickstart" in result
-        finally:
-            os.chdir(cwd)
 
 
 def test_py_samples_multiple_override():
     path_to_gen = MOCK / "multiple_override_path"
     with tempfile.TemporaryDirectory() as tempdir:
         workdir = shutil.copytree(path_to_gen, Path(tempdir) / "multiple_override_path")
-        cwd = os.getcwd()
-        os.chdir(workdir)
-
-        try:
+        with util.chdir(workdir):
             sample_files = common.py_samples(
                 unit_cov_level=97, cov_level=99, samples=True
             )
@@ -189,18 +157,13 @@ def test_py_samples_multiple_override():
                 result = f.read()
                 assert "Hello World" in result
                 assert "Hello Synthtool" in result
-        finally:
-            os.chdir(cwd)
 
 
 def test_py_samples_multiple_override_content():
     path_to_gen = MOCK / "multiple_override_path"
     with tempfile.TemporaryDirectory() as tempdir:
         workdir = shutil.copytree(path_to_gen, Path(tempdir) / "multiple_override_path")
-        cwd = os.getcwd()
-        os.chdir(workdir)
-
-        try:
+        with util.chdir(workdir):
             sample_files = common.py_samples(
                 unit_cov_level=97, cov_level=99, samples=True
             )
@@ -220,5 +183,3 @@ def test_py_samples_multiple_override_content():
             with open("README.md") as f:
                 result = f.read()
                 assert "Last Example" in result
-        finally:
-            os.chdir(cwd)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -54,132 +54,115 @@ def test_get_default_branch():
 
 def test_py_samples_clientlib():
     path_to_gen = MOCK / "client_library"
-    with tempfile.TemporaryDirectory() as tempdir:
-        workdir = shutil.copytree(path_to_gen, Path(tempdir) / "client_library")
-        with util.chdir(workdir):
-            sample_files = common.py_samples(
-                unit_cov_level=97, cov_level=99, samples=True
-            )
-            s.move(sample_files, excludes=["noxfile.py"])
-            assert os.path.isfile(workdir / "samples" / "README.md")
+    with util.copied_fixtures_dir(path_to_gen) as workdir:
+        sample_files = common.py_samples(
+            unit_cov_level=97, cov_level=99, samples=True
+        )
+        s.move(sample_files, excludes=["noxfile.py"])
+        assert os.path.isfile(workdir / "samples" / "README.md")
 
 
 def test_py_samples_custom_path():
     path_to_gen = MOCK / "custom_path"
-    with tempfile.TemporaryDirectory() as tempdir:
-        workdir = shutil.copytree(path_to_gen, Path(tempdir) / "custom_path")
-        with util.chdir(workdir):
+    with util.copied_fixtures_dir(path_to_gen) as workdir:
+        sample_files = common.py_samples(
+            unit_cov_level=97, cov_level=99, samples=True
+        )
+        s.move(sample_files, excludes=["noxfile.py"])
+        assert os.path.isfile(workdir / "custom_samples_folder" / "README.md")
+
+
+def test_py_samples_custom_path_DNE():
+    path_to_gen = MOCK / "custom_path_DNE"
+    with util.copied_fixtures_dir(path_to_gen) as workdir:
+        with raises(Exception) as e:
+            os.chdir(workdir / "custom_path_DNE")
             sample_files = common.py_samples(
                 unit_cov_level=97, cov_level=99, samples=True
             )
             s.move(sample_files, excludes=["noxfile.py"])
-            assert os.path.isfile(workdir / "custom_samples_folder" / "README.md")
-
-
-def test_py_samples_custom_path_DNE():
-    with tempfile.TemporaryDirectory() as tempdir:
-        workdir = shutil.copytree(
-            MOCK / "custom_path_DNE", Path(tempdir) / "custom_path_DNE"
-        )
-        with util.chdir(workdir):
-            with raises(Exception) as e:
-                os.chdir(workdir / "custom_path_DNE")
-                sample_files = common.py_samples(
-                    unit_cov_level=97, cov_level=99, samples=True
-                )
-                s.move(sample_files, excludes=["noxfile.py"])
-                assert "'nonexistent_folder' does not exist" in str(e.value)
+            assert "'nonexistent_folder' does not exist" in str(e.value)
 
 
 def test_py_samples_samples_folder():
     path_to_gen = MOCK / "samples_folder"
-    with tempfile.TemporaryDirectory() as tempdir:
-        workdir = shutil.copytree(path_to_gen, Path(tempdir) / "samples_folder")
-        with util.chdir(workdir):
-            sample_files = common.py_samples(
-                unit_cov_level=97, cov_level=99, samples=True
-            )
-            s.move(sample_files, excludes=["noxfile.py"])
-            assert os.path.isfile(workdir / "README.md")
+    with util.copied_fixtures_dir(path_to_gen) as workdir:
+        sample_files = common.py_samples(
+            unit_cov_level=97, cov_level=99, samples=True
+        )
+        s.move(sample_files, excludes=["noxfile.py"])
+        assert os.path.isfile(workdir / "README.md")
 
 
 def test_py_samples_override():
     path_to_gen = MOCK / "override_path"
-    with tempfile.TemporaryDirectory() as tempdir:
-        workdir = shutil.copytree(path_to_gen, Path(tempdir) / "override_path")
-        with util.chdir(workdir):
-            sample_files = common.py_samples(
-                unit_cov_level=97, cov_level=99, samples=True
-            )
-            for path in sample_files:
-                s.move(path, excludes=["noxfile.py"])
-            assert os.path.isfile(workdir / "README.md")
-            assert os.path.isfile(workdir / "override" / "README.md")
+    with util.copied_fixtures_dir(path_to_gen) as workdir:
+        sample_files = common.py_samples(
+            unit_cov_level=97, cov_level=99, samples=True
+        )
+        for path in sample_files:
+            s.move(path, excludes=["noxfile.py"])
+        assert os.path.isfile(workdir / "README.md")
+        assert os.path.isfile(workdir / "override" / "README.md")
 
 
 def test_py_samples_override_content():
     path_to_gen = MOCK / "override_path"
-    with tempfile.TemporaryDirectory() as tempdir:
-        workdir = shutil.copytree(path_to_gen, Path(tempdir) / "override_path")
-        with util.chdir(workdir):
-            sample_files = common.py_samples(
-                unit_cov_level=97, cov_level=99, samples=True
-            )
-            for path in sample_files:
-                s.move(path, excludes=["noxfile.py"])
-            os.chdir(workdir)
-            with open("README.md") as f:
-                result = f.read()
-                assert "Hello World" in result
-                assert "Quickstart" not in result
-            os.chdir(workdir / "override")
-            with open("README.md") as f:
-                result = f.read()
-                assert "Hello World" not in result
-                assert "Quickstart" in result
+    with util.copied_fixtures_dir(path_to_gen) as workdir:
+        sample_files = common.py_samples(
+            unit_cov_level=97, cov_level=99, samples=True
+        )
+        for path in sample_files:
+            s.move(path, excludes=["noxfile.py"])
+        os.chdir(workdir)
+        with open("README.md") as f:
+            result = f.read()
+            assert "Hello World" in result
+            assert "Quickstart" not in result
+        os.chdir(workdir / "override")
+        with open("README.md") as f:
+            result = f.read()
+            assert "Hello World" not in result
+            assert "Quickstart" in result
 
 
 def test_py_samples_multiple_override():
     path_to_gen = MOCK / "multiple_override_path"
-    with tempfile.TemporaryDirectory() as tempdir:
-        workdir = shutil.copytree(path_to_gen, Path(tempdir) / "multiple_override_path")
-        with util.chdir(workdir):
-            sample_files = common.py_samples(
-                unit_cov_level=97, cov_level=99, samples=True
-            )
-            for path in sample_files:
-                s.move(path, excludes=["noxfile.py"])
-            assert os.path.isfile(workdir / "README.md")
-            assert os.path.isfile(workdir / "override" / "README.md")
-            assert os.path.isfile(workdir / "another_override" / "README.md")
-            os.chdir(workdir / "another_override")
-            with open("README.md") as f:
-                result = f.read()
-                assert "Hello World" in result
-                assert "Hello Synthtool" in result
+    with util.copied_fixtures_dir(path_to_gen) as workdir:
+        sample_files = common.py_samples(
+            unit_cov_level=97, cov_level=99, samples=True
+        )
+        for path in sample_files:
+            s.move(path, excludes=["noxfile.py"])
+        assert os.path.isfile(workdir / "README.md")
+        assert os.path.isfile(workdir / "override" / "README.md")
+        assert os.path.isfile(workdir / "another_override" / "README.md")
+        os.chdir(workdir / "another_override")
+        with open("README.md") as f:
+            result = f.read()
+            assert "Hello World" in result
+            assert "Hello Synthtool" in result
 
 
 def test_py_samples_multiple_override_content():
     path_to_gen = MOCK / "multiple_override_path"
-    with tempfile.TemporaryDirectory() as tempdir:
-        workdir = shutil.copytree(path_to_gen, Path(tempdir) / "multiple_override_path")
-        with util.chdir(workdir):
-            sample_files = common.py_samples(
-                unit_cov_level=97, cov_level=99, samples=True
-            )
-            for path in sample_files:
-                s.move(path, excludes=["noxfile.py"])
-            os.chdir(workdir / "override")
-            with open("README.md") as f:
-                result = f.read()
-                assert "Quickstart" in result
-                assert "first_arg" in result
-            os.chdir(workdir / "another_override")
-            with open("README.md") as f:
-                result = f.read()
-                assert "Hello World" in result
-                assert "Hello Synthtool" in result
-            os.chdir(workdir)
-            with open("README.md") as f:
-                result = f.read()
-                assert "Last Example" in result
+    with util.copied_fixtures_dir(path_to_gen) as workdir:
+        sample_files = common.py_samples(
+            unit_cov_level=97, cov_level=99, samples=True
+        )
+        for path in sample_files:
+            s.move(path, excludes=["noxfile.py"])
+        os.chdir(workdir / "override")
+        with open("README.md") as f:
+            result = f.read()
+            assert "Quickstart" in result
+            assert "first_arg" in result
+        os.chdir(workdir / "another_override")
+        with open("README.md") as f:
+            result = f.read()
+            assert "Hello World" in result
+            assert "Hello Synthtool" in result
+        os.chdir(workdir)
+        with open("README.md") as f:
+            result = f.read()
+            assert "Last Example" in result

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -55,9 +55,7 @@ def test_get_default_branch():
 def test_py_samples_clientlib():
     path_to_gen = MOCK / "client_library"
     with util.copied_fixtures_dir(path_to_gen) as workdir:
-        sample_files = common.py_samples(
-            unit_cov_level=97, cov_level=99, samples=True
-        )
+        sample_files = common.py_samples(unit_cov_level=97, cov_level=99, samples=True)
         s.move(sample_files, excludes=["noxfile.py"])
         assert os.path.isfile(workdir / "samples" / "README.md")
 
@@ -65,9 +63,7 @@ def test_py_samples_clientlib():
 def test_py_samples_custom_path():
     path_to_gen = MOCK / "custom_path"
     with util.copied_fixtures_dir(path_to_gen) as workdir:
-        sample_files = common.py_samples(
-            unit_cov_level=97, cov_level=99, samples=True
-        )
+        sample_files = common.py_samples(unit_cov_level=97, cov_level=99, samples=True)
         s.move(sample_files, excludes=["noxfile.py"])
         assert os.path.isfile(workdir / "custom_samples_folder" / "README.md")
 
@@ -87,9 +83,7 @@ def test_py_samples_custom_path_DNE():
 def test_py_samples_samples_folder():
     path_to_gen = MOCK / "samples_folder"
     with util.copied_fixtures_dir(path_to_gen) as workdir:
-        sample_files = common.py_samples(
-            unit_cov_level=97, cov_level=99, samples=True
-        )
+        sample_files = common.py_samples(unit_cov_level=97, cov_level=99, samples=True)
         s.move(sample_files, excludes=["noxfile.py"])
         assert os.path.isfile(workdir / "README.md")
 
@@ -97,9 +91,7 @@ def test_py_samples_samples_folder():
 def test_py_samples_override():
     path_to_gen = MOCK / "override_path"
     with util.copied_fixtures_dir(path_to_gen) as workdir:
-        sample_files = common.py_samples(
-            unit_cov_level=97, cov_level=99, samples=True
-        )
+        sample_files = common.py_samples(unit_cov_level=97, cov_level=99, samples=True)
         for path in sample_files:
             s.move(path, excludes=["noxfile.py"])
         assert os.path.isfile(workdir / "README.md")
@@ -109,9 +101,7 @@ def test_py_samples_override():
 def test_py_samples_override_content():
     path_to_gen = MOCK / "override_path"
     with util.copied_fixtures_dir(path_to_gen) as workdir:
-        sample_files = common.py_samples(
-            unit_cov_level=97, cov_level=99, samples=True
-        )
+        sample_files = common.py_samples(unit_cov_level=97, cov_level=99, samples=True)
         for path in sample_files:
             s.move(path, excludes=["noxfile.py"])
         os.chdir(workdir)
@@ -129,9 +119,7 @@ def test_py_samples_override_content():
 def test_py_samples_multiple_override():
     path_to_gen = MOCK / "multiple_override_path"
     with util.copied_fixtures_dir(path_to_gen) as workdir:
-        sample_files = common.py_samples(
-            unit_cov_level=97, cov_level=99, samples=True
-        )
+        sample_files = common.py_samples(unit_cov_level=97, cov_level=99, samples=True)
         for path in sample_files:
             s.move(path, excludes=["noxfile.py"])
         assert os.path.isfile(workdir / "README.md")
@@ -147,9 +135,7 @@ def test_py_samples_multiple_override():
 def test_py_samples_multiple_override_content():
     path_to_gen = MOCK / "multiple_override_path"
     with util.copied_fixtures_dir(path_to_gen) as workdir:
-        sample_files = common.py_samples(
-            unit_cov_level=97, cov_level=99, samples=True
-        )
+        sample_files = common.py_samples(unit_cov_level=97, cov_level=99, samples=True)
         for path in sample_files:
             s.move(path, excludes=["noxfile.py"])
         os.chdir(workdir / "override")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -18,8 +18,6 @@ from pytest import raises
 import os
 import requests_mock
 import synthtool as s
-import tempfile
-import shutil
 from . import util
 
 

--- a/tests/test_language_java.py
+++ b/tests/test_language_java.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from synthtool.languages import java
 import requests_mock
 import pytest
+from . import util
 
 FIXTURES = Path(__file__).parent / "fixtures"
 TEMPLATES_PATH = Path(__file__).parent.parent / "synthtool" / "gcp" / "templates"
@@ -94,10 +95,7 @@ def test_working_common_templates():
         workdir = shutil.copytree(
             FIXTURES / "java_templates" / "standard", Path(tempdir) / "standard"
         )
-        cwd = os.getcwd()
-        os.chdir(workdir)
-
-        try:
+        with util.chdir(workdir):
             # generate the common templates
             java.common_templates(template_path=TEMPLATES_PATH)
             assert os.path.isfile("renovate.json")
@@ -111,8 +109,6 @@ def test_working_common_templates():
                         assert_valid_xml(os.path.join(dirpath, file))
                     elif ext == ".yaml" or ext == ".yml":
                         assert_valid_yaml(os.path.join(dirpath, file))
-        finally:
-            os.chdir(cwd)
 
 
 def test_remove_method():

--- a/tests/test_language_java.py
+++ b/tests/test_language_java.py
@@ -91,24 +91,20 @@ def test_working_common_templates():
             except yaml.YAMLError:
                 pytest.fail(f"unable to parse YAML: {file}")
 
-    with tempfile.TemporaryDirectory() as tempdir:
-        workdir = shutil.copytree(
-            FIXTURES / "java_templates" / "standard", Path(tempdir) / "standard"
-        )
-        with util.chdir(workdir):
-            # generate the common templates
-            java.common_templates(template_path=TEMPLATES_PATH)
-            assert os.path.isfile("renovate.json")
+    with util.copied_fixtures_dir(FIXTURES / "java_templates" / "standard") as workdir:
+        # generate the common templates
+        java.common_templates(template_path=TEMPLATES_PATH)
+        assert os.path.isfile("renovate.json")
 
-            # lint xml, yaml files
-            # use os.walk because glob ignores hidden directories
-            for (dirpath, _, filenames) in os.walk(tempdir):
-                for file in filenames:
-                    (_, ext) = os.path.splitext(file)
-                    if ext == ".xml":
-                        assert_valid_xml(os.path.join(dirpath, file))
-                    elif ext == ".yaml" or ext == ".yml":
-                        assert_valid_yaml(os.path.join(dirpath, file))
+        # lint xml, yaml files
+        # use os.walk because glob ignores hidden directories
+        for (dirpath, _, filenames) in os.walk(workdir):
+            for file in filenames:
+                (_, ext) = os.path.splitext(file)
+                if ext == ".xml":
+                    assert_valid_xml(os.path.join(dirpath, file))
+                elif ext == ".yaml" or ext == ".yml":
+                    assert_valid_yaml(os.path.join(dirpath, file))
 
 
 def test_remove_method():

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -183,9 +183,7 @@ class TestPostprocess(TestCase):
 # present in the docker image but absent while running unit tests.
 @patch("synthtool.languages.node.postprocess_gapic_library_hermetic")
 def test_owlbot_main(hermetic_mock):
-    temp_dir = Path(tempfile.mkdtemp())
-    shutil.copytree(FIXTURES / "nodejs-dlp", temp_dir / "nodejs-dlp")
-    with util.chdir(temp_dir / "nodejs-dlp"):
+    with util.copied_fixtures_dir(FIXTURES / "nodejs-dlp"):
         # just confirm it doesn't throw an exception.
         node.owlbot_main(TEMPLATES)
 
@@ -193,14 +191,8 @@ def test_owlbot_main(hermetic_mock):
 @pytest.fixture
 def nodejs_dlp():
     """chdir to a copy of nodejs-dlp-with-staging."""
-    temp_dir = Path(tempfile.mkdtemp())
-    shutil.copytree(FIXTURES / "nodejs-dlp-with-staging", temp_dir / "nodejs-dlp")
-    cwd = os.getcwd()
-    try:
-        os.chdir(temp_dir / "nodejs-dlp")
-        yield temp_dir / "nodejs-dlp"
-    finally:
-        os.chdir(cwd)
+    with util.copied_fixtures_dir(FIXTURES / "nodejs-dlp-with-staging") as workdir:
+        yield workdir
 
 
 @patch("synthtool.languages.node.postprocess_gapic_library_hermetic")

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -15,7 +15,6 @@
 import filecmp
 import os
 import pathlib
-import shutil
 import tempfile
 from pathlib import Path
 from unittest import TestCase

--- a/tests/test_partials.py
+++ b/tests/test_partials.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from pathlib import Path
 
 from synthtool.gcp import partials

--- a/tests/test_partials.py
+++ b/tests/test_partials.py
@@ -16,19 +16,16 @@ import os
 from pathlib import Path
 
 from synthtool.gcp import partials
+from . import util
 
 FIXTURES = Path(__file__).parent / "fixtures" / "node_templates" / "standard"
 
 
 def test_readme_partials():
-    cwd = os.getcwd()
-    os.chdir(FIXTURES)
-
-    data = partials.load_partials()
-    # should have populated introduction from partial.
-    assert "objects to users via direct download" in data["introduction"]
-
-    os.chdir(cwd)
+    with util.chdir(FIXTURES):
+        data = partials.load_partials()
+        # should have populated introduction from partial.
+        assert "objects to users via direct download" in data["introduction"]
 
 
 def test_readme_partials_not_found():

--- a/tests/test_python_library.py
+++ b/tests/test_python_library.py
@@ -19,6 +19,7 @@ import pytest
 
 from synthtool import gcp
 from synthtool.sources import templates
+from . import util
 
 
 PYTHON_LIBRARY = Path(__file__).parent.parent / "synthtool/gcp/templates/python_library"
@@ -101,27 +102,27 @@ def test_library_noxfile(template_kwargs, expected_text):
 
 
 def test_python_library():
-    os.chdir(Path(__file__).parent / "fixtures/python_library")
-    template_dir = Path(__file__).parent.parent / "synthtool/gcp/templates"
-    common = gcp.CommonTemplates(template_path=template_dir)
-    templated_files = common.py_library()
+    with util.chdir(Path(__file__).parent / "fixtures/python_library"):
+        template_dir = Path(__file__).parent.parent / "synthtool/gcp/templates"
+        common = gcp.CommonTemplates(template_path=template_dir)
+        templated_files = common.py_library()
 
-    assert os.path.exists(templated_files / ".kokoro/docs/docs-presubmit.cfg")
-    assert os.path.exists(templated_files / ".kokoro/docker/docs/fetch_gpg_keys.sh")
+        assert os.path.exists(templated_files / ".kokoro/docs/docs-presubmit.cfg")
+        assert os.path.exists(templated_files / ".kokoro/docker/docs/fetch_gpg_keys.sh")
 
 
 def test_split_system_tests():
-    os.chdir(Path(__file__).parent / "fixtures/python_library")
-    template_dir = Path(__file__).parent.parent / "synthtool/gcp/templates"
-    common = gcp.CommonTemplates(template_path=template_dir)
-    templated_files = common.py_library(split_system_tests=True)
+    with util.chdir(Path(__file__).parent / "fixtures/python_library"):
+        template_dir = Path(__file__).parent.parent / "synthtool/gcp/templates"
+        common = gcp.CommonTemplates(template_path=template_dir)
+        templated_files = common.py_library(split_system_tests=True)
 
-    with open(templated_files / ".kokoro/presubmit/presubmit.cfg", "r") as f:
-        contents = f.read()
-        assert "RUN_SYSTEM_TESTS" in contents
-        assert "false" in contents
+        with open(templated_files / ".kokoro/presubmit/presubmit.cfg", "r") as f:
+            contents = f.read()
+            assert "RUN_SYSTEM_TESTS" in contents
+            assert "false" in contents
 
-    assert os.path.exists(templated_files / ".kokoro/presubmit/system-3.8.cfg")
-    with open(templated_files / ".kokoro/presubmit/system-3.8.cfg", "r") as f:
-        contents = f.read()
-        assert "system-3.8" in contents
+        assert os.path.exists(templated_files / ".kokoro/presubmit/system-3.8.cfg")
+        with open(templated_files / ".kokoro/presubmit/system-3.8.cfg", "r") as f:
+            contents = f.read()
+            assert "system-3.8" in contents

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from pathlib import Path
 from synthtool.gcp import samples
 from . import util

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -15,25 +15,22 @@
 import os
 from pathlib import Path
 from synthtool.gcp import samples
+from . import util
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
 def test_load_node_samples():
-    cwd = os.getcwd()
-    os.chdir(FIXTURES / "node_templates" / "standard")
+    with util.chdir(FIXTURES / "node_templates" / "standard"):
+        all_samples = samples.all_samples(["samples/*.js"])
 
-    all_samples = samples.all_samples(["samples/*.js"])
+        # should have loaded samples.
+        assert all_samples[3]["title"] == "Requester Pays"
+        assert all_samples[3]["file"] == "samples/requesterPays.js"
+        assert len(all_samples) == 4
 
-    # should have loaded samples.
-    assert all_samples[3]["title"] == "Requester Pays"
-    assert all_samples[3]["file"] == "samples/requesterPays.js"
-    assert len(all_samples) == 4
-
-    # should have included additional meta-information provided.
-    assert all_samples[0]["title"] == "Metadata Example 1"
-    assert all_samples[0]["usage"] == "node hello-world.js"
-    assert all_samples[1]["title"] == "Metadata Example 2"
-    assert all_samples[1]["usage"] == "node goodnight-moon.js"
-
-    os.chdir(cwd)
+        # should have included additional meta-information provided.
+        assert all_samples[0]["title"] == "Metadata Example 1"
+        assert all_samples[0]["usage"] == "node hello-world.js"
+        assert all_samples[1]["title"] == "Metadata Example 2"
+        assert all_samples[1]["usage"] == "node goodnight-moon.js"

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from pathlib import Path
 from synthtool.gcp import snippets
 from . import util

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -15,29 +15,28 @@
 import os
 from pathlib import Path
 from synthtool.gcp import snippets
+from . import util
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
 def test_load_snippets():
-    cwd = os.getcwd()
-    os.chdir(FIXTURES)
+    with util.chdir(FIXTURES):
+        all_snippets = snippets.all_snippets(["snippets/*.java", "snippets/*.xml"])
+        assert len(all_snippets) == 2
 
-    all_snippets = snippets.all_snippets(["snippets/*.java", "snippets/*.xml"])
-    assert len(all_snippets) == 2
-
-    assert (
-        all_snippets["monitoring_quickstart"]
-        == """
+        assert (
+            all_snippets["monitoring_quickstart"]
+            == """
 public class MonitoringQuickstartSample {
     // do something
 }
 
 """
-    )
-    assert (
-        all_snippets["monitoring_install_with_bom"]
-        == """<dependencyManagement>
+        )
+        assert (
+            all_snippets["monitoring_install_with_bom"]
+            == """<dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -56,83 +55,65 @@ public class MonitoringQuickstartSample {
   </dependency>
 </dependencies>
 """
-    )
-
-    os.chdir(cwd)
+        )
 
 
 def test_interleaving_snippets():
-    cwd = os.getcwd()
-    os.chdir(FIXTURES)
+    with util.chdir(FIXTURES):
+        all_snippets = snippets.all_snippets_from_file("snippets/interleaved.js")
+        assert len(all_snippets) == 2
 
-    all_snippets = snippets.all_snippets_from_file("snippets/interleaved.js")
-    assert len(all_snippets) == 2
-
-    assert (
-        all_snippets["interleave_snippet_1"]
-        == """var line1 = 1;
+        assert (
+            all_snippets["interleave_snippet_1"]
+            == """var line1 = 1;
 var line2 = 2;
 """
-    )
+        )
 
-    assert (
-        all_snippets["interleave_snippet_2"]
-        == """var line2 = 2;
+        assert (
+            all_snippets["interleave_snippet_2"]
+            == """var line2 = 2;
 var line3 = 3;
 """
-    )
-
-    os.chdir(cwd)
+        )
 
 
 def test_interleaving_snippets_with_exclude():
-    cwd = os.getcwd()
-    os.chdir(FIXTURES)
+    with util.chdir(FIXTURES):
+        all_snippets = snippets.all_snippets_from_file(
+            "snippets/interleaved_with_exclude.js"
+        )
+        assert len(all_snippets) == 1
 
-    all_snippets = snippets.all_snippets_from_file(
-        "snippets/interleaved_with_exclude.js"
-    )
-    assert len(all_snippets) == 1
-
-    assert (
-        all_snippets["snippet_1"]
-        == """var line1 = 1;
+        assert (
+            all_snippets["snippet_1"]
+            == """var line1 = 1;
 var line3 = 3;
 """
-    )
-
-    os.chdir(cwd)
+        )
 
 
 def test_nested_snippets():
-    cwd = os.getcwd()
-    os.chdir(FIXTURES)
+    with util.chdir(FIXTURES):
+        all_snippets = snippets.all_snippets_from_file("snippets/nested.js")
+        assert len(all_snippets) == 2
 
-    all_snippets = snippets.all_snippets_from_file("snippets/nested.js")
-    assert len(all_snippets) == 2
-
-    assert (
-        all_snippets["nested_snippet_1"]
-        == """var line1 = 1;
+        assert (
+            all_snippets["nested_snippet_1"]
+            == """var line1 = 1;
 var line2 = 2;
 var line3 = 3;
 """
-    )
+        )
 
-    assert (
-        all_snippets["nested_snippet_2"]
-        == """var line2 = 2;
+        assert (
+            all_snippets["nested_snippet_2"]
+            == """var line2 = 2;
 """
-    )
-
-    os.chdir(cwd)
+        )
 
 
 def test_non_existent_file():
-    cwd = os.getcwd()
-    os.chdir(FIXTURES)
-
-    all_snippets = snippets.all_snippets_from_file("snippets/non-existent-file.foo")
-    assert len(all_snippets) == 0
-
-    os.chdir(cwd)
+    with util.chdir(FIXTURES):
+        all_snippets = snippets.all_snippets_from_file("snippets/non-existent-file.foo")
+        assert len(all_snippets) == 0

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -267,7 +267,7 @@ def test_copy_with_merge_file_permissions(expand_path_fixtures):
         assert os.stat(destination_file).st_mode == os.stat(template).st_mode
 
 
-def test_get_staging_dirs(change_test_dir):
+def test_get_staging_dirs():
     with util.chdir(Path(__file__).parent / "fixtures/staging_dirs"):
         assert [path.name for path in transforms.get_staging_dirs("v1")] == ["v2", "v1"]
         assert [path.name for path in transforms.get_staging_dirs("v2")] == ["v1", "v2"]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -23,6 +23,7 @@ import pytest
 
 from synthtool import transforms
 from synthtool import _tracked_paths
+from . import util
 import pathlib
 
 
@@ -165,15 +166,11 @@ def test__dont_overwrite():
         Path(dirb).joinpath("README.md").write_text("chickens")
         Path(dirb).joinpath("code.py").write_text("# chickens")
 
-        cwd = os.getcwd()
-        os.chdir(dirb)
-        try:
+        with util.chdir(dirb):
             _tracked_paths.add(dira)
             transforms.move(
                 [Path(dira).joinpath("*")], merge=transforms.dont_overwrite(["*.md"])
             )
-        finally:
-            os.chdir(cwd)
 
         # Should not have been overwritten.
         assert "chickens" == Path(dirb).joinpath("README.md").read_text()
@@ -189,14 +186,14 @@ def test__move_to_dest_subdir(expand_path_fixtures):
     dest = Path(str(expand_path_fixtures / normpath("dest/dira")))
 
     # Move to a different dir to make sure that move doesn't depend on the cwd
-    os.chdir(tempfile.gettempdir())
-    transforms.move(tmp_path / "dira", dest, excludes=["f.py"])
+    with util.chdir(tempfile.gettempdir()):
+        transforms.move(tmp_path / "dira", dest, excludes=["f.py"])
 
-    os.chdir(str(tmp_path))
-    files = sorted([str(x) for x in transforms._expand_paths("**/*", root="dest")])
+    with util.chdir(str(tmp_path)):
+        files = sorted([str(x) for x in transforms._expand_paths("**/*", root="dest")])
 
-    # Assert destination does not contain dira/f.py (excluded)
-    assert files == [normpath("dest/dira"), normpath("dest/dira/e.txt")]
+        # Assert destination does not contain dira/f.py (excluded)
+        assert files == [normpath("dest/dira"), normpath("dest/dira/e.txt")]
 
 
 def test_simple_replace(expand_path_fixtures):
@@ -258,27 +255,20 @@ def test_copy_with_merge_file_permissions(expand_path_fixtures):
     assert os.stat(destination_file).st_mode != os.stat(template).st_mode
 
     # Move to a different dir to make sure that move doesn't depend on the cwd
-    os.chdir(tempfile.gettempdir())
-    transforms.move(
-        sources=template_directory / "executable_file.sh",
-        destination=expand_path_fixtures / "executable_file.sh",
-        merge=_noop_merge,
-        required=True,
-    )
+    with util.chdir(tempfile.gettempdir()):
+        transforms.move(
+            sources=template_directory / "executable_file.sh",
+            destination=expand_path_fixtures / "executable_file.sh",
+            merge=_noop_merge,
+            required=True,
+        )
 
-    # ensure that the destination existing file now has the correct file permissions
-    assert os.stat(destination_file).st_mode == os.stat(template).st_mode
-
-
-@pytest.fixture(scope="function")
-def change_test_dir():
-    cur = os.curdir
-    os.chdir(Path(__file__).parent / "fixtures/staging_dirs")
-    yield
-    os.chdir(cur)
+        # ensure that the destination existing file now has the correct file permissions
+        assert os.stat(destination_file).st_mode == os.stat(template).st_mode
 
 
 def test_get_staging_dirs(change_test_dir):
-    assert [path.name for path in transforms.get_staging_dirs("v1")] == ["v2", "v1"]
-    assert [path.name for path in transforms.get_staging_dirs("v2")] == ["v1", "v2"]
-    assert [path.name for path in transforms.get_staging_dirs()] == ["v1", "v2"]
+    with util.chdir(Path(__file__).parent / "fixtures/staging_dirs"):
+        assert [path.name for path in transforms.get_staging_dirs("v1")] == ["v2", "v1"]
+        assert [path.name for path in transforms.get_staging_dirs("v2")] == ["v1", "v2"]
+        assert [path.name for path in transforms.get_staging_dirs()] == ["v1", "v2"]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+
+from . import util
+
+TEST_PATH = Path(__file__).parent / "testdata"
+
+
+def test_chdir():
+    cwd = os.getcwd()
+    with util.chdir(TEST_PATH):
+        assert os.getcwd().endswith("/testdata")
+
+    assert os.getcwd() == cwd
+
+
+def test_chdir_str():
+    cwd = os.getcwd()
+    with util.chdir(str(TEST_PATH)):
+        assert os.getcwd().endswith("/testdata")
+
+    assert os.getcwd() == cwd
+
+
+def test_chdir_restores_on_error():
+    cwd = os.getcwd()
+    try:
+        with util.chdir(TEST_PATH):
+            raise "foo"
+    except:
+        pass
+    assert os.getcwd() == cwd

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -40,7 +40,7 @@ def test_chdir_restores_on_error():
     cwd = os.getcwd()
     try:
         with util.chdir(TEST_PATH):
-            raise "foo"
-    except:
+            raise RuntimeError("foo")
+    except RuntimeError:
         pass
     assert os.getcwd() == cwd

--- a/tests/util.py
+++ b/tests/util.py
@@ -16,7 +16,9 @@ import contextlib
 import subprocess
 import os
 import pathlib
+import shutil
 import sys
+import tempfile
 import typing
 
 
@@ -93,6 +95,14 @@ def chdir(path: typing.Union[pathlib.Path, str]):
     old_cwd = os.getcwd()
     os.chdir(str(path))
     try:
-        yield
+        yield pathlib.Path(path)
     finally:
         os.chdir(old_cwd)
+
+
+@contextlib.contextmanager
+def copied_fixtures_dir(source: pathlib.Path):
+    with tempfile.TemporaryDirectory() as tempdir:
+        workdir = shutil.copytree(source, pathlib.Path(tempdir) / "workspace")
+        with chdir(workdir):
+            yield workdir

--- a/tests/util.py
+++ b/tests/util.py
@@ -92,6 +92,14 @@ with open("synth.metadata", "wt") as f:
 
 @contextlib.contextmanager
 def chdir(path: typing.Union[pathlib.Path, str]):
+    """Context Manager to change the current working directory and restore the
+    previous working directory after completing the context.
+
+    Args:
+        path (pathlib.Path, str) - The new current working directory.
+    Yields:
+        pathlib.Path - The new current working directory.
+    """
     old_cwd = os.getcwd()
     os.chdir(str(path))
     try:
@@ -102,6 +110,15 @@ def chdir(path: typing.Union[pathlib.Path, str]):
 
 @contextlib.contextmanager
 def copied_fixtures_dir(source: pathlib.Path):
+    """Context Manager to copy from a fixtures directory into a new temporary directory
+    and change the current working directory to that copy. Restores the original
+    current working directory after completing the context.
+
+    Args:
+        source (pathlib.Path) - The directory to copy.
+    Yields:
+        pathlib.Path - The temporary directory with the copied contents.
+    """
     with tempfile.TemporaryDirectory() as tempdir:
         workdir = shutil.copytree(source, pathlib.Path(tempdir) / "workspace")
         with chdir(workdir):

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import contextlib
 import subprocess
+import os
 import pathlib
 import sys
+import typing
 
 
 def make_working_repo(working_dir: str):
@@ -82,3 +86,13 @@ with open("synth.metadata", "wt") as f:
     )
 
     return text
+
+
+@contextlib.contextmanager
+def chdir(path: typing.Union[pathlib.Path, str]):
+    old_cwd = os.getcwd()
+    os.chdir(str(path))
+    try:
+        yield
+    finally:
+        os.chdir(old_cwd)


### PR DESCRIPTION
* `util.chdir(path)` - changes the current working directory and restores the original
* `util.copied_fixtures_dir(path)` - copies an entire directory to a new temporary directory, chdirs into that directory, and restores the original current working directory

These are 2 very common test setups that are used across the tests in this repository. It will help us ensure that we are correctly restoring the cwd between tests.