### PR TITLE
chore: Fix python owlbot post processor image cloudbuild.yaml

### DIFF
--- a/docker/owlbot/python/cloudbuild.yaml
+++ b/docker/owlbot/python/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
     args: [ 'build',
       '-t', 'gcr.io/$PROJECT_ID/owlbot-python:$SHORT_SHA',
       '-t', 'gcr.io/$PROJECT_ID/owlbot-python:latest',
-      '-f', 'docker/owlbot/nodejs/Dockerfile', '.' ]
+      '-f', 'docker/owlbot/python/Dockerfile', '.' ]
 images:
   - 'gcr.io/$PROJECT_ID/owlbot-python:$SHORT_SHA'
   - 'gcr.io/$PROJECT_ID/owlbot-python:latest'


### PR DESCRIPTION
I've confirmed that this works locally by running
```
gcloud builds submit --config=docker/owlbot/python/cloudbuild.yaml --substitutions=SHORT_SHA=$(git rev-parse --short HEAD)
```

Then I ran `python -v` in the docker container using 
```
docker run --rm -it --entrypoint /bin/bash <image>
```