### PR TITLE
chore(python): group renovate prs

### DIFF
--- a/synthtool/gcp/templates/python_library/renovate.json
+++ b/synthtool/gcp/templates/python_library/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
+    "group:all",
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],


### PR DESCRIPTION
Grouping renovate prs will help maintainers, especially on repos that require branches be up to date before merging. 

python-bigquery is already using the [groupall](https://docs.renovatebot.com/presets-group/#groupall) configuration. For example, see https://github.com/googleapis/python-bigquery/pull/928 .

cc @tswast 