### PR TITLE
chore(python): modify templated noxfile to support non-cloud APIs

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -112,7 +112,7 @@ def default(session):
         "py.test",
         "--quiet",
         f"--junitxml=unit_{session.python}_sponge_log.xml",
-        "--cov=google/cloud",
+        "--cov=google",
         "--cov=tests/unit",
         "--cov-append",
         "--cov-config=.coveragerc",


### PR DESCRIPTION
Currently the `owlbot.py` file for non-cloud APIs need to have replacements in `owlbot.py` in order to use the templated noxfile. See the example from `python-analytics-admin` [here](https://github.com/googleapis/python-analytics-admin/blob/main/owlbot.py#L42) which has:
```
s.replace("noxfile.py",
'''["']--cov=google/cloud["'],''',
'''"--cov=google.analytics",''')
```

This PR eliminates the need for this replacement in owlbot.py. I tested this change in https://github.com/googleapis/python-orchestration-airflow/pull/41, and https://github.com/googleapis/python-analytics-admin/pull/157 and the Kokoro build passed in both.
