### PR TITLE
fix: Add `shopt -s nullglob` to dependencies script

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 set -eo pipefail
+shopt -s nullglob
 
 ## Get the directory of the build script
 scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))


### PR DESCRIPTION
This prevents processing the unexpanded glob "**/.flattened-pom.xml" in repos which do not flatten any POMs.