### PR TITLE
chore(python): fix formatting issue in noxfile.py.j2

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -88,7 +88,9 @@ def default(session):
         CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
     )
     session.install("mock", "asyncmock", "pytest", "pytest-cov", "pytest-asyncio", "-c", constraints_path)
-    {% for d in unit_test_external_dependencies %}session.install("{{d}}", "-c", constraints_path){% endfor %}
+    {%- for d in unit_test_external_dependencies -%}
+    session.install("{{d}}", "-c", constraints_path)
+    {% endfor %}
     {% for dependency in unit_test_local_dependencies %}session.install("-e", "{{dependency}}", "-c", constraints_path)
     {% endfor %}
     {% for dependency in unit_test_dependencies %}session.install("-e", "{{dependency}}", "-c", constraints_path){% endfor %}


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/googleapis/repo-automation-bots/issues/2669, where the owlbot post processor fails due to a syntax issue.

With the existing noxfile.py.j2, the following code is generated for googleapis/python-logging
```
session.install("flask", "-c", constraints_path)session.install("webob", "-c", constraints_path)session.install("django", "-c", constraints_path)
```

Using the changes in this PR, the syntax issue appears to be fixed. 

Steps to reproduce:
1) In the root of the googleapis/synthtool repo, run `docker build -t testpostprocessor -f docker/owlbot/python/Dockerfile .`
2) In the root of the googleapis/python-logging repo, run `docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo testpostprocessor`
3) The above step should produce the following error https://github.com/googleapis/repo-automation-bots/issues/2669

To confirm this fix, repeat the above steps with the fixes in this PR.

Fixes https://github.com/googleapis/repo-automation-bots/issues/2669