### PR TITLE
chore: adding cloud-rad java xrefs

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc11.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc11.sh
@@ -49,6 +49,13 @@ pushd target/docfx-yml
 python3 -m docuploader create-metadata \
  --name ${NAME} \
  --version ${VERSION} \
+ --xrefs devsite://java/gax \
+ --xrefs devsite://java/google-cloud-core \
+ --xrefs devsite://java/api-common \
+ --xrefs devsite://java/proto-google-common-protos \
+ --xrefs devsite://java/google-api-client \
+ --xrefs devsite://java/google-http-client \
+ --xrefs devsite://java/protobuf \
  --language java
 
 # upload yml to production bucket


### PR DESCRIPTION
Fixes b/179912573

Adds cross reference links to docs. Currently will only link to the latest version of the library, but will revisit versioning as we address versioning for docs. http-client and protobuf don't have generated xrefs yet, but docpipline will skip those until we do.

 Tested this out on a few repos and appears to be working as intended.