### PR TITLE
chore: fix kokoro config for samples

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/periodic-head.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/periodic-head.cfg
@@ -7,5 +7,5 @@ env_vars: {
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-pubsub/.kokoro/test-samples-against-head.sh"
+    value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples-against-head.sh"
 }

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.7/periodic-head.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.7/periodic-head.cfg
@@ -7,5 +7,5 @@ env_vars: {
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-pubsub/.kokoro/test-samples-against-head.sh"
+    value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples-against-head.sh"
 }

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/periodic-head.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/periodic-head.cfg
@@ -7,5 +7,5 @@ env_vars: {
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-pubsub/.kokoro/test-samples-against-head.sh"
+    value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples-against-head.sh"
 }

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.9/periodic-head.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.9/periodic-head.cfg
@@ -7,5 +7,5 @@ env_vars: {
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-pubsub/.kokoro/test-samples-against-head.sh"
+    value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples-against-head.sh"
 }


### PR DESCRIPTION
Fixes #1166 

I tested these changes by running the following commands after cloning synthtool
```
git checkout fix-kokoro-sample-config
docker build -t testkokoro -f docker/owlbot/python/Dockerfile .
```

Once the docker image was built, I ran the following command in the root of python-aiplatform

```
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo testkokoro
```

which produced the following changes
```
partheniou@partheniou-vm-1:~/git/python-aiplatform$ git diff .kokoro
diff --git a/.kokoro/samples/python3.6/periodic-head.cfg b/.kokoro/samples/python3.6/periodic-head.cfg
index f9cfcd3..88d5235 100644
--- a/.kokoro/samples/python3.6/periodic-head.cfg
+++ b/.kokoro/samples/python3.6/periodic-head.cfg
@@ -7,5 +7,5 @@ env_vars: {
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-pubsub/.kokoro/test-samples-against-head.sh"
+    value: "github/python-aiplatform/.kokoro/test-samples-against-head.sh"
 }
diff --git a/.kokoro/samples/python3.7/periodic-head.cfg b/.kokoro/samples/python3.7/periodic-head.cfg
index f9cfcd3..88d5235 100644
--- a/.kokoro/samples/python3.7/periodic-head.cfg
+++ b/.kokoro/samples/python3.7/periodic-head.cfg
@@ -7,5 +7,5 @@ env_vars: {
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-pubsub/.kokoro/test-samples-against-head.sh"
+    value: "github/python-aiplatform/.kokoro/test-samples-against-head.sh"
 }
diff --git a/.kokoro/samples/python3.8/periodic-head.cfg b/.kokoro/samples/python3.8/periodic-head.cfg
index f9cfcd3..88d5235 100644
--- a/.kokoro/samples/python3.8/periodic-head.cfg
+++ b/.kokoro/samples/python3.8/periodic-head.cfg
@@ -7,5 +7,5 @@ env_vars: {
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-pubsub/.kokoro/test-samples-against-head.sh"
+    value: "github/python-aiplatform/.kokoro/test-samples-against-head.sh"
 }
diff --git a/.kokoro/samples/python3.9/periodic-head.cfg b/.kokoro/samples/python3.9/periodic-head.cfg
index f9cfcd3..88d5235 100644
--- a/.kokoro/samples/python3.9/periodic-head.cfg
+++ b/.kokoro/samples/python3.9/periodic-head.cfg
@@ -7,5 +7,5 @@ env_vars: {
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-pubsub/.kokoro/test-samples-against-head.sh"
+    value: "github/python-aiplatform/.kokoro/test-samples-against-head.sh"
 }
```