### PR TITLE
build(node): switch back to keystore for publication

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/publish.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/publish.sh
@@ -24,7 +24,7 @@ python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /
 
 cd $(dirname $0)/..
 
-NPM_TOKEN=$(cat $KOKORO_GFILE_DIR/secret_manager/npm_publish_token)
+NPM_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/73713_google-cloud-npm-token-1)
 echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
 npm install

--- a/synthtool/gcp/templates/node_library/.kokoro/release/publish.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/release/publish.cfg
@@ -7,6 +7,15 @@ before_action {
   }
 }
 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "google-cloud-npm-token-1"
+    }
+  }
+}
+
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "npm_publish_token,releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"

--- a/synthtool/gcp/templates/node_library/.kokoro/release/publish.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/release/publish.cfg
@@ -18,7 +18,7 @@ before_action {
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "npm_publish_token,releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
+  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
 }
 
 # Download trampoline resources.


### PR DESCRIPTION
Switching back to keystore for npm publication until release conductor is ready to go.