### PR TITLE
chore(docs): remove mention about samples README

### DIFF
--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -96,8 +96,7 @@ use this {{metadata['repo']['name_pretty']}} Client Library.
 {% if metadata['samples']|length %}
 ## Samples
 
-Samples are in the [`samples/`](https://github.com/{{  metadata['repo']['repo'] }}/tree/master/samples) directory. The samples' `README.md`
-has instructions for running the samples.
+Samples are in the [`samples/`](https://github.com/{{  metadata['repo']['repo'] }}/tree/master/samples) directory.
 
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |


### PR DESCRIPTION
Fixes googleapis/java-logging#586.
Since no java repos have README in samples/ subfolder, we remove the mentioning from README