### PR TITLE
ci: removing linkage-monitor from the required checks

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/sync-repo-settings.yaml
+++ b/synthtool/gcp/templates/java_library/.github/sync-repo-settings.yaml
@@ -31,7 +31,6 @@ branchProtectionRules:
   requiredStatusCheckContexts:
   - "dependencies (8)"
   - "dependencies (11)"
-  - "linkage-monitor"
   - "lint"
   - "clirr"
   - "units (8)"

--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -42,19 +42,6 @@ jobs:
         java-version: ${{'{{matrix.java}}'}}
     - run: java -version
     - run: .kokoro/dependencies.sh
-  linkage-monitor:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - run: java -version
-    - name: Install artifacts to local Maven repository
-      run: .kokoro/build.sh
-      shell: bash
-    - name: Validate any conflicts with regard to com.google.cloud:libraries-bom (latest release)
-      uses: GoogleCloudPlatform/cloud-opensource-java/linkage-monitor@v1-linkagemonitor
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Linkage Monitor has served to identify the dependency conflicts
between the source tree in a pull request and the latest Libraries
BOM. However the Libraries BOM now implements the process to sync
with the dependencies of the Google Cloud BOM and the Google Cloud
BOM achieves dependency convergence with regard to the shared
dependencies BOM. Therefore, Linkage Monitor does not give much
benefit to our library development process any more.
GoogleCloudPlatform/cloud-opensource-java#2137