### PR TITLE
chore(python): Noxfile recognizes that tests can live in a folder

### DIFF
--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -187,6 +187,7 @@ def _session_tests(
 ) -> None:
     # check for presence of tests
     test_list = glob.glob("*_test.py") + glob.glob("test_*.py")
+    test_list.extend(glob.glob("tests"))
     if len(test_list) == 0:
         print("No tests found, skipping directory.")
     else:


### PR DESCRIPTION
Pytest works just fine with tests organized inside a `tests` folder. I see no reason why we shouldn't accept that. Also, I wanted to put tests in dedicated folder in my samples ;)

Tested it locally