### PR TITLE
chore: python 3.9 as the default python version for noxfile.py

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -222,7 +222,7 @@ class CommonTemplates:
 
         # Set default Python versions for noxfile.py
         if "default_python_version" not in kwargs:
-            kwargs["default_python_version"] = "3.8"
+            kwargs["default_python_version"] = "3.9"
         if "unit_test_python_versions" not in kwargs:
             kwargs["unit_test_python_versions"] = ["3.6", "3.7", "3.8", "3.9"]
             if "microgenerator" not in kwargs:


### PR DESCRIPTION
#1069 was merged which upgrades the python version in the post processor image from python 3.8 to 3.9. The default version for `noxfile.py` should also be updated.