### PR TITLE
fix(java): Pass integration test flags to native image testing

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.sh
@@ -71,7 +71,7 @@ integration)
     ;;
 graalvm)
     # Run Unit and Integration Tests with Native Image
-    mvn -ntp -Pnative -Penable-integration-tests test
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Penable-integration-tests test
     RETURN_CODE=$?
     ;;
 samples)


### PR DESCRIPTION
This passes integration test args to the native image testing command in order to capture integration test settings from repo tests.

Will fix GraalVM breakages for https://github.com/googleapis/java-redis