### PR TITLE
build: make OwlBot check required

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/sync-repo-settings.yaml
+++ b/synthtool/gcp/templates/java_library/.github/sync-repo-settings.yaml
@@ -37,6 +37,7 @@ branchProtectionRules:
   - "units (11)"
   - "Kokoro - Test: Integration"
   - "cla/google"
+  - "OwlBot Post Processor"
 # List of explicit permissions to add (additive only)
 permissionRules:
 - team: yoshi-admins


### PR DESCRIPTION
Towards https://github.com/googleapis/repo-automation-bots/issues/2112

This file is only created upon initial generation. This will make it required for newly generated repositories.