### PR TITLE
chore(python): fix lint error in samples noxfile

### DIFF
--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -16,8 +16,8 @@ from __future__ import print_function
 
 import glob
 import os
-import sys
 from pathlib import Path
+import sys
 from typing import Callable, Dict, List, Optional
 
 import nox


### PR DESCRIPTION
Synthtool PR https://github.com/googleapis/synthtool/pull/1326 is causing PRs to fail the `Samples - lint` check downstream with error
```
I100 Import statements are in the wrong order. 'from pathlib import Path' should be before 'import sys'
```
For example, see https://github.com/googleapis/python-vision/pull/295/files