### PR TITLE
chore: use cov_level in `.coveragerc`

### DIFF
--- a/synthtool/gcp/templates/python_library/.coveragerc
+++ b/synthtool/gcp/templates/python_library/.coveragerc
@@ -21,7 +21,7 @@ omit =
   google/cloud/__init__.py
 
 [report]
-fail_under = 100
+fail_under = {{ cov_level if cov_level != None else '100' }}
 show_missing = True
 exclude_lines =
     # Re-enable the standard pragma


### PR DESCRIPTION
Fixes #1228