### PR TITLE
ci: removing linkage-monitor from the required checks

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/sync-repo-settings.yaml
+++ b/synthtool/gcp/templates/java_library/.github/sync-repo-settings.yaml
@@ -31,7 +31,6 @@ branchProtectionRules:
   requiredStatusCheckContexts:
   - "dependencies (8)"
   - "dependencies (11)"
-  - "linkage-monitor"
   - "lint"
   - "clirr"
   - "units (8)"


### PR DESCRIPTION
Linkage Monitor has served to identify the dependency conflicts
between the source tree in a pull request and the latest Libraries
BOM. However the Libraries BOM now implements the process to sync
with the dependencies of the Google Cloud BOM and the Google Cloud
BOM achieves dependency convergence with regard to the shared
dependencies BOM. Therefore, Linkage Monitor does not give much
benefit to our library development process any more.
https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/2137
