### PR TITLE
chore(python): include docs/UPGRADING.md in docs/index.rst if it exists

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -252,6 +252,10 @@ class CommonTemplates:
         ):
             self.excludes += ["docs/index.rst"]
 
+        # Add kwargs to signal that upgrading.rst should be included in docs/index.rst if it exists
+        if (Path("docs/upgrading.rst").exists()):
+            kwargs["include_uprading_doc"] = True
+
         # Assume the python-docs-samples Dockerfile is used for samples by default
         if "custom_samples_dockerfile" not in kwargs:
             kwargs["custom_samples_dockerfile"] = False

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -253,7 +253,7 @@ class CommonTemplates:
             self.excludes += ["docs/index.rst"]
 
         # Add kwargs to signal that upgrading.rst should be included in docs/index.rst if it exists
-        if (Path("docs/upgrading.rst").exists()):
+        if Path("docs/upgrading.rst").exists():
             kwargs["include_uprading_doc"] = True
 
         # Assume the python-docs-samples Dockerfile is used for samples by default

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -252,8 +252,8 @@ class CommonTemplates:
         ):
             self.excludes += ["docs/index.rst"]
 
-        # Add kwargs to signal that upgrading.rst should be included in docs/index.rst if it exists
-        if Path("docs/upgrading.rst").exists():
+        # Add kwargs to signal that UPGRADING.md should be included in docs/index.rst if it exists
+        if Path("docs/UPGRADING.md").exists():
             kwargs["include_uprading_doc"] = True
 
         # Assume the python-docs-samples Dockerfile is used for samples by default

--- a/synthtool/gcp/templates/python_library/docs/index.rst
+++ b/synthtool/gcp/templates/python_library/docs/index.rst
@@ -21,9 +21,9 @@ Migration Guide
 See the guide below for instructions on migrating to the latest version.
 
 .. toctree::
-   :maxdepth: 2
+    :maxdepth: 2
 
-   UPGRADING
+    UPGRADING
 
 {% endif %}
 Changelog
@@ -32,6 +32,6 @@ Changelog
 For a list of all ``{{ metadata['repo']['distribution_name'] }}`` releases:
 
 .. toctree::
-   :maxdepth: 2
+    :maxdepth: 2
 
-   changelog
+    changelog

--- a/synthtool/gcp/templates/python_library/docs/index.rst
+++ b/synthtool/gcp/templates/python_library/docs/index.rst
@@ -15,7 +15,16 @@ API Reference
     {{ version }}/types
 {% endfor %}
 {% if include_uprading_doc %}
-.. include:: UPGRADING.md
+Migration Guide
+---------------
+
+See the guide below for instructions on migrating to the latest version.
+
+.. toctree::
+   :maxdepth: 2
+
+   UPGRADING
+
 {% endif %}
 Changelog
 ---------

--- a/synthtool/gcp/templates/python_library/docs/index.rst
+++ b/synthtool/gcp/templates/python_library/docs/index.rst
@@ -15,7 +15,7 @@ API Reference
     {{ version }}/types
 {% endfor %}
 {% if include_uprading_doc %}
-.. include:: upgrading.rst
+.. include:: UPGRADING.md
 {% endif %}
 Changelog
 ---------

--- a/synthtool/gcp/templates/python_library/docs/index.rst
+++ b/synthtool/gcp/templates/python_library/docs/index.rst
@@ -14,16 +14,8 @@ API Reference
     {{ version }}/services
     {{ version }}/types
 {% endfor %}
-{%- if migration_guide_version %}
-Migration Guide
----------------
-
-See the guide below for instructions on migrating to the {{ migration_guide_version }} release of this library.
-
-.. toctree::
-    :maxdepth: 2
-
-    UPGRADING
+{% if include_uprading_doc %}
+.. include:: upgrading.rst
 {% endif %}
 Changelog
 ---------


### PR DESCRIPTION
PR #1114 added `docs/index.rst` to python templates. In PR #1114, the migration section was included in the templates. Instead of including the migration section, I'd like to add a `kwargs` to signal whether a migration guide should be included in `docs/index.rst`. 

I've included the steps I used for testing after cloning synthtool.
```
git checkout include-upgrading-rst-in-index-rst
docker build -f docker/owlbot/python/Dockerfile -t testindexrst .
```

After cloning [python-access-approval](https://github.com/googleapis/python-access-approval/), I completed the following steps
1) Run `rm -rf owlbot.py` to delete owlbot.py to avoid having to customize owlbot.py to autogenerate docs/index.rst
2) Run `docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo testindexrst`
3) Confirm that `docs/index.rst` does not include `docs/upgrading.rst`
4) Run `touch docs/UPGRADING.md`
5) Run `docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo testindexrst`
6) Confirm that `docs/index.rst` includes `docs/upgrading.rst`
