### PR TITLE
chore: remove All rights reserved clause from java.header

### DIFF
--- a/synthtool/gcp/templates/java_library/java.header
+++ b/synthtool/gcp/templates/java_library/java.header
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright \d\d\d\d,? Google (Inc\.|LLC)( All [rR]ights [rR]eserved\.)?$
+^ \* Copyright \d\d\d\d,? Google (Inc\.|LLC)$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the "License"\);$
 ^ \* you may not use this file except in compliance with the License\.$


### PR DESCRIPTION
After discussion with OSPO, it has been decided to remove "All rights reserved" clause from the java.header file to better reflect the [correct license header](https://g3doc.corp.google.com/company/teams/opensource/releasing/preparing.md?cl=head#Apache-header).