### PR TITLE
feat: add sphinx-copybutton to generated docs

### DIFF
--- a/synthtool/gcp/templates/python_library/docs/conf.py.j2
+++ b/synthtool/gcp/templates/python_library/docs/conf.py.j2
@@ -57,6 +57,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "recommonmark",
+    "sphinx_copybutton",
 ]
 
 # autodoc/autosummary flags

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -209,7 +209,7 @@ def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx==4.0.1", "alabaster", "recommonmark")
+    session.install("sphinx==4.0.1", "alabaster", "recommonmark", "sphinx-copybutton", )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(
@@ -229,7 +229,7 @@ def docfx(session):
     """Build the docfx yaml files for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx==4.0.1", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml")
+    session.install("sphinx==4.0.1", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml", "sphinx-copybutton")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(
@@ -246,7 +246,8 @@ def docfx(session):
             "sphinx.ext.napoleon,"
             "sphinx.ext.todo,"
             "sphinx.ext.viewcode,"
-            "recommonmark"
+            "recommonmark",
+            "sphinx_copybutton",
         ),
         "-b",
         "html",

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -229,7 +229,7 @@ def docfx(session):
     """Build the docfx yaml files for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx==4.0.1", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml", "sphinx-copybutton")
+    session.install("sphinx==4.0.1", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(
@@ -247,7 +247,6 @@ def docfx(session):
             "sphinx.ext.todo,"
             "sphinx.ext.viewcode,"
             "recommonmark",
-            "sphinx_copybutton",
         ),
         "-b",
         "html",


### PR DESCRIPTION
Add [sphinx-copybutton](https://github.com/executablebooks/sphinx-copybutton) to generated docs to help easier copying of code snippets.

Note: I wasn't able to get synthtool to work for https://github.com/googleapis/python-vision:

```shell
➜  python-vision git:(main) synthtool              
2021-11-01 22:06:03,169 synthtool > /home/[REDACTED]/python-vision/synth.py not found.
NoneType: None                                                                                                                                                     /0.6s
```
Any help would be appreciated!

In the docs (https://github.com/googleapis/synthtool/blob/master/synthtool/README.md):
```
e.g. the synth.py for the Cloud Tasks API for Python, Java, Node.js, PHP, or Ruby.
```
the link `https://github.com/googleapis/python-tasks/blob/master/synth.py is broken.
