### PR TITLE
chore(python): fix formatting issue in noxfile.py.j2

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -88,7 +88,7 @@ def default(session):
         CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
     )
     session.install("mock", "asyncmock", "pytest", "pytest-cov", "pytest-asyncio", "-c", constraints_path)
-    {%- for d in unit_test_external_dependencies -%}
+    {% for d in unit_test_external_dependencies -%}
     session.install("{{d}}", "-c", constraints_path)
     {% endfor %}
     {% for dependency in unit_test_local_dependencies %}session.install("-e", "{{dependency}}", "-c", constraints_path)


### PR DESCRIPTION
PR #1237 fixed a formatting issue in noxfile.py.j2 however after running the latest post processor image, there is still a syntax issue.

Here are the steps that I ran to validate this fix.

Checkout the branch for this PR and run the following:
```
docker build -t testlogging -f docker/owlbot/python/Dockerfile .
```

In the python-logging repo, run 
```
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo testlogging
```