### PR TITLE
chore: Remove commit body and PR# from post-processor-changes-txt

### DIFF
--- a/docker/owlbot/python/cloudbuild.yaml
+++ b/docker/owlbot/python/cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
     entrypoint: '/bin/sh'
     args:
       - '-c'
-      - 'git log -1 --format="%s%n%n%b%nSource-Link: https://github.com/googleapis/synthtool/commit/%H" > post-processor-changes.txt'
+      - 'git log -1 --format="%s%n%nSource-Link: https://github.com/googleapis/synthtool/commit/%H" | sed -e "s/([^()]*)$//g" > post-processor-changes.txt'
   - name: 'gcr.io/cloud-builders/docker'
     args: [ 'build',
       '-t', 'gcr.io/$PROJECT_ID/owlbot-python:$SHORT_SHA',


### PR DESCRIPTION
Fixes #1134 🦕

Removes the commit body and relative PR# from the commit message.

For example, for this commit: https://github.com/googleapis/synthtool/commit/9763f20e4b7bb1091082462b2f7970e965d0d414

`post-processor-changes.txt` would contain

```
build: enable npm for php/python builds 

Source-Link: https://github.com/googleapis/synthtool/commit/9763f20e4b7bb1091082462b2f7970e965d0d414
```

instead of

```
build: enable npm for php/python builds (#1133)

* build: enable npm for php/python builds

* update comment
Source-Link: https://github.com/googleapis/synthtool/commit/9763f20e4b7bb1091082462b2f7970e965d0d414
```