### PR TITLE
fix: don't invoke postprocess_gapic_library_hermetic() when there are

### DIFF
--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -359,12 +359,11 @@ def owlbot_main(
             versions=versions,
             default_version=default_version,
         )
+        s_copy([templates], excludes=templates_excludes)
+        postprocess_gapic_library_hermetic()
     else:
         templates = common_templates.node_library(source_location="build/src")
-
-    s_copy([templates], excludes=templates_excludes)
-
-    postprocess_gapic_library_hermetic()
+        s_copy([templates], excludes=templates_excludes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
… no versions to post process.

Fixes one more way `owlbot_main()` choked on repos without source code from googleapis-gen.

Fixes https://github.com/googleapis/repo-automation-bots/issues/1600