### PR TITLE
chore: upgrade npm version

### DIFF
--- a/.kokoro-autosynth/build-in-docker.sh
+++ b/.kokoro-autosynth/build-in-docker.sh
@@ -45,6 +45,9 @@ nvm install --lts
 node --version
 npm --version
 
+# Upgrade the NPM version
+sudo npm install -g npm
+
 # Setup git credentials
 echo "https://${GITHUB_TOKEN}:@github.com" >> ~/.git-credentials
 git config --global credential.helper 'store --file ~/.git-credentials'


### PR DESCRIPTION
Mimicking https://github.com/googleapis/synthtool/blob/master/.kokoro-autosynth/build.sh#L20-L21 in order to utilize npm 7.