### PR TITLE
build(node): run linkinator against index.html

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
@@ -50,4 +50,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: npm install
+      - run: npm run docs
       - uses: JustinBeckwith/linkinator-action@v1
+        with:
+          paths: docs/


### PR DESCRIPTION
Run linkinator against generated `docs/` folder.

Tested here: https://github.com/googleapis/nodejs-storage/pull/1614