### PR TITLE
build: enable release-trigger bot

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/release-trigger.yml
+++ b/synthtool/gcp/templates/node_library/.github/release-trigger.yml
@@ -1,0 +1,1 @@
+enabled: true


### PR DESCRIPTION
This will speed up the triggering of kokoro release jobs, make them retryable, and reduce permissions errors.