### PR TITLE
build(python): exit with success status if no samples found

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/test-samples-impl.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/test-samples-impl.sh
@@ -20,9 +20,9 @@ set -eo pipefail
 # Enables `**` to include files nested inside sub-folders
 shopt -s globstar
 
-# Exit early if samples directory doesn't exist
-if [ ! -d "./samples" ]; then
-  echo "No tests run. `./samples` not found"
+# Exit early if samples don't exist
+if ! compgen -G  "./samples/**/requirements.txt" > /dev/null; then
+  echo "No tests run. './samples/**/requirements.txt' not found"
   exit 0
 fi
 

--- a/synthtool/gcp/templates/python_library/.kokoro/test-samples-impl.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/test-samples-impl.sh
@@ -21,7 +21,7 @@ set -eo pipefail
 shopt -s globstar
 
 # Exit early if samples don't exist
-if ! compgen -G  "./samples/**/requirements.txt" > /dev/null; then
+if ! find samples -name 'requirements.txt' | grep -q .; then
   echo "No tests run. './samples/**/requirements.txt' not found"
   exit 0
 fi


### PR DESCRIPTION
Look for  `requirements.txt` in `samples` to check if any samples exist. The current check for `samples/` doesn't always work as some repos have placeholder `samples` directories with READMEs.

- Repo without samples: https://github.com/googleapis/python-websecurityscanner/pull/84, [log](https://source.cloud.google.com/results/invocations/fc1a30bb-f1fe-4dab-b806-f550fe44cec1/targets)
- Repo with samples https://github.com/googleapis/python-vision/pull/194, [log](https://source.cloud.google.com/results/invocations/af04ad8c-938d-47a5-a11e-7721f32fb6ed/targets)


This will make it possible to add samples kokoro jobs to every repository and remove custom sync repo settings configs.

~EDIT: This doesn't seem to work correctly for more deeply nested directories, I will look around to find something that works.~

