### PR TITLE
feat: add env var DEFAULT_BRANCH_PATH

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -369,6 +369,17 @@ def _load_repo_metadata(metadata_file: str = "./.repo-metadata.json") -> Dict:
 
 
 def _get_default_branch_name(repository_name: str) -> str:
+    """Read the default branch name from the environment.
+
+    First checks environment variable DEFAULT_BRANCH_PATH.  If found, it
+    reads the contents of the file at DEFAULT_BRANCH_PATH and returns it.
+
+    Then checks environment varabile DEFAULT_BRANCH, and returns it if found.
+    """
+    default_branch_path = os.getenv("DEFAULT_BRANCH_PATH")
+    if default_branch_path:
+        return Path(default_branch_path).read_text().strip()
+
     # This default should be switched to "main" once we've migrated
     # the majority of our repositories:
     return os.getenv("DEFAULT_BRANCH", "master")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from synthtool.gcp.common import decamelize, _get_default_branch_name
-from pathlib import Path
-from pytest import raises
 import os
-import synthtool as s
-from . import util
+import tempfile
+from pathlib import Path
 from unittest import mock
+
+from pytest import raises
+
+import synthtool as s
+from synthtool.gcp.common import _get_default_branch_name, decamelize
+
+from . import util
 
 MOCK = Path(__file__).parent / "generationmock"
 template_dir = Path(__file__).parent.parent / "synthtool/gcp/templates"
@@ -42,8 +46,17 @@ def test_handles_empty_string():
 
 
 def test_get_default_branch():
-    with mock.patch.dict(os.environ, {"DEFAULT_BRANCH": "main"}):
-        assert _get_default_branch_name("repo_name") == "main"
+    with mock.patch.dict(os.environ, {"DEFAULT_BRANCH": "chickens"}):
+        assert _get_default_branch_name("repo_name") == "chickens"
+
+
+def test_get_default_branch_path():
+    f = tempfile.NamedTemporaryFile("wt", delete=False)
+    fname = f.name
+    f.write("ducks\n")
+    f.close()
+    with mock.patch.dict(os.environ, {"DEFAULT_BRANCH_PATH": fname}):
+        assert _get_default_branch_name("repo_name") == "ducks"
 
 
 def test_py_samples_clientlib():


### PR DESCRIPTION
First step to fixing https://github.com/googleapis/repo-automation-bots/issues/2098.

I want to observe the default branch in the first cloud build step,
then pass it to a later step.  However, it can't be passed directly
via an environment variable because steps can't modify their environment
variables and it's not possible to dynamically compose an environment
variable in a cloud-build.yaml.

Therefore, I'll observe the default branch and record it in a file, and
then pass it the file path to the later step.  The contents of the file
may change but the path to the file is constant and can be specified
in cloud-build.yaml.