### PR TITLE
chore(python): fix undefined name 'glob' in samples noxfile

### DIFF
--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+import glob
 import os
 from pathlib import Path
 import sys


### PR DESCRIPTION
PR https://github.com/googleapis/synthtool/pull/1321 added `glob.glob` but the import statement was missing.