### PR TITLE
chore: disable renovate dependency dashboard

### DIFF
--- a/synthtool/gcp/templates/node_library/renovate.json
+++ b/synthtool/gcp/templates/node_library/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-    "docker:disable"
+    "docker:disable",
+    ":disableDependencyDashboard"
   ],
   "pinVersions": false,
   "rebaseStalePrs": true,


### PR DESCRIPTION
`config:base` started enabling the dependency dashboard by default. We were not using it before, so this turns it off.

See https://docs.renovatebot.com/configuration-options/#dependencydashboard