### PR TITLE
chore(python): include UPGRADING.rst if it exists

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -259,7 +259,7 @@ class CommonTemplates:
             self.excludes += ["docs/index.rst"]
 
         # Add kwargs to signal that UPGRADING.md should be included in docs/index.rst if it exists
-        if Path("docs/UPGRADING.md").exists():
+        if Path("docs/UPGRADING.md").exists() or Path("docs/UPGRADING.rst").exists():
             kwargs["include_uprading_doc"] = True
 
         # If the directory `google/cloud` exists, add kwargs to signal that the client library is for a Cloud API


### PR DESCRIPTION
In https://github.com/googleapis/python-datacatalog/issues/153 we discovered that Markdown does not support certain formatting options, like tables when rendered from Sphinx.