### PR TITLE
ci: pull request template includes sample format

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/PULL_REQUEST_TEMPLATE.md
+++ b/synthtool/gcp/templates/java_library/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,6 @@ Thank you for opening a Pull Request! Before submitting your PR, there are a few
 - [ ] Appropriate docs were updated (if necessary)
 
 Fixes #<issue_number_goes_here> ☕️
+
+If you write sample code, please follow the [samples format](
+https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).


### PR DESCRIPTION
@lesv During today's meeting @BenWhitehead had an idea to reference the SAMPLE_FORMAT.md in the pull request template. What do you think?