### PR TITLE
build(java): use ENABLE_FLAKYBOT env variable

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.sh
@@ -115,7 +115,7 @@ fi
 # fix output location of logs
 bash .kokoro/coerce_logs.sh
 
-if [[ "${ENABLE_BUILD_COP}" == "true" ]]
+if [[ "${ENABLE_FLAKYBOT}" == "true" ]]
 then
     chmod +x ${KOKORO_GFILE_DIR}/linux_amd64/flakybot
     ${KOKORO_GFILE_DIR}/linux_amd64/flakybot -repo={{metadata['repo']['repo']}}

--- a/synthtool/gcp/templates/java_library/.kokoro/nightly/integration.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/nightly/integration.cfg
@@ -22,7 +22,7 @@ env_vars: {
 }
 
 env_vars: {
-  key: "ENABLE_BUILD_COP"
+  key: "ENABLE_FLAKYBOT"
   value: "true"
 }
 

--- a/synthtool/gcp/templates/java_library/.kokoro/nightly/samples.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/nightly/samples.cfg
@@ -33,6 +33,6 @@ env_vars: {
 }
 
 env_vars: {
-  key: "ENABLE_BUILD_COP"
+  key: "ENABLE_FLAKYBOT"
   value: "true"
 }


### PR DESCRIPTION
Kokoro job config now supports both environment variables during this migration period.