### PR TITLE
chore(python): fix autogenerated docs/index.rst to support nested dir

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -375,7 +375,7 @@ def detect_versions(
             pass
 
     # Sort the sub directories alphabetically.
-    sub_dirs = sorted([p.name for p in Path(path).glob("*v[1-9]*")])
+    sub_dirs = sorted([p.name for p in Path(path).rglob("*v[1-9]*") if p.is_dir()])
 
     if sub_dirs:
         # if `default_version` is not specified, return the sorted directories.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -233,3 +233,19 @@ def test_detect_versions_with_default_version_from_metadata():
             json.dump(test_json, metadata)
         versions = detect_versions(default_first=True)
         assert ["api_v3", "api_v1", "api_v2"] == versions
+
+
+def test_detect_versions_nested_directory():
+    temp_dir = Path(tempfile.mkdtemp())
+    src_dir = temp_dir / "src" / "src2" / "src3"
+    vs = ("v1", "v2", "v3")
+    for v in vs:
+        os.makedirs(src_dir / v)
+
+    with util.chdir(temp_dir):
+        versions = detect_versions(default_version="v1")
+        assert ["v2", "v3", "v1"] == versions
+        versions = detect_versions(default_version="v2")
+        assert ["v1", "v3", "v2"] == versions
+        versions = detect_versions(default_version="v3")
+        assert ["v1", "v2", "v3"] == versions


### PR DESCRIPTION
PR #1114 added docs/index.rst to python templates. PR #1114 didn't generate docs/index.rst properly for [python-orchestration-airflow](https://github.com/googleapis/python-orchestration-airflow) because it only detects versions in the 1st level of the `/google/cloud/<API>` directory. As a result, no versions are detected. The versions for python-orchestration-airflow are 1 level deeper at `/google/cloud/orchestration/airflow`. I've also found and fixed a bug where I wasn't checking if the path is a directory.

I've included the steps I used for testing after cloning synthtool.
```
git checkout fix-auto-generated-docs-index-rst-to-work-with-nested 
docker build -f docker/owlbot/python/Dockerfile -t testindexrst .
```

After cloning [python-orchestration-airflow](https://github.com/googleapis/python-orchestration-airflow/), I completed the following steps
1) Run `rm -rf owlbot.py` to delete owlbot.py to avoid having to customize owlbot.py to autogenerate docs/index.rst
2) Run `docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo testindexrst`
3) Confirm that `docs/index.rst` looks correct and versions are missing