### PR TITLE
docs(nodejs): move branch references to main

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/generated-files-bot.yml
+++ b/synthtool/gcp/templates/node_library/.github/generated-files-bot.yml
@@ -8,9 +8,9 @@ generatedFiles:
 - path: '.github/generated-files-bot.+(yml|yaml)'
   message: '`.github/generated-files-bot.(yml|yaml)` should be updated in [`synthtool`](https://github.com/googleapis/synthtool)'
 - path: 'README.md'
-  message: '`README.md` is managed by [`synthtool`](https://github.com/googleapis/synthtool). However, a partials file can be used to update the README, e.g.: https://github.com/googleapis/nodejs-storage/blob/master/.readme-partials.yaml'
+  message: '`README.md` is managed by [`synthtool`](https://github.com/googleapis/synthtool). However, a partials file can be used to update the README, e.g.: https://github.com/googleapis/nodejs-storage/blob/{{ metadata['repo']['default_branch'] }}/.readme-partials.yaml'
 - path: 'samples/README.md'
-  message: '`samples/README.md` is managed by [`synthtool`](https://github.com/googleapis/synthtool). However, a partials file can be used to update the README, e.g.: https://github.com/googleapis/nodejs-storage/blob/master/.readme-partials.yaml'
+  message: '`samples/README.md` is managed by [`synthtool`](https://github.com/googleapis/synthtool). However, a partials file can be used to update the README, e.g.: https://github.com/googleapis/nodejs-storage/blob/{{ metadata['repo']['default_branch'] }}/.readme-partials.yaml'
 ignoreAuthors:
 - 'gcf-owl-bot[bot]'
 - 'yoshi-automation'

--- a/synthtool/gcp/templates/node_library/.kokoro/continuous/node10/common.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/continuous/node10/common.cfg
@@ -7,7 +7,7 @@ action {
   }
 }
 
-# Bring in codecov.io master token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
+# Bring in codecov.io token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
 before_action {
   fetch_keystore {
     keystore_resource {

--- a/synthtool/gcp/templates/node_library/.kokoro/continuous/node10/test.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/continuous/node10/test.cfg
@@ -1,4 +1,4 @@
-# Bring in codecov.io master token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
+# Bring in codecov.io token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
 before_action {
   fetch_keystore {
     keystore_resource {

--- a/synthtool/gcp/templates/node_library/.kokoro/presubmit/node10/common.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/presubmit/node10/common.cfg
@@ -7,7 +7,7 @@ action {
   }
 }
 
-# Bring in codecov.io master token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
+# Bring in codecov.io token into the build as $KOKORO_KEYSTORE_DIR/73713_dpebot_codecov_token
 before_action {
   fetch_keystore {
     keystore_resource {

--- a/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
@@ -39,7 +39,7 @@ if [ -f samples/package.json ]; then
     npm link ../
     npm install
     cd ..
-    # If tests are running against master, configure flakybot
+    # If tests are running against main branch, configure flakybot
     # to open issues on failures:
     if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
       export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml

--- a/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
@@ -33,7 +33,7 @@ fi
 
 npm install
 
-# If tests are running against master, configure flakybot
+# If tests are running against main branch, configure flakybot
 # to open issues on failures:
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
   export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml

--- a/synthtool/gcp/templates/node_library/.kokoro/test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/test.sh
@@ -21,7 +21,7 @@ export NPM_CONFIG_PREFIX=${HOME}/.npm-global
 cd $(dirname $0)/..
 
 npm install
-# If tests are running against master, configure flakybot
+# If tests are running against main branch, configure flakybot
 # to open issues on failures:
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
   export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -10,7 +10,7 @@
 
 {{ metadata['repo']['release_level']|release_quality_badge }}
 [![npm version](https://img.shields.io/npm/v/{{ metadata['name'] }}.svg)](https://www.npmjs.org/package/{{ metadata['name'] }})
-[![codecov](https://img.shields.io/codecov/c/github/{{ metadata['repo']['repo'] }}/master.svg?style=flat)](https://codecov.io/gh/{{ metadata['repo']['repo'] }})
+[![codecov](https://img.shields.io/codecov/c/github/{{ metadata['repo']['repo'] }}/{{metadata['repo']['default_branch']}}.svg?style=flat)](https://codecov.io/gh/{{ metadata['repo']['repo'] }})
 
 {% if metadata['deprecated'] %}
 | :warning: Deprecated Module |
@@ -146,8 +146,8 @@ Contributions welcome! See the [Contributing Guide](https://github.com/{{ metada
 Please note that this `README.md`, the `samples/README.md`,
 and a variety of configuration files in this repository (including `.nycrc` and `tsconfig.json`)
 are generated from a central template. To edit one of these files, make an edit
-to its template in this
-[directory](https://github.com/googleapis/synthtool/tree/master/synthtool/gcp/templates/node_library).
+to its templates in
+[directory](https://github.com/googleapis/synthtool).
 
 ## License
 


### PR DESCRIPTION
Noticed a few references to `master` branch which I have updated to `main`.