### PR TITLE
fix(java): Add -ntp flag to native image testing command

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.sh
@@ -71,7 +71,7 @@ integration)
     ;;
 graalvm)
     # Run Unit and Integration Tests with Native Image
-    mvn test -Pnative -Penable-integration-tests
+    mvn -ntp -Pnative -Penable-integration-tests test
     RETURN_CODE=$?
     ;;
 samples)


### PR DESCRIPTION
This adds the -ntp flag to native image testing command to produce more readable test log outputs.