### PR TITLE
fix: make version check case insensitive

### DIFF
--- a/synthtool/languages/php.py
+++ b/synthtool/languages/php.py
@@ -73,11 +73,10 @@ def _find_copy_target(src: Path, version_string: str) -> typing.Optional[Path]:
     if not entries:
         return None
     for entry in entries:
-        entry = Path(entry.path).resolve()
-        if entry.stem.lower() == version_string:
+        if Path(entry.path).resolve().stem.lower() == version_string:
             return src
         if entry.is_dir():
-            return _find_copy_target(entry, version_string)
+            return _find_copy_target(Path(entry.path).resolve(), version_string)
     return None
 
 

--- a/synthtool/languages/php.py
+++ b/synthtool/languages/php.py
@@ -73,10 +73,11 @@ def _find_copy_target(src: Path, version_string: str) -> typing.Optional[Path]:
     if not entries:
         return None
     for entry in entries:
-        if entry.path.endswith(version_string):
+        entry = Path(entry.path).resolve()
+        if entry.stem.lower() == version_string:
             return src
         if entry.is_dir():
-            return _find_copy_target(Path(entry.path).resolve(), version_string)
+            return _find_copy_target(entry, version_string)
     return None
 
 
@@ -95,7 +96,7 @@ def owlbot_copy_version(
     if not entries:
         logger.info("there is no src directory '%s' to copy", src_dir)
         return
-    version_string = os.path.basename(os.path.basename(next(entries)))
+    version_string = os.path.basename(os.path.basename(next(entries))).lower()
     logger.debug("version_string detected: %s", version_string)
 
     # copy all src including partial veneer classes


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-php/pull/5061 exposed an issue with copying over generated metadata during the post processing job.

Generated protos rely on a php_namespace setting where we have a convention of lower casing the words alpha, beta, etc. in a version string. The generated metadata, on the other hand, does not follow these rules and is generated using a capital letter for these strings (e.g., Alpha, Beta).

This fix makes the directory check case insensitive, which should allow us to pick up the metadata directory in post processing for any packages which have alpha or beta qualifiers.

Please let me know if you would like for this change to include a set of further fixtures alongside https://github.com/googleapis/synthtool/tree/master/tests/fixtures/php/php_asset to help cover this case.