### PR TITLE
chore: replace feat/fix with chore in post-processor-changes.txt for python

### DIFF
--- a/docker/owlbot/python/cloudbuild.yaml
+++ b/docker/owlbot/python/cloudbuild.yaml
@@ -4,7 +4,15 @@ steps:
     entrypoint: '/bin/sh'
     args:
       - '-c'
-      - 'git log -1 --format="%s%n%nSource-Link: https://github.com/googleapis/synthtool/commit/%H" | sed -e "s/([^()]*)$//g" > post-processor-changes.txt'
+      # Get the last commit in synthtool and write it to post-processor-changes.txt.
+      # If the commit message ends with parenthesis, remove them.
+      # If the commit message starts with feat or fix, replace it with chore.
+      # If the commit message includes ! followed by a colon to signal a breaking change, remove the !.
+      - >
+          git log -1 --format="%s%n%nSource-Link: https://github.com/googleapis/synthtool/commit/%H" > post-processor-changes.txt &&
+          sed -i "s/([^()]*)$//g" post-processor-changes.txt &&
+          sed -i "s/^\(feat\|fix\)/chore/g" post-processor-changes.txt &&
+          sed -i "s/\!:/:/g" post-processor-changes.txt
   - name: 'gcr.io/cloud-builders/docker'
     args: [ 'build',
       '-t', 'gcr.io/$PROJECT_ID/owlbot-python:$SHORT_SHA',


### PR DESCRIPTION
This PR modifies the commit message stored in post-processor-changes.txt. The prefix feat/fix is changed to chore.

I tested this change locally using the following commands:

```
# Use gcloud builds submit to publish an image using the cloudbuild.yaml with changes from this PR
gcloud builds submit --config=docker/owlbot/python/cloudbuild.yaml --substitutions=SHORT_SHA=$(git rev-parse --short HEAD) 
```

```
# Pull the image that I just published, replacing PROJECT_ID with my own project id
docker pull gcr.io/<PROJECT_ID>/owlbot-python
```

```
# Run the container and enter bash, replacing PROJECT_ID with my own project id
docker run --rm -it --entrypoint /bin/bash gcr.io/<PROJECT_ID>/owlbot-python:latest
```

```
# After the above step, you should have a prompt in the docker container. Inspect post-processor-changes.txt and make sure the prefix is chore
cat post-processor-changes.txt
```