### PR TITLE
build: use trampoline_v2 for python samples and allow custom dockerfile

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -236,6 +236,10 @@ class CommonTemplates:
         # Don't add samples templates if there are no samples
         if "samples" not in kwargs:
             self.excludes += ["samples/AUTHORING_GUIDE.md", "samples/CONTRIBUTING.md"]
+        
+        # Assume the python-docs-samples Dockerfile is used for samples by default
+        if "custom_samples_dockerfile" not in kwargs:
+            kwargs["custom_samples_dockerfile"] = False
 
         ret = self._generic_library("python_library", **kwargs)
 

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -236,7 +236,7 @@ class CommonTemplates:
         # Don't add samples templates if there are no samples
         if "samples" not in kwargs:
             self.excludes += ["samples/AUTHORING_GUIDE.md", "samples/CONTRIBUTING.md"]
-        
+
         # Assume the python-docs-samples Dockerfile is used for samples by default
         if "custom_samples_dockerfile" not in kwargs:
             kwargs["custom_samples_dockerfile"] = False

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/lint/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/lint/common.cfg
@@ -20,7 +20,7 @@ env_vars: {
 {% if custom_samples_dockerfile %}
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-docker"
+    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-samples-docker"
 }
 
 # Configure the docker image for kokoro-trampoline.

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/lint/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/lint/common.cfg
@@ -17,13 +17,24 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"
 }
+{% if custom_samples_dockerfile %}
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-docker"
+}
 
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_DOCKERFILE"
+    value: ".kokoro/docker/samples/Dockerfile"
+}
+{% else %}
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
     value: "gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
 }
-
+{% endif %}
 # Download secrets for samples
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
 
@@ -31,4 +42,4 @@ gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/trampoline.sh"
+build_file: "{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/trampoline_v2.sh"

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/common.cfg
@@ -26,7 +26,7 @@ env_vars: {
 {% if custom_samples_dockerfile %}
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-docker"
+    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-samples-docker"
 }
 
 # Configure the docker image for kokoro-trampoline.

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/common.cfg
@@ -23,7 +23,6 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"
 }
-
 {% if custom_samples_dockerfile %}
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
@@ -35,22 +34,13 @@ env_vars: {
     key: "TRAMPOLINE_DOCKERFILE"
     value: ".kokoro/docker/samples/Dockerfile"
 }
-
-# Upload the docker image after successful builds.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE_UPLOAD"
-    value: "true"
-}
-
 {% else %}
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
     value: "gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
 }
-
 {% endif %}
-
 # Download secrets for samples
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
 

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/common.cfg
@@ -24,11 +24,32 @@ env_vars: {
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"
 }
 
+{% if custom_samples_dockerfile %}
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-docker"
+}
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_DOCKERFILE"
+    value: ".kokoro/docker/samples/Dockerfile"
+}
+
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+
+{% else %}
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
     value: "gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
 }
+
+{% endif %}
 
 # Download secrets for samples
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
@@ -37,4 +58,4 @@ gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/trampoline.sh"
+build_file: "{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/trampoline_v2.sh"

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/periodic-head.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/periodic-head.cfg
@@ -9,3 +9,10 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples-against-head.sh"
 }
+{% if custom_samples_dockerfile %}
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+{% endif %}

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/periodic.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.6/periodic.cfg
@@ -4,3 +4,10 @@ env_vars: {
     key: "INSTALL_LIBRARY_FROM_SOURCE"
     value: "False"
 }
+{% if custom_samples_dockerfile %}
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+{% endif %}

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.7/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.7/common.cfg
@@ -26,7 +26,7 @@ env_vars: {
 {% if custom_samples_dockerfile %}
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-docker"
+    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-samples-docker"
 }
 
 # Configure the docker image for kokoro-trampoline.

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.7/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.7/common.cfg
@@ -23,7 +23,6 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"
 }
-
 {% if custom_samples_dockerfile %}
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
@@ -35,22 +34,13 @@ env_vars: {
     key: "TRAMPOLINE_DOCKERFILE"
     value: ".kokoro/docker/samples/Dockerfile"
 }
-
-# Upload the docker image after successful builds.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE_UPLOAD"
-    value: "true"
-}
-
 {% else %}
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
     value: "gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
 }
-
 {% endif %}
-
 # Download secrets for samples
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
 

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.7/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.7/common.cfg
@@ -24,11 +24,32 @@ env_vars: {
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"
 }
 
+{% if custom_samples_dockerfile %}
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-docker"
+}
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_DOCKERFILE"
+    value: ".kokoro/docker/samples/Dockerfile"
+}
+
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+
+{% else %}
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
     value: "gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
 }
+
+{% endif %}
 
 # Download secrets for samples
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
@@ -37,4 +58,4 @@ gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/trampoline.sh"
+build_file: "{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/trampoline_v2.sh"

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.7/periodic.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.7/periodic.cfg
@@ -4,3 +4,10 @@ env_vars: {
     key: "INSTALL_LIBRARY_FROM_SOURCE"
     value: "False"
 }
+{% if custom_samples_dockerfile %}
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+{% endif %}

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/common.cfg
@@ -24,11 +24,30 @@ env_vars: {
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"
 }
 
+{% if custom_samples_dockerfile %}
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-docker"
+}
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_DOCKERFILE"
+    value: ".kokoro/docker/samples/Dockerfile"
+}
+
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+{% else %}
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
     value: "gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
 }
+{% endif %}
 
 # Download secrets for samples
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
@@ -37,4 +56,4 @@ gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/trampoline.sh"
+build_file: "{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/trampoline_v2.sh"

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/common.cfg
@@ -26,7 +26,7 @@ env_vars: {
 {% if custom_samples_dockerfile %}
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-docker"
+    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-samples-docker"
 }
 
 # Configure the docker image for kokoro-trampoline.

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/common.cfg
@@ -23,7 +23,6 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"
 }
-
 {% if custom_samples_dockerfile %}
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
@@ -35,12 +34,6 @@ env_vars: {
     key: "TRAMPOLINE_DOCKERFILE"
     value: ".kokoro/docker/samples/Dockerfile"
 }
-
-# Upload the docker image after successful builds.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE_UPLOAD"
-    value: "true"
-}
 {% else %}
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -48,7 +41,6 @@ env_vars: {
     value: "gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
 }
 {% endif %}
-
 # Download secrets for samples
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
 

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/periodic-head.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/periodic-head.cfg
@@ -9,3 +9,10 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples-against-head.sh"
 }
+{% if custom_samples_dockerfile %}
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+{% endif %}

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/periodic.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.8/periodic.cfg
@@ -4,3 +4,10 @@ env_vars: {
     key: "INSTALL_LIBRARY_FROM_SOURCE"
     value: "False"
 }
+{% if custom_samples_dockerfile %}
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+{% endif %}

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.9/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.9/common.cfg
@@ -26,7 +26,7 @@ env_vars: {
 {% if custom_samples_dockerfile %}
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-docker"
+    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-samples-docker"
 }
 
 # Configure the docker image for kokoro-trampoline.

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.9/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.9/common.cfg
@@ -23,7 +23,6 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"
 }
-
 {% if custom_samples_dockerfile %}
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
@@ -35,22 +34,13 @@ env_vars: {
     key: "TRAMPOLINE_DOCKERFILE"
     value: ".kokoro/docker/samples/Dockerfile"
 }
-
-# Upload the docker image after successful builds.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE_UPLOAD"
-    value: "true"
-}
-
 {% else %}
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
     value: "gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
 }
-
 {% endif %}
-
 # Download secrets for samples
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
 

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.9/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.9/common.cfg
@@ -24,11 +24,32 @@ env_vars: {
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"
 }
 
+{% if custom_samples_dockerfile %}
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-docker"
+}
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_DOCKERFILE"
+    value: ".kokoro/docker/samples/Dockerfile"
+}
+
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+
+{% else %}
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
     value: "gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
 }
+
+{% endif %}
 
 # Download secrets for samples
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
@@ -37,4 +58,4 @@ gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/trampoline.sh"
+build_file: "{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/trampoline_v2.sh"

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.9/periodic-head.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.9/periodic-head.cfg
@@ -9,3 +9,10 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples-against-head.sh"
 }
+{% if custom_samples_dockerfile %}
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+{% endif %}

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.9/periodic.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.9/periodic.cfg
@@ -4,3 +4,10 @@ env_vars: {
     key: "INSTALL_LIBRARY_FROM_SOURCE"
     value: "False"
 }
+{% if custom_samples_dockerfile %}
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+{% endif %}

--- a/synthtool/gcp/templates/python_library/.kokoro/test-samples-against-head.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/test-samples-against-head.sh
@@ -23,6 +23,4 @@ set -eo pipefail
 # Enables `**` to include files nested inside sub-folders
 shopt -s globstar
 
-cd github/{{ metadata['repo']['repo'].split('/')[1] }}
-
 exec .kokoro/test-samples-impl.sh

--- a/synthtool/gcp/templates/python_library/.kokoro/test-samples.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/test-samples.sh
@@ -24,8 +24,6 @@ set -eo pipefail
 # Enables `**` to include files nested inside sub-folders
 shopt -s globstar
 
-cd github/{{ metadata['repo']['repo'].split('/')[1] }}
-
 # Run periodic samples tests at latest release
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"periodic"* ]]; then
     # preserving the test runner implementation.

--- a/synthtool/gcp/templates/python_library/.trampolinerc
+++ b/synthtool/gcp/templates/python_library/.trampolinerc
@@ -16,15 +16,26 @@
 
 # Add required env vars here.
 required_envvars+=(
-    "STAGING_BUCKET"
-    "V2_STAGING_BUCKET"
 )
 
 # Add env vars which are passed down into the container here.
 pass_down_envvars+=(
+    "NOX_SESSION"
+    ###############
+    # Docs builds
+    ###############
     "STAGING_BUCKET"
     "V2_STAGING_BUCKET"
-    "NOX_SESSION"
+    ##################
+    # Samples builds
+    ##################
+    "INSTALL_LIBRARY_FROM_SOURCE"
+    "RUN_TESTS_SESSION"
+    "BUILD_SPECIFIC_GCLOUD_PROJECT"
+    # Target directories.
+    "RUN_TESTS_DIRS"
+    # The nox session to run.
+    "RUN_TESTS_SESSION"
 )
 
 # Prevent unintentional override on the default image.


### PR DESCRIPTION
* Use trampoline_v2 ([Docker CI Helper](https://github.com/GoogleCloudPlatform/docker-ci-helper)) for all python samples.
* Optionally allow samples to run with a Dockerfile specified in the library repository at `.kokoro/docker/samples`. On a successful test run, this Dockerfile is uploaded to `gcr.io/cloud-devrel-kokoro-resources/{repo-name}-samples-docker`. The option is enabled by passing `custom_samples_dockerfile=True` to `common.py_library` in `owlbot.py`.

    ```py
     templated_files = common.py_library(microgenerator=True, custom_samples_dockerfile=True)
    ```

See https://github.com/googleapis/python-asset/pull/308 for an example of moving samples to to trampoline_v2.

See https://github.com/googleapis/python-recaptcha-enterprise/pull/128 for an example of moving to trampoline_v2 + using a custom Dockerfile.
