### PR TITLE
chore(java): update windows build

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -26,6 +26,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
         java-version: 8


### PR DESCRIPTION
to install maven 3.8.1 at runtime too (related to #1202)

Tested in [java-bigquerystorage](https://github.com/googleapis/java-bigquerystorage/pull/1291/commits/7834f4ff86858f6ed0b8068ea66dadf6365e399a)