### PR TITLE
chore(java): install maven 3.8.1 at runtime

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
-        java-version: ${{matrix.java}}
+        java-version: ${{'{{matrix.java}}'}}
     - run: java -version
     - run: .kokoro/build.sh
       env:
@@ -45,7 +45,7 @@ jobs:
         maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
-        java-version: ${{matrix.java}}
+        java-version: ${{'{{matrix.java}}'}}
     - run: java -version
     - run: .kokoro/dependencies.sh
   lint:

--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
 name: ci
 jobs:
   units:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     strategy:
       matrix:
         java: [8, 11]
@@ -31,7 +31,7 @@ jobs:
       env:
         JOB_TYPE: test
   dependencies:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     strategy:
       matrix:
         java: [8, 11]
@@ -43,7 +43,7 @@ jobs:
     - run: java -version
     - run: .kokoro/dependencies.sh
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
@@ -54,7 +54,7 @@ jobs:
       env:
         JOB_TYPE: lint
   clirr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1

--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -6,15 +6,18 @@ on:
 name: ci
 jobs:
   units:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         java: [8, 11]
     steps:
     - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
-        java-version: ${{'{{matrix.java}}'}}
+        java-version: ${{matrix.java}}
     - run: java -version
     - run: .kokoro/build.sh
       env:
@@ -31,21 +34,27 @@ jobs:
       env:
         JOB_TYPE: test
   dependencies:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         java: [8, 11]
     steps:
     - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
-        java-version: ${{'{{matrix.java}}'}}
+        java-version: ${{matrix.java}}
     - run: java -version
     - run: .kokoro/dependencies.sh
   lint:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
         java-version: 8
@@ -54,9 +63,12 @@ jobs:
       env:
         JOB_TYPE: lint
   clirr:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
         java-version: 8


### PR DESCRIPTION
Gitbub Action updated LTS([18.04](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md), [20.04](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md)) versions of Github-Hosted runners for Ubuntu with the latest version of Apache Maven. The new version of Ubuntu has `Apache Maven 3.8.2` which is incompatible with `flatten-maven-plugin:1.2.7`. This caused all github actions using the latest Ubuntu version to fail.
```
Error:  Failed to execute goal org.codehaus.mojo:flatten-maven-plugin:1.2.7:flatten (flatten) on project google-cloud-bigquery: failed to create a clean pom: unable to create flattened dependencies: caught exception when flattening dependencies: Failed to read artifact descriptor for com.fasterxml.jackson.core:jackson-core::2.12.5: Could not find artifact com.fasterxml.jackson:jackson-base:pom:2.12.5 -> [Help 1]
```

The immediate solution is to use [this](https://github.com/marketplace/actions/setup-maven) community action to install maven 3.8.1 at runtime.