### PR TITLE
chore: add samples noxfile test

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -37,6 +37,6 @@ def lint(session):
 
 @nox.session(python=['3.6', '3.8'])
 def test(session):
-    session.install('pytest', 'pytest-cov', 'requests_mock', 'watchdog')
+    session.install('pytest', 'pytest-cov', 'requests_mock', 'watchdog', 'flake8')
     session.run('pip', 'install', '-e', '.')
     session.run('pytest', '--cov-report', 'term-missing', '--cov', 'autosynth', 'synthtool', 'tests', *session.posargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ lxml
 
 # Install sample-tester for generated samples
 sample-tester
+
+# flake8 is used to validate the python samples noxfile template
+flake8

--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -59,7 +59,7 @@ TEST_CONFIG = {
 }
 
 
-try:
+try
     # Ensure we can import noxfile_config in the project's directory.
     sys.path.append(".")
     from noxfile_config import TEST_CONFIG_OVERRIDE

--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -14,9 +14,10 @@
 
 from __future__ import print_function
 
+import glob
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
 import nox

--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -14,7 +14,6 @@
 
 from __future__ import print_function
 
-import glob
 import os
 from pathlib import Path
 import sys
@@ -72,7 +71,7 @@ except ImportError as e:
 TEST_CONFIG.update(TEST_CONFIG_OVERRIDE)
 
 
-def get_pytest_env_vars() -> Dict[str, str]
+def get_pytest_env_vars() -> Dict[str, str]:
     """Returns a dict for pytest invocation."""
     ret = {}
 

--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -72,7 +72,7 @@ except ImportError as e:
 TEST_CONFIG.update(TEST_CONFIG_OVERRIDE)
 
 
-def get_pytest_env_vars() -> Dict[str, str]:
+def get_pytest_env_vars() -> Dict[str, str]
     """Returns a dict for pytest invocation."""
     ret = {}
 

--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -59,7 +59,7 @@ TEST_CONFIG = {
 }
 
 
-try
+try:
     # Ensure we can import noxfile_config in the project's directory.
     sys.path.append(".")
     from noxfile_config import TEST_CONFIG_OVERRIDE

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -47,7 +47,9 @@ def test_samples_billing():
     ).read_text()
     assert "and you will need to [enable billing]" in result
 
+
 # def test_samples_noxfile(template_kwargs, expected_text):
+
 
 def test_samples_noxfile():
     t = templates.Templates(PYTHON_SAMPLES)

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -50,7 +50,7 @@ def test_samples_billing():
 # def test_samples_noxfile(template_kwargs, expected_text):
 
 def test_samples_noxfile(template_kwargs, expected_text):
-    t = templates.Templates(PYTHON_SAMPLES
+    t = templates.Templates(PYTHON_SAMPLES)
     result = t.render("noxfile.py.j2", **template_kwargs,).read_text()
     # Validate Python syntax.
     result_code = compile(result, "noxfile.py", "exec")

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tempfile
+
 from pathlib import Path
 
 from synthtool.sources import templates
@@ -49,12 +51,16 @@ def test_samples_billing():
 
 
 def test_samples_noxfile():
+    from flake8.checker import FileChecker
     t = templates.Templates(PYTHON_SAMPLES)
     result = t.render("noxfile.py.j2").read_text()
     # Validate Python syntax.
     result_code = compile(result, "noxfile.py", "exec")
-    # exec(result_code, {}, {})
     assert result_code is not None
+    result_code_temp_file = tempfile.TemporaryFile()
+    result_code_temp_file.write(result_code)
+    print(FileChecker(result_code_temp_file))
+    
 
 
 def test_samples_footer():

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -63,7 +63,6 @@ def test_samples_noxfile():
     # run flake8, which will check for missing imports
     # test fails if flake8 fails, no need to assert
     subprocess.check_call(["flake8", result_code_temp_file.name ])
-    
 
 
 def test_samples_footer():

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -62,7 +62,7 @@ def test_samples_noxfile():
     result_code_temp_file.write(bytes(result, "utf-8"))
     # run flake8, which will check for missing imports
     # test fails if flake8 fails, no need to assert
-    subprocess.check_call(["flake8", result_code_temp_file.name ])
+    subprocess.check_call(["flake8", result_code_temp_file.name])
 
 
 def test_samples_footer():

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -49,9 +49,9 @@ def test_samples_billing():
 
 # def test_samples_noxfile(template_kwargs, expected_text):
 
-def test_samples_noxfile(template_kwargs, expected_text):
+def test_samples_noxfile():
     t = templates.Templates(PYTHON_SAMPLES)
-    result = t.render("noxfile.py.j2", **template_kwargs,).read_text()
+    result = t.render("noxfile.py.j2").read_text()
     # Validate Python syntax.
     result_code = compile(result, "noxfile.py", "exec")
     assert result_code is not None

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -52,6 +52,8 @@ def test_samples_billing():
 
 
 def test_samples_noxfile():
+    import shutil
+
     t = templates.Templates(PYTHON_SAMPLES)
     result = t.render("noxfile.py.j2").read_text()
     # Validate Python syntax.
@@ -62,7 +64,7 @@ def test_samples_noxfile():
     result_code_temp_file.write(bytes(result, "utf-8"))
     # run flake8, which will check for missing imports
     # test fails if flake8 fails, no need to assert
-    subprocess.check_call(["flake8", result_code_temp_file.name])
+    subprocess.check_call([shutil.which("flake8"), result_code_temp_file.name])
 
 
 def test_samples_footer():

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -47,6 +47,17 @@ def test_samples_billing():
     ).read_text()
     assert "and you will need to [enable billing]" in result
 
+# def test_samples_noxfile(template_kwargs, expected_text):
+
+def test_samples_noxfile(template_kwargs, expected_text):
+    t = templates.Templates(PYTHON_SAMPLES
+    result = t.render("noxfile.py.j2", **template_kwargs,).read_text()
+    # Validate Python syntax.
+    result_code = compile(result, "noxfile.py", "exec")
+    assert result_code is not None
+    # for expected in expected_text:
+    #     assert expected in result
+
 
 def test_samples_footer():
     t = templates.Templates(PYTHON_SAMPLES)

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -60,8 +60,8 @@ def test_samples_noxfile():
     # write rendered template to a file
     result_code_temp_file = tempfile.NamedTemporaryFile()
     result_code_temp_file.write(bytes(result, "utf-8"))
-
     # run flake8, which will check for missing imports
+    # test fails if flake8 fails, no need to assert
     subprocess.check_call(["flake8", result_code_temp_file.name ])
     
 

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import subprocess
 import tempfile
 
 from pathlib import Path
@@ -51,15 +52,17 @@ def test_samples_billing():
 
 
 def test_samples_noxfile():
-    from flake8.checker import FileChecker
     t = templates.Templates(PYTHON_SAMPLES)
     result = t.render("noxfile.py.j2").read_text()
     # Validate Python syntax.
     result_code = compile(result, "noxfile.py", "exec")
     assert result_code is not None
-    result_code_temp_file = tempfile.TemporaryFile()
-    result_code_temp_file.write(result_code)
-    print(FileChecker(result_code_temp_file))
+    # write rendered template to a file
+    result_code_temp_file = tempfile.NamedTemporaryFile()
+    result_code_temp_file.write(bytes(result, "utf-8"))
+
+    # run flake8, which will check for missing imports
+    subprocess.check_call(["flake8", result_code_temp_file.name ])
     
 
 

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -53,7 +53,7 @@ def test_samples_noxfile():
     result = t.render("noxfile.py.j2").read_text()
     # Validate Python syntax.
     result_code = compile(result, "noxfile.py", "exec")
-    exec(result_code, {}, {})
+    # exec(result_code, {}, {})
     assert result_code is not None
 
 

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -53,6 +53,7 @@ def test_samples_noxfile():
     result = t.render("noxfile.py.j2").read_text()
     # Validate Python syntax.
     result_code = compile(result, "noxfile.py", "exec")
+    exec(result_code, {}, {})
     assert result_code is not None
 
 

--- a/tests/test_sample_templates.py
+++ b/tests/test_sample_templates.py
@@ -48,17 +48,12 @@ def test_samples_billing():
     assert "and you will need to [enable billing]" in result
 
 
-# def test_samples_noxfile(template_kwargs, expected_text):
-
-
 def test_samples_noxfile():
     t = templates.Templates(PYTHON_SAMPLES)
     result = t.render("noxfile.py.j2").read_text()
     # Validate Python syntax.
     result_code = compile(result, "noxfile.py", "exec")
     assert result_code is not None
-    # for expected in expected_text:
-    #     assert expected in result
 
 
 def test_samples_footer():


### PR DESCRIPTION
Add a test for the samples noxfile template that compiles the code, saves it to a temp file, and runs flake8 on it to both make sure there are no syntax errors and ensure there are no import errors