### PR TITLE
chore(python): rename default branch to main

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/build.sh
@@ -41,7 +41,7 @@ python3 -m pip install --upgrade --quiet nox
 python3 -m nox --version
 
 # If this is a continuous build, send the test log to the FlakyBot.
-# See https://github.com/googleapis/repo-automation-bots/tree/master/packages/flakybot.
+# See https://github.com/googleapis/repo-automation-bots/tree/main/packages/flakybot.
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
   cleanup() {
     chmod +x $KOKORO_GFILE_DIR/linux_amd64/flakybot

--- a/synthtool/gcp/templates/python_library/.kokoro/test-samples-impl.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/test-samples-impl.sh
@@ -80,7 +80,7 @@ for file in samples/**/requirements.txt; do
     EXIT=$?
 
     # If this is a periodic build, send the test log to the FlakyBot.
-    # See https://github.com/googleapis/repo-automation-bots/tree/master/packages/flakybot.
+    # See https://github.com/googleapis/repo-automation-bots/tree/main/packages/flakybot.
     if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"periodic"* ]]; then
       chmod +x $KOKORO_GFILE_DIR/linux_amd64/flakybot
       $KOKORO_GFILE_DIR/linux_amd64/flakybot

--- a/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
+++ b/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
@@ -118,9 +118,9 @@ Coding Style
    export GOOGLE_CLOUD_TESTING_BRANCH="main"
 
   By doing this, you are specifying the location of the most up-to-date
-  version of ``{{ metadata['repo']['repo'].split('/')[1] }}``. Then the
-  suggested remote name ``upstream`` should point to the official ``googleapis``
-  checkout and the the branch should be the default branch on that remote (``main``).
+  version of ``{{ metadata['repo']['repo'].split('/')[1] }}``. The
+  remote name ``upstream`` should point to the official ``googleapis``
+  checkout and the branch should be the default branch on that remote (``main``).
 
 - This repository contains configuration for the
   `pre-commit <https://pre-commit.com/>`__ tool, which automates checking

--- a/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
+++ b/synthtool/gcp/templates/python_library/CONTRIBUTING.rst
@@ -55,9 +55,9 @@ You'll have to create a development environment using a Git checkout:
    # Configure remotes such that you can pull changes from the {{ metadata['repo']['repo'] }}
    # repository into your local repository.
    $ git remote add upstream git@github.com:{{ metadata['repo']['repo'] }}.git
-   # fetch and merge changes from upstream into master
+   # fetch and merge changes from upstream into main
    $ git fetch upstream
-   $ git merge upstream/master
+   $ git merge upstream/main
 
 Now your local repo is set up such that you will push changes to your GitHub
 repo, from which you can submit a pull request.
@@ -115,12 +115,12 @@ Coding Style
   variables::
 
    export GOOGLE_CLOUD_TESTING_REMOTE="upstream"
-   export GOOGLE_CLOUD_TESTING_BRANCH="master"
+   export GOOGLE_CLOUD_TESTING_BRANCH="main"
 
   By doing this, you are specifying the location of the most up-to-date
-  version of ``{{ metadata['repo']['repo'].split('/')[1] }}``. The the suggested remote name ``upstream``
-  should point to the official ``googleapis`` checkout and the
-  the branch should be the main branch on that remote (``master``).
+  version of ``{{ metadata['repo']['repo'].split('/')[1] }}``. Then the
+  suggested remote name ``upstream`` should point to the official ``googleapis``
+  checkout and the the branch should be the default branch on that remote (``main``).
 
 - This repository contains configuration for the
   `pre-commit <https://pre-commit.com/>`__ tool, which automates checking
@@ -219,7 +219,7 @@ The `description on PyPI`_ for the project comes directly from the
 ``README``. Due to the reStructuredText (``rst``) parser used by
 PyPI, relative links which will work on GitHub (e.g. ``CONTRIBUTING.rst``
 instead of
-``https://github.com/{{ metadata['repo']['repo']}}/blob/master/CONTRIBUTING.rst``)
+``https://github.com/{{ metadata['repo']['repo']}}/blob/main/CONTRIBUTING.rst``)
 may cause problems creating links or rendering the description.
 
 .. _description on PyPI: https://pypi.org/project/{{ metadata['repo']['distribution_name']}}
@@ -240,7 +240,7 @@ We support:
 
 Supported versions can be found in our ``noxfile.py`` `config`_.
 
-.. _config: https://github.com/{{ metadata['repo']['repo'] }}/blob/master/noxfile.py
+.. _config: https://github.com/{{ metadata['repo']['repo'] }}/blob/main/noxfile.py
 
 
 We also explicitly decided to support Python 3 beginning with version {{ unit_test_python_versions | first }}.

--- a/synthtool/gcp/templates/python_library/docs/conf.py.j2
+++ b/synthtool/gcp/templates/python_library/docs/conf.py.j2
@@ -76,8 +76,8 @@ source_suffix = [".rst", ".md"]
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = "index"
+# The root toctree document.
+root_doc = "index"
 
 # General information about the project.
 project = "{{ metadata['repo']['distribution_name'] }}"
@@ -280,7 +280,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (
-        master_doc,
+        root_doc,
         "{{ metadata['repo']['distribution_name'] }}.tex",
         "{{ metadata['repo']['distribution_name'] }} Documentation",
         author,
@@ -315,7 +315,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     (
-        master_doc,
+        root_doc,
         "{{ metadata['repo']['distribution_name'] }}",
         "{{ metadata['repo']['distribution_name'] }} Documentation",
         [author],
@@ -334,7 +334,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (
-        master_doc,
+        root_doc,
         "{{ metadata['repo']['distribution_name'] }}",
         "{{ metadata['repo']['distribution_name'] }} Documentation",
         author,


### PR DESCRIPTION
All googleapis python repos (with exception of tooling) have migrated to use a default branch of main. See tracking issue [here](https://github.com/googleapis/google-cloud-python/issues/10579).