### PR TITLE
feat: add eslintignore for sameple generated code

### DIFF
--- a/synthtool/gcp/templates/node_library/.eslintignore
+++ b/synthtool/gcp/templates/node_library/.eslintignore
@@ -4,3 +4,4 @@ test/fixtures
 build/
 docs/
 protos/
+samples/generated/


### PR DESCRIPTION
`synthtool` overwrite the generated `.eslintignore` file.
Add `samples/generated` folder to ignore the lint.
