### PR TITLE
chore: update jre to 11 for linter

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         distribution: zulu
-        java-version: 8
+        java-version: 11
     - run: java -version
     - run: .kokoro/build.sh
       env:


### PR DESCRIPTION
java-format requires JRE v11+ to run linter. It still check older code, just jre has to be 11+: https://github.com/google/google-java-format/issues/529

Updating ci.yaml template since it is applicable for all the libraries.