### PR TITLE
build(java): switch to release-please for release tagging

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/release-please.yml
+++ b/synthtool/gcp/templates/java_library/.github/release-please.yml
@@ -1,2 +1,3 @@
-releaseType: java-yoshi
 bumpMinorPreMajor: true
+handleGHRelease: true
+releaseType: java-yoshi

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -400,6 +400,10 @@ def _merge_release_please(destination_text: str):
         return destination_text
 
     config["handleGHRelease"] = True
+
+    if "branches" in config:
+        for branch in config["branches"]:
+            branch["handleGHRelease"] = True
     return yaml.dump(config)
 
 

--- a/tests/fixtures/java_templates/release-please-update/.github/release-please.yml
+++ b/tests/fixtures/java_templates/release-please-update/.github/release-please.yml
@@ -1,0 +1,6 @@
+releaseType: java-yoshi
+bumpMinorPreMajor: true
+branches:
+- releaseType: java-lts
+  bumpMinorPreMajor: true
+  branch: 1.127.12-sp

--- a/tests/fixtures/java_templates/release-please-update/.repo-metadata.json
+++ b/tests/fixtures/java_templates/release-please-update/.repo-metadata.json
@@ -1,0 +1,17 @@
+{
+    "name": "cloudasset",
+    "name_pretty": "Cloud Asset Inventory",
+    "product_documentation": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
+    "api_reference": "https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview",
+    "api_description": "provides inventory services based on a time series database. This database keeps a five week history of Google Cloud asset metadata. The Cloud Asset Inventory export service allows you to export all asset metadata at a certain timestamp or export event change history during a timeframe.",
+    "client_documentation": "https://googleapis.dev/java/google-cloud-asset/latest/index.html",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187210&template=0",
+    "release_level": "ga",
+    "transport": "grpc",
+    "requires_billing": true,
+    "language": "java",
+    "repo": "googleapis/java-asset",
+    "repo_short": "java-asset",
+    "distribution_name": "com.google.cloud:google-cloud-asset",
+    "api_id": "cloudasset.googleapis.com"
+}

--- a/tests/test_language_java.py
+++ b/tests/test_language_java.py
@@ -180,6 +180,24 @@ def test_fix_grpc_license_idempotent():
         )
 
 
+def test_release_please_handle_releases():
+    with util.copied_fixtures_dir(FIXTURES / "java_templates" / "release-please-update") as workdir:
+        # generate the common templates
+        java.common_templates(template_path=TEMPLATES_PATH)
+
+        assert os.path.isfile(".github/release-please.yml")
+        with open(".github/release-please.yml") as fp:
+            assert fp.read() == """branches:
+- branch: 1.127.12-sp
+  bumpMinorPreMajor: true
+  handleGHRelease: true
+  releaseType: java-lts
+bumpMinorPreMajor: true
+handleGHRelease: true
+releaseType: java-yoshi
+"""
+
+
 def assert_matches_golden(expected, actual):
     matching_lines = 0
     with open(actual, "rt") as fp:

--- a/tests/test_language_java.py
+++ b/tests/test_language_java.py
@@ -181,13 +181,17 @@ def test_fix_grpc_license_idempotent():
 
 
 def test_release_please_handle_releases():
-    with util.copied_fixtures_dir(FIXTURES / "java_templates" / "release-please-update") as workdir:
+    with util.copied_fixtures_dir(
+        FIXTURES / "java_templates" / "release-please-update"
+    ) as workdir:
         # generate the common templates
         java.common_templates(template_path=TEMPLATES_PATH)
 
         assert os.path.isfile(".github/release-please.yml")
         with open(".github/release-please.yml") as fp:
-            assert fp.read() == """branches:
+            assert (
+                fp.read()
+                == """branches:
 - branch: 1.127.12-sp
   bumpMinorPreMajor: true
   handleGHRelease: true
@@ -196,6 +200,7 @@ bumpMinorPreMajor: true
 handleGHRelease: true
 releaseType: java-yoshi
 """
+            )
 
 
 def assert_matches_golden(expected, actual):

--- a/tests/test_language_java.py
+++ b/tests/test_language_java.py
@@ -183,7 +183,7 @@ def test_fix_grpc_license_idempotent():
 def test_release_please_handle_releases():
     with util.copied_fixtures_dir(
         FIXTURES / "java_templates" / "release-please-update"
-    ) as workdir:
+    ):
         # generate the common templates
         java.common_templates(template_path=TEMPLATES_PATH)
 


### PR DESCRIPTION
Requires https://github.com/googleapis/releasetool/pull/323 to be merged first

If no `.github/release-please.yml` exists, create one from the template.
If one does exist, set `handleGHRelease` to `true` for the main config and each configured branch.

See https://github.com/googleapis/repo-automation-bots/tree/master/packages/release-please#configuration for config file structure.

This is part of go/deprecate-autorelease-tag where we switch from autorelease tagging to release-please tagging.