### PR TITLE
chore: update cloud rad publish_javadoc11 script

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc11.cfg
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc11.cfg
@@ -26,5 +26,5 @@ before_action {
   }
 }
 
-# Downloads docfx doclet resource. This will be in ${KOKORO_GFILE_DIR}/<doclet name>
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/docfx"
+# cloud rad java resources will be in ${KOKORO_GFILE_DIR}
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/cloud-rad-java"

--- a/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc11.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc11.sh
@@ -12,52 +12,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 set -eo pipefail
 
-if [[ -z "${CREDENTIALS}" ]]; then
-  CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
-fi
-
-if [[ -z "${STAGING_BUCKET_V2}" ]]; then
-  echo "Need to set STAGING_BUCKET_V2 environment variable"
-  exit 1
-fi
-
 # work from the git root directory
-pushd $(dirname "$0")/../../
+cd $(dirname "$0")/../../
+export ROOT_DIR=$(pwd)
 
-# install docuploader package
-python3 -m pip install gcp-docuploader
-
-# compile all packages
-mvn clean install -B -q -DskipTests=true
-
-export NAME={{ metadata['repo']['distribution_name'].split(':')|last }}
+export NAME=google-cloud-memcache
 export VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 
-# cloud RAD generation
-mvn clean javadoc:aggregate -B -q -P docFX
-# include CHANGELOG
-cp CHANGELOG.md target/docfx-yml/history.md
+if [ "$REGENERATE" = "true" ]; then
+  GENERATE=${KOKORO_GFILE_DIR}/regenerate_publish_javadoc11.sh
+else
+  GENERATE=${KOKORO_GFILE_DIR}/publish_javadoc11.sh
+fi
 
-pushd target/docfx-yml
-
-# create metadata
-python3 -m docuploader create-metadata \
- --name ${NAME} \
- --version ${VERSION} \
- --xrefs devsite://java/gax \
- --xrefs devsite://java/google-cloud-core \
- --xrefs devsite://java/api-common \
- --xrefs devsite://java/proto-google-common-protos \
- --xrefs devsite://java/google-api-client \
- --xrefs devsite://java/google-http-client \
- --xrefs devsite://java/protobuf \
- --language java
-
-# upload yml to production bucket
-python3 -m docuploader upload . \
- --credentials ${CREDENTIALS} \
- --staging-bucket ${STAGING_BUCKET_V2} \
- --destination-prefix docfx
+bash ${GENERATE}

--- a/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc11.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc11.sh
@@ -18,7 +18,7 @@ set -eo pipefail
 cd $(dirname "$0")/../../
 export ROOT_DIR=$(pwd)
 
-export NAME=google-cloud-memcache
+export NAME={{ metadata['repo']['distribution_name'].split(':')|last }}
 export VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 
 if [ "$REGENERATE" = "true" ]; then

--- a/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc11.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc11.sh
@@ -22,9 +22,9 @@ export NAME={{ metadata['repo']['distribution_name'].split(':')|last }}
 export VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 
 if [ "$REGENERATE" = "true" ]; then
-  GENERATE=${KOKORO_GFILE_DIR}/regenerate_publish_javadoc11.sh
+  GENERATE=${KOKORO_GFILE_DIR}/regenerate_publish_cloudrad_docs.sh
 else
-  GENERATE=${KOKORO_GFILE_DIR}/publish_javadoc11_1.0.0.sh
+  GENERATE=${KOKORO_GFILE_DIR}/publish_cloudrad_docs_1.0.0.sh
 fi
 
 bash ${GENERATE}

--- a/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc11.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/release/publish_javadoc11.sh
@@ -24,7 +24,7 @@ export VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 if [ "$REGENERATE" = "true" ]; then
   GENERATE=${KOKORO_GFILE_DIR}/regenerate_publish_javadoc11.sh
 else
-  GENERATE=${KOKORO_GFILE_DIR}/publish_javadoc11.sh
+  GENERATE=${KOKORO_GFILE_DIR}/publish_javadoc11_1.0.0.sh
 fi
 
 bash ${GENERATE}


### PR DESCRIPTION
- moved resources from `cloud-devrel-kokoro-resources/docfx` to `cloud-devrel-kokoro-resources/cloud-rad-java`
- moved generation script to bucket
- enable use of regeneration script over default by including env REGENERATE=true

- tested in individual repos and works as intended
- REGENERATE env allowed with cl/415613940

go/cloud-rad-java-regeneration
b/187403315