### PR TITLE
feat: introduce GraalVM testing build script changes

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.sh
@@ -69,6 +69,25 @@ integration)
       verify
     RETURN_CODE=$?
     ;;
+graalvm)
+    # Install GraalVM
+    graalvmDir=${KOKORO_ARTIFACTS_DIR}/graalvm
+    mkdir ${graalvmDir}
+    retry_with_backoff 3 10 \
+      curl --fail --show-error --silent --location \
+      https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.2.0/graalvm-ce-java11-linux-amd64-21.2.0.tar.gz \
+      | tar xz --directory ${graalvmDir} --strip-components=1
+
+    # Set GraalVM as the Java installation
+    export JAVA_HOME=${graalvmDir}
+    export PATH="$JAVA_HOME/bin:$PATH"
+
+    # Install Native Image
+    gu install native-image
+
+    # Run Unit and Integration Tests
+    mvn test -Pnative -Penable-integration-tests
+    ;;
 samples)
     SAMPLES_DIR=samples
     # only run ITs in snapshot/ on presubmit PRs. run ITs in all 3 samples/ subdirectories otherwise.

--- a/synthtool/gcp/templates/java_library/.kokoro/presubmit/graalvm-native.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/presubmit/graalvm-native.cfg
@@ -1,0 +1,33 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "graalvm"
+}
+
+# TODO: remove this after we've migrated all tests and scripts
+env_vars: {
+  key: "GCLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT"
+  value: "gcloud-devel"
+}
+
+env_vars: {
+  key: "GOOGLE_APPLICATION_CREDENTIALS"
+  value: "secret_manager/java-it-service-account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-it-service-account"
+}


### PR DESCRIPTION
This PR introduces the build script changes needed to introduce GraalVM testing to client library repositories. It is a follow-up to https://github.com/googleapis/java-shared-config/pull/314

As discussed in https://github.com/googleapis/java-shared-config/pull/314, the intention is to produce changes that are no-op's and gradually opt-in projects into GraalVM testing.

Summary of changes:

* **build.sh** - Add an additional switch case `graalvm` which contains the sequence of commands to install GraalVM and run unit and integration tests compiled with GraalVM native image. The switch case statement is only activated if the `JOB_TYPE` env variable is set to `graalvm` in the Kokoro `.cfg` file. Should not affect existing code which does not set `JOB_TYPE=graalvm`. 

* **graalvm-native.cfg** - Introduces the GraalVM `.cfg` that defines the Kokoro presubmit job.

In order to opt-in a project into GraalVM testing, we just need to add the corresponding `graalvm-native.cfg` in google3 for each repository to start running the new presubmit job for the specified repository.

Additional notes: @lesv suggested implementing a dedicated GraalVM container image for testing: https://github.com/googleapis/testing-infra-docker/issues/165

cc/ @lesv @Neenu1995 @suztomo 
