### PR TITLE
build(node): do not throw on deprecation

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/test.sh
@@ -32,6 +32,9 @@ if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ART
   }
   trap cleanup EXIT HUP
 fi
+# Unit tests exercise the entire API surface, which may include
+# deprecation warnings:
+export MOCHA_THROW_DEPRECATION=false
 npm test
 
 # codecov combines coverage across integration and unit tests. Include


### PR DESCRIPTION
We created a ton of flaky bot issues, due to to ignoring deprecation warnings only in our GitHub action unit tests:

Refs https://github.com/googleapis/nodejs-service-usage/issues/22