### PR TITLE
feat: add Samples section to CONTRIBUTING.rst

### DIFF
--- a/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
+++ b/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
@@ -187,6 +187,30 @@ Build the docs via:
 
    $ nox -s docs
 
+*************************
+Samples and code snippets
+*************************
+
+Code samples and snippets live in the `samples/` catalogue. Feel free to
+provide more examples, but make sure to write tests for those examples.
+Each folder containing example code requires its own `noxfile.py` script
+which automates testing. If you decide to create a new folder, you can
+base it on the `samples/snippets` folder (providing `noxfile.py` and
+the requirements files).
+
+The tests will run against a real Google Cloud Project, so you should
+configure them just like the System Tests.
+
+- To run sample tests, you can execute::
+
+   # Run all tests in a folder
+   $ cd samples/snippets
+   $ nox -s py-3.8
+
+   # Run a single sample test
+   $ cd samples/snippets
+   $ nox -s py-3.8 -- -k <name of test>
+
 ********************************************
 Note About ``README`` as it pertains to PyPI
 ********************************************


### PR DESCRIPTION
Adding a section about samples in CONTRIBUTING.rst if Python
libraries template.

Fixing #1124 