### PR TITLE
deps: upgrade google-java-format to 1.13.0

### DIFF
--- a/docker/owlbot/java/Dockerfile
+++ b/docker/owlbot/java/Dockerfile
@@ -15,9 +15,10 @@
 # build from the root of this repo:
 FROM gcr.io/cloud-devrel-public-resources/java11
 
-# The formatter version used by the fmt-maven-plugin
-# https://github.com/coveooss/fmt-maven-plugin
-ARG JAVA_FORMAT_VERSION=1.11.0
+# The formatter version used by the fmt-maven-plugin through the
+# google-cloud-shared-config.
+# https://github.com/googleapis/java-shared-config/blob/main/pom.xml#L228
+ARG JAVA_FORMAT_VERSION=1.13.0
 
 RUN apt-get install -y --no-install-recommends jq
 

--- a/docker/owlbot/java/Dockerfile
+++ b/docker/owlbot/java/Dockerfile
@@ -15,7 +15,9 @@
 # build from the root of this repo:
 FROM gcr.io/cloud-devrel-public-resources/java8
 
-ARG JAVA_FORMAT_VERSION=1.7
+# The formatter version used by the fmt-maven-plugin
+# https://github.com/coveooss/fmt-maven-plugin
+ARG JAVA_FORMAT_VERSION=1.11.0
 
 RUN apt-get install -y --no-install-recommends jq
 

--- a/docker/owlbot/java/Dockerfile
+++ b/docker/owlbot/java/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # build from the root of this repo:
-FROM gcr.io/cloud-devrel-public-resources/java8
+FROM gcr.io/cloud-devrel-public-resources/java11
 
 # The formatter version used by the fmt-maven-plugin
 # https://github.com/coveooss/fmt-maven-plugin

--- a/docker/owlbot/java/container_test.yaml
+++ b/docker/owlbot/java/container_test.yaml
@@ -17,10 +17,10 @@ commandTests:
 - name: "version"
   command: ["java", "-version"]
   # java -version outputs to stderr...
-  expectedError: ["(java|openjdk) version \"1.8.*\""]
+  expectedError: ["(java|openjdk) version \"11.*\""]
 - name: "formatter"
   command: ["java", "-jar", "/owlbot/google-java-format.jar", "--version"]
-  expectedError: ["google-java-format: Version 1.7"]
+  expectedError: ["google-java-format: Version 1.13.0"]
 - name: "python"
   command: ["python", "--version"]
   expectedOutput: ["Python 3.6.1"]


### PR DESCRIPTION
Fixes https://github.com/googleapis/synthtool/issues/1287

https://github.com/googleapis/java-shared-config/pull/361 sets the google-java-format version 1.13.0.  Timur already committed the Java version upgrade for the linter. https://github.com/googleapis/synthtool/commit/42a3786737c17ece39924d7025f3be481812da53

As per @chingor13 , the formatter version was previously pinned to the old formatter because of Java 7 support.