### PR TITLE
fix(ruby): Disable multi-commits for Ruby bazel autosynth

### DIFF
--- a/.kokoro-autosynth/ruby.cfg
+++ b/.kokoro-autosynth/ruby.cfg
@@ -20,11 +20,6 @@ env_vars: {
 }
 
 env_vars: {
-    key: "AUTOSYNTH_MULTIPLE_COMMITS"
-    value: "true"
-}
-
-env_vars: {
     key: "SYNTHTOOL_TRACK_OBSOLETE_FILES"
     value: "true"
 }


### PR DESCRIPTION
I've determined that Ruby autosynth jobs that use Bazel are taking far too long, sometimes up to an hour _per library_, causing autosynth to timeout. The problem is that some synth jobs need to run large numbers (up to dozens) of gapic generation bazel builds, against different commits from googleapis. For Ruby, many older commits from googleapis have incomplete, buggy, or unoptimized bazel configurations that will either fail to build in spectacular ways, or (worse) result in long-running bazel jobs that (among other things) download and build the Ruby VM from source. When there are dozens of such bazel builds in a single synth job, it becomes clear why the overall synth job will eventually timeout. [Example log (internal-only link)](https://fusion.corp.googleusercontent.com/file/autoview?fileUri=googlefile%3A%2Fplacer%2Fprod%2Fhome%2Fkokoro-dedicated%2Fbuild_artifacts%2Fprod%2Fcloud-devrel%2Fclient-libraries%2Fautosynth%2Fruby%2F1123%2F20210707-113453%2Fgithub%2Fsynthtool%2Flogs%2Fgoogle-cloud-logging-v2%2Fsponge_log.log&filename=test.log&invocationId=ba404481-449a-4de5-8169-a6fc5aa41592&actionName=invocations%2Fba404481-449a-4de5-8169-a6fc5aa41592%2Ftargets%2Fgithub%252Fsynthtool%252Flogs%252Fgoogle-cloud-logging-v2%2FconfiguredTargets%2Fdefault%2Factions%2Ftest_attempt0&contentType=ansi). Therefore, I'm disabling the multi-commit feature for Ruby Bazel jobs, to unstick autosynth until we can complete the migration to owlbot.