### PR TITLE
build: enable npm for php/python builds

### DIFF
--- a/.kokoro-autosynth/build-in-docker.sh
+++ b/.kokoro-autosynth/build-in-docker.sh
@@ -28,6 +28,23 @@ ssh-keyscan github.com >> "$HOME/.ssh/known_hosts"
 # Kokoro exposes this as a file, but the scripts expect just a plain variable.
 export GITHUB_TOKEN=$(cat ${KOKORO_KEYSTORE_DIR}/73713_yoshi-automation-github-key)
 
+# Install npm to facilitate installtion of a code formatter for PHP: https://github.com/prettier/plugin-php
+# Use `nvm` to bootstrap the installation of node.js and npm.
+# To learn more: https://github.com/nvm-sh/nvm
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+
+# Activate `nvm` so the binary is available on the path
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+# Use the latest LTS version of nodejs.  This can change over time, but
+# should prevent the need to modify this file every year.
+nvm install --lts
+
+# Verify expected versions of nodejs and npm
+node --version
+npm --version
+
 # Setup git credentials
 echo "https://${GITHUB_TOKEN}:@github.com" >> ~/.git-credentials
 git config --global credential.helper 'store --file ~/.git-credentials'

--- a/.kokoro-autosynth/build-in-docker.sh
+++ b/.kokoro-autosynth/build-in-docker.sh
@@ -28,7 +28,7 @@ ssh-keyscan github.com >> "$HOME/.ssh/known_hosts"
 # Kokoro exposes this as a file, but the scripts expect just a plain variable.
 export GITHUB_TOKEN=$(cat ${KOKORO_KEYSTORE_DIR}/73713_yoshi-automation-github-key)
 
-# Install npm to facilitate installtion of a code formatter for PHP: https://github.com/prettier/plugin-php
+# Install npm to facilitate installation of a code formatter for PHP: https://github.com/prettier/plugin-php
 # Use `nvm` to bootstrap the installation of node.js and npm.
 # To learn more: https://github.com/nvm-sh/nvm
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash


### PR DESCRIPTION
One of the nicer code formatting tools I've found for PHP is, interestingly enough, written in node: https://github.com/prettier/plugin-php

I was hoping to use it as part of our synth scripts to help smooth over some recent changes from the microgenerator. Ultimately I think I'd like to work this into the microgenerator, but am hoping this would be an acceptable alternative until then.

These additions are copied over from [node's build file](https://github.com/googleapis/synthtool/blob/master/.kokoro-autosynth/nodejs-build.sh#L20-L34) and based upon reviewing the changes [here](https://github.com/googleapis/synthtool/pull/1063/files). If there is a more appropriate way to achieve this here or we'd prefer to have a separate build file for PHP, please let me know, but it seemed relatively low impact to include this for python as well.