### PR TITLE
chore: fix log.py from failing lint-3.6 check

### DIFF
--- a/synthtool/log.py
+++ b/synthtool/log.py
@@ -18,7 +18,7 @@ import sys
 try:
     from colorlog import ColoredFormatter
 except ImportError:
-    ColoredFormatter = None
+    ColoredFormatter
 
 SUCCESS = 25
 
@@ -68,7 +68,7 @@ def configure_logger(name: str, color: bool = bool(ColoredFormatter)):
             },
         )
     else:
-        formatter = logging.Formatter(
+        formatter = logging.Formatter(  # type: ignore
             "%(asctime)s %(name)s [%(levelname)s] > %(message)s"
         )
 


### PR DESCRIPTION
lint-3.6 check was failing in master branch of synthtool with the following error.
```
synthtool/log.py:21: error: Cannot assign to a type
synthtool/log.py:21: error: Incompatible types in assignment (expression has type "None", variable has type "Type[ColoredFormatter]")
synthtool/log.py:71: error: Incompatible types in assignment (expression has type "Formatter", variable has type "ColoredFormatter")
Found 3 errors in 1 file (checked 47 source files)
nox > Command mypy synthtool autosynth failed with exit code 1
nox > Session lint-3.6 failed.
```