### PR TITLE
fix(deps): lock click to 7.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ description = ''
 version = '2020.02.04'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
-    "click",
+    "click >=7.0.0, <8.0.0",
     "colorlog",
     "deprecation",
     "jinja2",


### PR DESCRIPTION
This fixes synthtool in our owlbot-java image which is using an older version of python.

This is for the same error we fixed in releasetool. https://github.com/googleapis/releasetool/pull/333