### PR TITLE
build: update auto-approve config for new validation

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/auto-approve.yml
+++ b/synthtool/gcp/templates/node_library/.github/auto-approve.yml
@@ -6,7 +6,7 @@ rules:
   - "CHANGELOG\\.md$"
   maxFiles: 3
 - author: "renovate-bot"
-  title: "^(fix\\(deps\\)|chore\\(deps\\)):"
+  title: "^(fix|chore)\\(deps\\):"
   changedFiles: 
-  - "/package\\.json$"
+  - "package\\.json$"
   maxFiles: 2


### PR DESCRIPTION
This PR contains changes in the validation schema, given recommendations for updating the regex: https://github.com/googleapis/repo-automation-bots/pull/2288

I would like to merge this PR, then merge repo-automation-bots, then merge the resulting PRs. If we attempt to merge these PRs before merging the repo-automation-bots, we will get a failing Auto-approve.yml file.