### PR TITLE
chore(python): detect when samples testing requires custom dockerfile

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -266,6 +266,11 @@ class CommonTemplates:
         if Path("google/cloud").exists():
             kwargs["is_google_cloud_api"] = True
 
+        # If Dockerfile exists in .kokoro/docker/samples, add kwargs to
+        # signal that a custom docker image should be used when testing samples.
+        if Path(".kokoro/docker/samples/Dockerfile").exists():
+            kwargs["custom_samples_dockerfile"] = True
+
         # Assume the python-docs-samples Dockerfile is used for samples by default
         if "custom_samples_dockerfile" not in kwargs:
             kwargs["custom_samples_dockerfile"] = False

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -268,12 +268,7 @@ class CommonTemplates:
 
         # If Dockerfile exists in .kokoro/docker/samples, add kwargs to
         # signal that a custom docker image should be used when testing samples.
-        if Path(".kokoro/docker/samples/Dockerfile").exists():
-            kwargs["custom_samples_dockerfile"] = True
-
-        # Assume the python-docs-samples Dockerfile is used for samples by default
-        if "custom_samples_dockerfile" not in kwargs:
-            kwargs["custom_samples_dockerfile"] = False
+        kwargs["custom_samples_dockerfile"] = Path(".kokoro/docker/samples/Dockerfile").exists()
 
         ret = self._generic_library("python_library", **kwargs)
 

--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -268,7 +268,9 @@ class CommonTemplates:
 
         # If Dockerfile exists in .kokoro/docker/samples, add kwargs to
         # signal that a custom docker image should be used when testing samples.
-        kwargs["custom_samples_dockerfile"] = Path(".kokoro/docker/samples/Dockerfile").exists()
+        kwargs["custom_samples_dockerfile"] = Path(
+            ".kokoro/docker/samples/Dockerfile"
+        ).exists()
 
         ret = self._generic_library("python_library", **kwargs)
 


### PR DESCRIPTION
The [python-recaptcha-enterprise](https://github.com/googleapis/python-recaptcha-enterprise) requires a custom Dockerfile for samples testing. This PR eliminates the need to set the `custom_samples_dockerfile` argument of `py_library` which is currently done in owlbot.py [here](https://github.com/googleapis/python-recaptcha-enterprise/blob/main/owlbot.py#L42). IOW, kwargs `custom_samples_dockerfile` will automatically be set to `True` if the following file exists: `/.kokoro/docker/samples/Dockerfile`.

I tested the changes using the following commands after cloning synthtool
```
git checkout automatically-detect-when-samples-require-custom-dockerfile
docker build -f docker/owlbot/python/Dockerfile -t customdockerfile . 
```

Once the docker image was built, I ran the following commands in the root of python-recaptcha-enterprise.
```
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo customdockerfile
```