### PR TITLE
chore(python): fix erroneous versions detected in detect_versions()

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -384,11 +384,11 @@ def detect_versions(
         except FileNotFoundError:
             pass
 
-    # Detect versions in either the first, second or third level of hierarchy
-    for level in ("*v[1-9]*", "*/*v[1-9]*", "*/*/*v[1-9]*"):
+    # Detect versions up to a depth of 4 in directory hierarchy
+    for level in ("*v[1-9]*", "*/*v[1-9]*", "*/*/*v[1-9]*", "*/*/*/*v[1-9]*"):
         # Sort the sub directories alphabetically.
         sub_dirs = sorted([p.name for p in Path(path).glob(level) if p.is_dir()])
-        # Don't proceed to the next level if we've detected sub directories in this level
+        # Don't proceed to the next level if we've detected versions in this depth level
         if sub_dirs:
             break
 

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -384,8 +384,13 @@ def detect_versions(
         except FileNotFoundError:
             pass
 
-    # Sort the sub directories alphabetically.
-    sub_dirs = sorted([p.name for p in Path(path).rglob("*v[1-9]*") if p.is_dir()])
+    # Detect versions in either the first, second or third level of hierarchy
+    for level in ("*v[1-9]*", "*/*v[1-9]*", "*/*/*v[1-9]*"):
+        # Sort the sub directories alphabetically.
+        sub_dirs = sorted([p.name for p in Path(path).glob(level) if p.is_dir()])
+        # Don't proceed to the next level if we've detected sub directories in this level
+        if sub_dirs:
+            break
 
     if sub_dirs:
         # if `default_version` is not specified, return the sorted directories.

--- a/synthtool/languages/python.py
+++ b/synthtool/languages/python.py
@@ -184,7 +184,7 @@ def owlbot_main() -> None:
 
         templated_files = CommonTemplates().py_library(
             microgenerator=True,
-            versions=detect_versions(path="./google/cloud", default_first=True),
+            versions=detect_versions(path="./google", default_first=True),
         )
         s.move(
             [templated_files], excludes=[".coveragerc"]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -237,7 +237,7 @@ def test_detect_versions_with_default_version_from_metadata():
 
 def test_detect_versions_nested_directory():
     temp_dir = Path(tempfile.mkdtemp())
-    src_dir = temp_dir / "src" / "src2" / "src3"
+    src_dir = temp_dir / "src" / "src2" / "src3" / "src4"
     vs = ("v1", "v2", "v3")
     for v in vs:
         os.makedirs(src_dir / v)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -241,6 +241,8 @@ def test_detect_versions_nested_directory():
     vs = ("v1", "v2", "v3")
     for v in vs:
         os.makedirs(src_dir / v)
+        # this folder should be ignored
+        os.makedirs(src_dir / v / "some_other_service_v1_beta")
 
     with util.chdir(temp_dir):
         versions = detect_versions(default_version="v1")


### PR DESCRIPTION
PR #1246 added ability to detect versions recursively when `detect_versions()` is called, however we're seeing erroneous versions detected in python-webrisk [here](https://github.com/googleapis/python-webrisk/pull/137/files#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R22).

I've updated the code to stop searching subdirectories if versions are found in the parent directory. I've also added a test to confirm the behaviour.

With the code in #1246, the following versions are detected.
```
webrisk_v1
webrisk_v1beta1
web_risk_service_v1_beta1 <- this is erroneously detected, and it is actually a service under webrisk_v1beta1
```

With the code in this PR, the following versions are detected
```
webrisk_v1
webrisk_v1beta1
```
