### PR TITLE
chore: update google-gax version in Docker file

### DIFF
--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -48,7 +48,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@2.27.1 typescript@3.9.9 \
+RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@2.29.1 typescript@3.9.9 \
     chalk@4.1.2 escodegen@2.0.0 espree@7.3.1 estraverse@5.2.0 glob@7.2.0 jsdoc@3.6.7 \
     minimist@1.2.5 semver@7.3.5 tmp@0.2.1 uglify-js@3.14.2
 


### PR DESCRIPTION
Fix the compile proto issue in https://github.com/googleapis/nodejs-bigtable/pull/993
Error log from owlbot: https://pantheon2.corp.google.com/navigation-error;errorUrl=%2Fcloud-build%2Fbuilds%3Bregion%3Dglobal%2Febc9667e-9012-4b46-a5db-dc4975d5c9fe%3Fproject%3Drepo-automation-bots&pli%3D1/permissions?project=repo-automation-bots