### PR TITLE
build(node): switch $default-branch with template variable

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - $default-branch
+      - {{metadata['repo']['default_branch']}}
   pull_request:
 name: ci
 jobs:


### PR DESCRIPTION
This will get our builds working again once PRs land.