### PR TITLE
build(nodejs): switch to linkinator for scanning links

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
@@ -50,8 +50,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - run: npm install
-      - run: npm run docs-test
+      - uses: JustinBeckwith/linkinator-action@v1


### PR DESCRIPTION
Switch to GitHub Action for scanning links, this has the benefit that it properly scans new links added in PR.

See in action here: https://github.com/googleapis/nodejs-storage/pull/1593