### PR TITLE
build(node): update deps used during post-processing

### DIFF
--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -48,9 +48,9 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@2.12.0 typescript@3.9.9 \
-    chalk@4.0.0 escodegen@2.0.0 espree@7.1.0 estraverse@5.1.0 glob@7.1.6 jsdoc@3.6.3 \
-    minimist@1.2.0 semver@7.1.2 tmp@0.2.1 uglify-js@3.7.7
+RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@2.27.1 typescript@3.9.9 \
+    chalk@4.1.2 escodegen@2.0.0 espree@7.3.1 estraverse@5.2.0 glob@7.2.0 jsdoc@3.6.7 \
+    minimist@1.2.5 semver@7.3.5 tmp@0.2.1 uglify-js@3.14.2
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]


### PR DESCRIPTION
In the name of repeatable builds, we lock down the dependencies used by Node.js in the post-processor.

gax had not been updated in some time, which lead to compilation issues.

Fixes https://github.com/googleapis/google-cloud-node-core/issues/581