### PR TITLE
chore(java): update ci.yaml

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ jobs:
   units:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         java: [8, 11, 17]
     steps:


### PR DESCRIPTION
Let's let all the unit tests complete for now.  Java 17 isn't quite ready.