### PR TITLE
chore: add preserve_gapic to java library generation options

### DIFF
--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -369,7 +369,7 @@ def bazel_library(
         destination_name=destination_name,
         cloud_api=cloud_api,
         diregapic=diregapic,
-        preserve_gapic=preserve_gapic
+        preserve_gapic=preserve_gapic,
     )
 
     return library

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -256,7 +256,7 @@ def _common_generation(
     )
 
     if preserve_gapic:
-        format_code(f"gapic-google-{cloud_prefix}{destination_name}/src")
+        format_code(f"gapic-google-{cloud_prefix}{destination_name}-{version}/src")
     else:
         format_code(f"google-{cloud_prefix}{destination_name}/src")
     format_code(f"grpc-google-{cloud_prefix}{destination_name}-{version}/src")


### PR DESCRIPTION
There are cases when generating a library the gapic directory prefix should be preserved (veneer clients for example). This feature adds a new parameter `preserve_gapic` to `java.gapic_library` and `java.bazel_library`