### PR TITLE
chore(python): omit google/__init__.py in coverage

### DIFF
--- a/synthtool/gcp/templates/python_library/.coveragerc
+++ b/synthtool/gcp/templates/python_library/.coveragerc
@@ -18,6 +18,7 @@
 [run]
 branch = True
 omit =
+  google/__init__.py
   google/cloud/__init__.py
 
 [report]


### PR DESCRIPTION
#1263 included a change to a noxfile to cater for non-cloud APIs, however there also need to be a corresponding change in `.coveragerc` to exclude `google/__init__.py` in order to maintain 100% coverage.