### PR TITLE
chore(python): remove noxfile.py check for GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
+++ b/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
@@ -160,21 +160,7 @@ Running System Tests
   auth settings and change some configuration in your project to
   run all the tests.
 
-- System tests will be run against an actual project and
-  so you'll need to provide some environment variables to facilitate
-  authentication to your project:
-
-  - ``GOOGLE_APPLICATION_CREDENTIALS``: The path to a JSON key file;
-    Such a file can be downloaded directly from the developer's console by clicking
-    "Generate new JSON key". See private key
-    `docs <https://cloud.google.com/storage/docs/authentication#generating-a-private-key>`__
-    for more details.
-
-- Once you have downloaded your json keys, set the environment variable 
-  ``GOOGLE_APPLICATION_CREDENTIALS`` to the absolute path of the json file::
-
-   $ export GOOGLE_APPLICATION_CREDENTIALS="/Users/<your_username>/path/to/app_credentials.json"
-
+- System tests will be run against an actual project. You should use local credentials from gcloud when possible. See [Best practices for application authentication](https://cloud.google.com/docs/authentication/best-practices-applications#local_development_and_testing_with_the). Some tests require a service account. For those tests see [Authenticating as a service account](https://cloud.google.com/docs/authentication/production).
 
 *************
 Test Coverage

--- a/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
+++ b/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
@@ -160,7 +160,7 @@ Running System Tests
   auth settings and change some configuration in your project to
   run all the tests.
 
-- System tests will be run against an actual project. You should use local credentials from gcloud when possible. See [Best practices for application authentication](https://cloud.google.com/docs/authentication/best-practices-applications#local_development_and_testing_with_the). Some tests require a service account. For those tests see [Authenticating as a service account](https://cloud.google.com/docs/authentication/production).
+- System tests will be run against an actual project. You should use local credentials from gcloud when possible. See `Best practices for application authentication <https://cloud.google.com/docs/authentication/best-practices-applications#local_development_and_testing_with_the>`__. Some tests require a service account. For those tests see `Authenticating as a service account <https://cloud.google.com/docs/authentication/production>`__.
 
 *************
 Test Coverage

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -147,9 +147,6 @@ def system(session):
     # Check the value of `RUN_SYSTEM_TESTS` env var. It defaults to true.
     if os.environ.get("RUN_SYSTEM_TESTS", "true") == 'false':
         session.skip("RUN_SYSTEM_TESTS is set to false, skipping")
-    # Sanity check: Only run tests if the environment variable is set.
-    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", ""):
-        session.skip("Credentials must be set via environment variable")
     # Install pyopenssl for mTLS testing.
     if os.environ.get("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false") == "true":
         session.install("pyopenssl")
@@ -207,10 +204,6 @@ def system(session):
 def samples(session):
     requirements_path = os.path.join("samples", "requirements.txt")
     requirements_exists = os.path.exists(requirements_path)
-
-    # Sanity check: Only run tests if the environment variable is set.
-    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", ""):
-        session.skip("Credentials must be set via environment variable")
 
     session.install("mock", "pytest")
     if requirements_exists:


### PR DESCRIPTION
For Python system tests, don't enforce that `GOOGLE_APPLICATION_CREDENTIALS` is set, since the majority of tests can be run with user credentials.

