### PR TITLE
docs(python): fix broken links in multiprocessing.rst

### DIFF
--- a/synthtool/gcp/templates/python_library/docs/multiprocessing.rst
+++ b/synthtool/gcp/templates/python_library/docs/multiprocessing.rst
@@ -1,7 +1,7 @@
 .. note::
 
-   Because this client uses :mod:`grpcio` library, it is safe to
+   Because this client uses :mod:`grpc` library, it is safe to
    share instances across threads. In multiprocessing scenarios, the best
    practice is to create client instances *after* the invocation of
-   :func:`os.fork` by :class:`multiprocessing.Pool` or
+   :func:`os.fork` by :class:`multiprocessing.pool.Pool` or
    :class:`multiprocessing.Process`.


### PR DESCRIPTION
In the [generated docs](https://googleapis.dev/python/webrisk/latest/index.html#next-steps) for `google-cloud-webrisk`, under the `Note:` section the links for `grpcio` and `multiprocessing.Pool` aren't working. I applied the fixes in this PR in the [python-webrisk](https://github.com/googleapis/python-webrisk) repo and ran `nox -s docs` to generate the docs using `sphinx`. I've confirmed that the links are now working.