### PR TITLE
build(node): explicit update to google-gax

### DIFF
--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -47,7 +47,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@2.10.3 typescript@3.9.9 \
+RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@2.12.0 typescript@3.9.9 \
     chalk@4.0.0 escodegen@2.0.0 espree@7.1.0 estraverse@5.1.0 glob@7.1.6 jsdoc@3.6.3 \
     minimist@1.2.0 semver@7.1.2 tmp@0.2.1 uglify-js@3.7.7
 


### PR DESCRIPTION
We run the post-processor at a specific version of google-gax.