### PR TITLE
chore(nodejs): migrate README to use stable or preview release_levels

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -442,7 +442,7 @@ def _load_repo_metadata(metadata_file: str = "./.repo-metadata.json") -> Dict:
     * `product_documentation` - The product documentation on cloud.google.com
     * `client_documentation` - The client library reference documentation
     * `issue_tracker` - The public issue tracker for the product
-    * `release_level` - The release level of the client library. One of: alpha, beta, ga, deprecated
+    * `release_level` - The release level of the client library. One of: stable, preview
     * `language` - The repo language. One of dotnet, go, java, nodejs, php, python, ruby
     * `repo` - The GitHub repo in the format {owner}/{repo}
     * `distribution_name` - The language-idiomatic package/distribution name

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -111,28 +111,16 @@ _Legacy Node.js versions are supported as a best effort:_
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-{% if metadata['repo']['release_level'] == 'ga' %}
-This library is considered to be **General Availability (GA)**. This means it
-is stable; the code surface will not change in backwards-incompatible ways
-unless absolutely necessary (e.g. because of critical security issues) or with
-an extensive deprecation period. Issues and requests against **GA** libraries
-are addressed with the highest priority.
+{% if metadata['repo']['release_level'] == 'stable' %}
+This library is considered to be **stable**; the code surface will not change in
+backwards-incompatible ways unless absolutely necessary (e.g. because of critical
+security issues) or with an extensive deprecation period. Issues and requests
+against **stable** libraries are addressed with the highest priority.
 {% endif %}
-{% if metadata['repo']['release_level'] == 'beta' %}
-This library is considered to be in **beta**. This means it is expected to be
-mostly stable while we work toward a general availability release; however,
-complete stability is not guaranteed. We will address issues and requests
-against beta libraries with a high priority.
-{% endif %}
-{% if metadata['repo']['release_level'] == 'alpha' %}
-This library is considered to be in **alpha**. This means it is still a
-work-in-progress and under active development. Any release is subject to
-backwards-incompatible changes at any time.
-{% endif %}
-{% if metadata['release_level'] == 'deprecated' %}
-This library is **deprecated**. This means that it is no longer being
-actively maintained and the only updates the library will receive will
-be for critical security issues. {% if metadata['deprecated'] %}{{ metadata['deprecated'] }}{% endif %}
+{% if metadata['repo']['release_level'] == 'preview' %}
+This library is considered to be in **preview**. This means that it is not expected
+to be stable. We will address issues and requests against preview libraries with
+a high priority.
 {% endif %}
 
 More Information: [Google Cloud Platform Launch Stages][launch_stages]

--- a/synthtool/sources/templates.py
+++ b/synthtool/sources/templates.py
@@ -101,9 +101,7 @@ def release_quality_badge(input: str) -> str:
     elif release_quality == "PREVIEW":
         badge = "beta-yellow"
     else:
-        log.error(
-            "Expected 'release_quality' to be one of: (stable, preview)"
-        )
+        log.error("Expected 'release_quality' to be one of: (stable, preview)")
         return ""
     return f"[![release level](https://img.shields.io/badge/release%20level-{badge}.svg?style=flat)](https://cloud.google.com/terms/launch-stages)"
 

--- a/synthtool/sources/templates.py
+++ b/synthtool/sources/templates.py
@@ -96,19 +96,13 @@ def release_quality_badge(input: str) -> str:
     release_quality = input.upper()
     badge = ""
 
-    if release_quality == "GA":
+    if release_quality == "STABLE":
         badge = "general%20availability%20%28GA%29-brightgreen"
-    elif release_quality == "BETA":
+    elif release_quality == "PREVIEW":
         badge = "beta-yellow"
-    elif release_quality == "ALPHA":
-        badge = "alpha-orange"
-    elif release_quality == "EAP":
-        badge = "EAP-yellow"
-    elif release_quality == "DEPRECATED":
-        badge = "deprecated-red"
     else:
         log.error(
-            "Expected 'release_quality' to be one of: (ga, beta, alpha, eap, deprecated)"
+            "Expected 'release_quality' to be one of: (stable, preview)"
         )
         return ""
     return f"[![release level](https://img.shields.io/badge/release%20level-{badge}.svg?style=flat)](https://cloud.google.com/terms/launch-stages)"

--- a/tests/fixtures/nodejs-dlp-with-staging/.repo-metadata.json
+++ b/tests/fixtures/nodejs-dlp-with-staging/.repo-metadata.json
@@ -2,7 +2,7 @@
   "client_documentation": "https://googleapis.dev/nodejs/dlp/latest",
   "api_id": "dlp.googleapis.com",
   "distribution_name": "@google-cloud/dlp",
-  "release_level": "ga",
+  "release_level": "stable",
   "default_version": "v2",
   "language": "nodejs",
   "name_pretty": "Cloud Data Loss Prevention",

--- a/tests/fixtures/nodejs-dlp/.repo-metadata.json
+++ b/tests/fixtures/nodejs-dlp/.repo-metadata.json
@@ -2,7 +2,7 @@
   "client_documentation": "https://googleapis.dev/nodejs/dlp/latest",
   "api_id": "dlp.googleapis.com",
   "distribution_name": "@google-cloud/dlp",
-  "release_level": "ga",
+  "release_level": "stable",
   "default_version": "v2",
   "language": "nodejs",
   "name_pretty": "Cloud Data Loss Prevention",

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -79,7 +79,7 @@ def test_release_quality_badge():
         "README.md", metadata={"repo": {"release_level": "preview"}, "samples": {}}
     ).read_text()
     assert "https://img.shields.io/badge/release%20level-beta-yellow.svg" in result
-    assert "This library is considered to be in **beta**" in result
+    assert "This library is considered to be in **preview**" in result
 
 
 def test_syntax_highlighter():

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -76,7 +76,7 @@ def test_render_preserve_mode():
 def test_release_quality_badge():
     t = templates.Templates(NODE_TEMPLATES)
     result = t.render(
-        "README.md", metadata={"repo": {"release_level": "beta"}, "samples": {}}
+        "README.md", metadata={"repo": {"release_level": "preview"}, "samples": {}}
     ).read_text()
     assert "https://img.shields.io/badge/release%20level-beta-yellow.svg" in result
     assert "This library is considered to be in **beta**" in result


### PR DESCRIPTION
This PR modifies the README template for nodejs to use `stable` or `preview` as required by go/library-data-integrity instead of `ga`, `beta`, `alpha`, `eap` or `deprecated`.