### PR TITLE
fix: Use bazel 4.0 in the default autosynth build script

### DIFF
--- a/.kokoro-autosynth/build.sh
+++ b/.kokoro-autosynth/build.sh
@@ -22,7 +22,7 @@ sudo npm install -g npm
 
 # Install bazel 3.0.0
 mkdir -p ~/bazel
-curl -L https://github.com/bazelbuild/bazel/releases/download/3.0.0/bazel-3.0.0-linux-x86_64 -o ~/bazel/bazel
+curl -L https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel-4.0.0-linux-x86_64 -o ~/bazel/bazel
 chmod +x ~/bazel/bazel
 export PATH=~/bazel:"$PATH"
 


### PR DESCRIPTION
For Ruby. An attempt to fix https://github.com/googleapis/google-cloud-ruby/issues/11262