### PR TITLE
ci(python): run lint / unit tests / docs as GH actions

### DIFF
--- a/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
@@ -1,4 +1,3 @@
-{% raw -%}
 name: "Docs"
 
 on:
@@ -16,7 +15,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "{{ unit_test_python_versions | last }}"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel
@@ -24,4 +23,3 @@ jobs:
     - name: Run docs
       run: |
         nox -s docs docfx
-{% endraw %}

--- a/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+{% raw -%}
+name: "Docs"
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  run-docs:
+    name: docs
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run docs
+      run: |
+        nox -s docs docfx
+{% endraw %}

--- a/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
@@ -1,13 +1,10 @@
-name: "Docs"
-
 on:
   pull_request:
     branches:
       - main
-
+name: docs
 jobs:
-  run-docs:
-    name: docs
+  docs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -22,4 +19,20 @@ jobs:
         python -m pip install nox
     - name: Run docs
       run: |
-        nox -s docs docfx
+        nox -s docs
+  docfx:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "{{ unit_test_python_versions | last }}"
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run docfx
+      run: |
+        nox -s docfx

--- a/synthtool/gcp/templates/python_library/.github/workflows/lint.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/lint.yml
@@ -1,4 +1,3 @@
-{% raw -%}
 name: "Lint"
 
 on:
@@ -16,7 +15,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "{{ unit_test_python_versions | last }}"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel
@@ -27,4 +26,3 @@ jobs:
     - name: Run lint_setup_py
       run: |
         nox -s lint_setup_py
-{% endraw %}

--- a/synthtool/gcp/templates/python_library/.github/workflows/lint.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/lint.yml
@@ -1,13 +1,10 @@
-name: "Lint"
-
 on:
   pull_request:
     branches:
       - main
-
+name: lint
 jobs:
-  run-lint:
-    name: lint
+  lint:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/synthtool/gcp/templates/python_library/.github/workflows/lint.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+{% raw -%}
+name: "Lint"
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  run-lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run lint
+      run: |
+        nox -s lint
+    - name: Run lint_setup_py
+      run: |
+        nox -s lint_setup_py
+{% endraw %}

--- a/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
@@ -1,51 +1,40 @@
-name: "Unit tests"
-
 on:
   pull_request:
     branches:
       - main
-
+name: unittest
 jobs:
-  run-unittests:
-{%- raw %}
-    name: unit-${{ matrix.python }}
-{%- endraw %}
+  unit:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python:
-{%- for v in unit_test_python_versions %}
-          - "{{v}}"
-{%- endfor %}
+        python: {{unit_test_python_versions}}
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-{%- raw %}
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python }}
+        python-version: ${{ '{{' }} matrix.python {{ '}}' }}
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel
         python -m pip install nox
     - name: Run unit tests
       env:
-        COVERAGE_FILE: .coverage${{ matrix.option }}-${{matrix.python }}
+        COVERAGE_FILE: .coverage-${{ '{{' }} matrix.python {{ '}}' }}
       run: |
-        nox -s unit${{ matrix.option }}-${{ matrix.python }}
+        nox -s unit-${{ '{{' }} matrix.python {{ '}}' }}
     - name: Upload coverage results
       uses: actions/upload-artifact@v2
       with:
         name: coverage-artifacts
-        path: .coverage${{ matrix.option }}-${{ matrix.python }}
-{%- endraw %}
+        path: .coverage-${{ '{{' }} matrix.python {{ '}}' }}
 
-  report-coverage:
-    name: cover
+  cover:
     runs-on: ubuntu-latest
     needs:
-        - run-unittests
+        - unit
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
@@ -1,0 +1,68 @@
+{% raw -%}
+name: "Unit tests"
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  run-unittests:
+    name: unit-${{ matrix.python }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run unit tests
+      env:
+        COVERAGE_FILE: .coverage${{ matrix.option }}-${{matrix.python }}
+      run: |
+        nox -s unit${{ matrix.option }}-${{ matrix.python }}
+    - name: Upload coverage results
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-artifacts
+        path: .coverage${{ matrix.option }}-${{ matrix.python }}
+
+  report-coverage:
+    name: cover
+    runs-on: ubuntu-latest
+    needs:
+        - run-unittests
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install coverage
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install coverage
+    - name: Download coverage results
+      uses: actions/download-artifact@v2
+      with:
+        name: coverage-artifacts
+        path: .coverage-results/
+    - name: Report coverage results
+      run: |
+        coverage combine .coverage-results/.coverage*
+        coverage report --show-missing --fail-under=100
+{% endraw %}

--- a/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
@@ -1,4 +1,3 @@
-{% raw -%}
 name: "Unit tests"
 
 on:
@@ -8,19 +7,20 @@ on:
 
 jobs:
   run-unittests:
+{%- raw %}
     name: unit-${{ matrix.python }}
+{%- endraw %}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python:
-          - "3.6"
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
+{%- for v in unit_test_python_versions %}
+          - "{{v}}"
+{%- endfor %}
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+{%- raw %}
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
@@ -39,6 +39,7 @@ jobs:
       with:
         name: coverage-artifacts
         path: .coverage${{ matrix.option }}-${{ matrix.python }}
+{%- endraw %}
 
   report-coverage:
     name: cover
@@ -51,7 +52,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "{{ unit_test_python_versions | last }}"
     - name: Install coverage
       run: |
         python -m pip install --upgrade setuptools pip wheel
@@ -65,4 +66,3 @@ jobs:
       run: |
         coverage combine .coverage-results/.coverage*
         coverage report --show-missing --fail-under=100
-{% endraw %}


### PR DESCRIPTION
I tested the changes using the following commands after cloning synthtool

```
git checkout add-lint-unittest-docs-checks-as-github-actions
docker build -f docker/owlbot/python/Dockerfile -t movetoghactions .
```

Once the docker image was built, I ran the following commands in the root of [python-access-approval](https://github.com/googleapis/python-access-approval).

```
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo movetoghactions
```

This should not impact the existing kokoro or docs pre-submit jobs as we are adding github action checks in parallel. Once this is merged, we can disable the kokoro/docs on a per repo basis.