### PR TITLE
chore(python): disable dependency dashboard

### DIFF
--- a/synthtool/gcp/templates/python_library/renovate.json
+++ b/synthtool/gcp/templates/python_library/renovate.json
@@ -1,6 +1,8 @@
 {
   "extends": [
-    "config:base",  ":preserveSemverRanges"
+    "config:base",
+    ":preserveSemverRanges",
+    ":disableDependencyDashboard"
   ],
   "ignorePaths": [".pre-commit-config.yaml"],
   "pip_requirements": {


### PR DESCRIPTION
Similar to https://github.com/googleapis/synthtool/pull/1194, let's disable the dependency dashboard which was [recently enabled by default](https://docs.renovatebot.com/configuration-options/#dependencydashboard) in Renovate v26.0.0.