### PR TITLE
chore(owlbot-java): only add modules with version v1 or v2 to parent pom

### DIFF
--- a/docker/owlbot/java/src/fix-poms.py
+++ b/docker/owlbot/java/src/fix-poms.py
@@ -129,23 +129,24 @@ def update_cloud_pom(
     # insert proto dependencies after protobuf-java
     for m in proto_modules:
         if m.artifact_id not in existing_dependencies:
-            print(f"adding new dependency {m.artifact_id}")
-            new_dependency = etree.Element(
-                "{http://maven.apache.org/POM/4.0.0}dependency"
-            )
-            new_dependency.tail = "\n    "
-            new_dependency.text = "\n      "
-            new_group = etree.Element("{http://maven.apache.org/POM/4.0.0}groupId")
-            new_group.text = m.group_id
-            new_group.tail = "\n      "
-            new_artifact = etree.Element(
-                "{http://maven.apache.org/POM/4.0.0}artifactId"
-            )
-            new_artifact.text = m.artifact_id
-            new_artifact.tail = "\n    "
-            new_dependency.append(new_group)
-            new_dependency.append(new_artifact)
-            dependencies.insert(proto_index + 1, new_dependency)
+            if "v1" in m.artifact_id or "v2" in m.artifact_id:
+                print(f"adding new dependency {m.artifact_id}")
+                new_dependency = etree.Element(
+                    "{http://maven.apache.org/POM/4.0.0}dependency"
+                )
+                new_dependency.tail = "\n    "
+                new_dependency.text = "\n      "
+                new_group = etree.Element("{http://maven.apache.org/POM/4.0.0}groupId")
+                new_group.text = m.group_id
+                new_group.tail = "\n      "
+                new_artifact = etree.Element(
+                    "{http://maven.apache.org/POM/4.0.0}artifactId"
+                )
+                new_artifact.text = m.artifact_id
+                new_artifact.tail = "\n    "
+                new_dependency.append(new_group)
+                new_dependency.append(new_artifact)
+                dependencies.insert(proto_index + 1, new_dependency)
 
     tree.write(filename, pretty_print=True, xml_declaration=True, encoding="utf-8")
 

--- a/docker/owlbot/java/src/fix-poms.py
+++ b/docker/owlbot/java/src/fix-poms.py
@@ -18,6 +18,7 @@ import itertools
 import json
 from lxml import etree
 import os
+import re
 from typing import List, Mapping
 from poms import module, templates
 
@@ -129,7 +130,7 @@ def update_cloud_pom(
     # insert proto dependencies after protobuf-java
     for m in proto_modules:
         if m.artifact_id not in existing_dependencies:
-            if "v1" in m.artifact_id or "v2" in m.artifact_id:
+            if re.match(r"proto-.*-v\d+.*", m.artifact_id):
                 print(f"adding new dependency {m.artifact_id}")
                 new_dependency = etree.Element(
                     "{http://maven.apache.org/POM/4.0.0}dependency"


### PR DESCRIPTION
Java-gsuite-addons has an extra set of protos that other protos in the library depend on. These are added to the repo as a separate module `proto-google-apps-script-type-protos`. Only proto-google-cloud-gsuite-addons-v1 depends on this module. But owlbot is currently configured to add all modules to its parent pom. Since the parent do not depend on this extra protos module, it fails the dependency check.
![image](https://user-images.githubusercontent.com/13271327/120238953-42800300-c22b-11eb-9b30-2ffe213d415c.png)


To solve this issue, the post-processor is being configured to add only the modules with a version (v1 or v2) in it.