### PR TITLE
chore(python): simplify nox steps in CONTRIBUTING.rst

### DIFF
--- a/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
+++ b/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
@@ -75,8 +75,7 @@ We use `nox <https://nox.readthedocs.io/en/latest/>`__ to instrument our tests.
 - To test your changes, run unit tests with ``nox``::
     $ nox -s unit
 
-- Args to pytest can be passed through the nox command separated by a `--`. For
-  example, to run a single test::
+- To run a single unit test::
 
     $ nox -s unit-{{ unit_test_python_versions | last }} -- -k <name of test>
 

--- a/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
+++ b/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
@@ -73,9 +73,7 @@ Using ``nox``
 We use `nox <https://nox.readthedocs.io/en/latest/>`__ to instrument our tests.
 
 - To test your changes, run unit tests with ``nox``::
-{% for v in unit_test_python_versions %}
-    $ nox -s unit-{{ v }}
-{%- endfor %}
+    $ nox -s unit
 
 - Args to pytest can be passed through the nox command separated by a `--`. For
   example, to run a single test::
@@ -148,9 +146,7 @@ Running System Tests
 - To run system tests, you can execute::
 
    # Run all system tests
-{%- for system_test_version in system_test_python_versions %}
-   $ nox -s system-{{ system_test_version }}
-{%- endfor %}
+   $ nox -s system
 
    # Run a single system test
    $ nox -s system-{{ system_test_python_versions | last}} -- -k <name of test>


### PR DESCRIPTION
This is a follow up to PR #1132 based on feedback from https://github.com/googleapis/python-bigquery-sqlalchemy/pull/191 to simplify the steps to run `nox` in [CONTRIBUTING.rst](https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/CONTRIBUTING.rst).