### PR TITLE
chore(python): use cov_level in unittest gh action

### DIFF
--- a/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
@@ -54,4 +54,4 @@ jobs:
     - name: Report coverage results
       run: |
         coverage combine .coverage-results/.coverage*
-        coverage report --show-missing --fail-under=100
+        coverage report --show-missing --fail-under={{ cov_level if cov_level != None else 100 }}


### PR DESCRIPTION
PR #1333 added [Github Actions](https://github.com/googleapis/synthtool/tree/master/synthtool/gcp/templates/python_library/.github/workflows) to python library templates. The coverage command [here](https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml#L57) will fail on repos that don't have 100% coverage. This PR makes use of the `cov_level` template variable to set the coverage level to the correct value for each repo.

