### PR TITLE
chore: fail samples nox session if python version is missing

### DIFF
--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -98,6 +98,10 @@ INSTALL_LIBRARY_FROM_SOURCE = os.environ.get("INSTALL_LIBRARY_FROM_SOURCE", Fals
     "True",
     "true",
 )
+
+# Error if a python version is missing
+nox.options.error_on_missing_interpreters = True
+
 #
 # Style Checks
 #


### PR DESCRIPTION
Same as https://github.com/GoogleCloudPlatform/python-docs-samples/pull/6764