### PR TITLE
chore(python): avoid `.nox` directories when building docs

### DIFF
--- a/synthtool/gcp/templates/python_library/docs/conf.py.j2
+++ b/synthtool/gcp/templates/python_library/docs/conf.py.j2
@@ -110,6 +110,7 @@ language = None
 # directories to ignore when looking for source files.
 exclude_patterns = [
     "_build",
+    "**/.nox/**/*",
     "samples/AUTHORING_GUIDE.md",
     "samples/CONTRIBUTING.md",
     "samples/snippets/README.rst",


### PR DESCRIPTION
Fixes #1179 