### PR TITLE
chore(python): run blacken session for all directories with a noxfile

### DIFF
--- a/synthtool/languages/python.py
+++ b/synthtool/languages/python.py
@@ -192,7 +192,9 @@ def owlbot_main() -> None:
 
         py_samples(skip_readmes=True)
 
-        s.shell.run(["nox", "-s", "blacken"], hide_output=False)
+        # run blacken session for all directories which a noxfile
+        for noxfile in Path(".").glob("**/noxfile.py"):
+            s.shell.run(["nox", "-s", "blacken"], cwd=noxfile.parent, hide_output=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Many python repositories have a separate `noxfile.py` file in the `samples` directory. This PR modifies `owlbot_main()` for python to run the `blacken` nox session on all directories that contain a `noxfile.py` rather than only the root of the repository.

I tested the changes using the following commands after cloning synthtool
```
git checkout run-blacken-session-for-all-dirs
docker build -f docker/owlbot/python/Dockerfile -t runblackenonsamples . 
```

Once the docker image was built, I ran the following commands in the root of python-apigee-connect which has no samples and python-secret-manager which has samples. I've confirmed that the blacken session runs on all directories that have `noxfile.py`.
```
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo runblackenonsamples
```