### PR TITLE
chore(deps): update actions/checkout action to v3

### DIFF
--- a/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Python
       uses: actions/setup-python@v3
       with:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Python
       uses: actions/setup-python@v3
       with:

--- a/synthtool/gcp/templates/python_library/.github/workflows/lint.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Python
       uses: actions/setup-python@v3
       with:

--- a/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
         python: {{unit_test_python_versions}}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Python
       uses: actions/setup-python@v3
       with:
@@ -37,7 +37,7 @@ jobs:
         - unit
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Python
       uses: actions/setup-python@v3
       with:


### PR DESCRIPTION
Release notes for v3: https://github.com/actions/checkout/releases/tag/v3.0.0

https://github.com/googleapis/python-workflows/pull/138/checks ran successfully with the changes here.