### PR TITLE
build: add jdk 17 to java units and dependency builds

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -9,14 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17]
     steps:
     - uses: actions/checkout@v2
     - uses: stCarolas/setup-maven@v4
       with:
         maven-version: 3.8.1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
+        distribution: zulu
         java-version: ${{'{{matrix.java}}'}}
     - run: java -version
     - run: .kokoro/build.sh
@@ -29,8 +30,9 @@ jobs:
     - uses: stCarolas/setup-maven@v4
       with:
         maven-version: 3.8.1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
+        distribution: zulu
         java-version: 8
     - run: java -version
     - run: .kokoro/build.bat
@@ -40,14 +42,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17]
     steps:
     - uses: actions/checkout@v2
     - uses: stCarolas/setup-maven@v4
       with:
         maven-version: 3.8.1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
+        distribution: zulu
         java-version: ${{'{{matrix.java}}'}}
     - run: java -version
     - run: .kokoro/dependencies.sh
@@ -58,8 +61,9 @@ jobs:
     - uses: stCarolas/setup-maven@v4
       with:
         maven-version: 3.8.1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
+        distribution: zulu
         java-version: 8
     - run: java -version
     - run: .kokoro/build.sh
@@ -72,8 +76,9 @@ jobs:
     - uses: stCarolas/setup-maven@v4
       with:
         maven-version: 3.8.1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
+        distribution: zulu
         java-version: 8
     - run: java -version
     - run: .kokoro/build.sh

--- a/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/dependencies.sh
@@ -28,7 +28,28 @@ source ${scriptDir}/common.sh
 java -version
 echo $JOB_TYPE
 
-export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=128m"
+function determineMavenOpts() {
+  local javaVersion=$(
+    # filter down to the version line, then pull out the version between quotes,
+    # then trim the version number down to its minimal number (removing any
+    # update or suffix number).
+    java -version 2>&1 | grep "version" \
+      | sed -E 's/^.*"(.*?)".*$/\1/g' \
+      | sed -E 's/^(1\.[0-9]\.0).*$/\1/g'
+  )
+
+  case $javaVersion in
+    "17")
+      # MaxPermSize is no longer supported as of jdk 17
+      echo -n "-Xmx1024m"
+      ;;
+    *)
+      echo -n "-Xmx1024m -XX:MaxPermSize=128m"
+      ;;
+  esac
+}
+
+export MAVEN_OPTS=$(determineMavenOpts)
 
 # this should run maven enforcer
 retry_with_backoff 3 10 \


### PR DESCRIPTION
* update dependencies.sh to not pass MaxPermSize when jdk 17 is used. MaxPermSize is an unrecognized flag in jdk 17.


A prototpe of these changes has been tested in https://github.com/googleapis/java-storage/pull/1016