### PR TITLE
chore(python): rename master_doc to root_doc

### DIFF
--- a/synthtool/gcp/templates/python_library/docs/conf.py.j2
+++ b/synthtool/gcp/templates/python_library/docs/conf.py.j2
@@ -76,8 +76,8 @@ source_suffix = [".rst", ".md"]
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = "index"
+# The root toctree document.
+root_doc = "index"
 
 # General information about the project.
 project = "{{ metadata['repo']['distribution_name'] }}"
@@ -280,7 +280,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (
-        master_doc,
+        root_doc,
         "{{ metadata['repo']['distribution_name'] }}.tex",
         "{{ metadata['repo']['distribution_name'] }} Documentation",
         author,
@@ -315,7 +315,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     (
-        master_doc,
+        root_doc,
         "{{ metadata['repo']['distribution_name'] }}",
         "{{ metadata['repo']['distribution_name'] }} Documentation",
         [author],
@@ -334,7 +334,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (
-        master_doc,
+        root_doc,
         "{{ metadata['repo']['distribution_name'] }}",
         "{{ metadata['repo']['distribution_name'] }} Documentation",
         author,


### PR DESCRIPTION
Rename `master_doc` to `root_doc` in python templates. See sphinx docs:
https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-root_doc