### PR TITLE
build(node): don't throw on deprecation in unit tests

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
       - run: rm -rf node_modules
       - run: npm install
       - run: npm test
+        env:
+          MOCHA_THROW_DEPRECATION: false
   windows:
     runs-on: windows-latest
     steps:
@@ -33,6 +35,8 @@ jobs:
           node-version: 14
       - run: npm install
       - run: npm test
+        env:
+          MOCHA_THROW_DEPRECATION: false
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This addresses an issue with builds caused by us including deprecation notices on some methods.