### PR TITLE
chore: remove sudo usage

### DIFF
--- a/.kokoro-autosynth/build-in-docker.sh
+++ b/.kokoro-autosynth/build-in-docker.sh
@@ -46,7 +46,7 @@ node --version
 npm --version
 
 # Upgrade the NPM version
-sudo npm install -g npm
+npm install -g npm
 
 # Setup git credentials
 echo "https://${GITHUB_TOKEN}:@github.com" >> ~/.git-credentials


### PR DESCRIPTION
Follows: https://github.com/googleapis/synthtool/pull/1138. The latest build failed with `.kokoro-autosynth/build-in-docker.sh: line 49: sudo: command not found` - it should be safe to remove as we likely already have root in the container.