### PR TITLE
build(nodejs): remove staging fallback

### DIFF
--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -317,13 +317,11 @@ def owlbot_main(
             s_copy([library], excludes=staging_excludes)
         # The staging directory should never be merged into the main branch.
         shutil.rmtree(staging)
-    else:
+    elif default_version:
         # Collect the subdirectories of the src directory.
         src = Path("src")
-        versions = [v.name for v in src.iterdir() if v.is_dir()]
         # Reorder the versions so the default version always comes last.
-        if default_version:
-            versions = [v for v in versions if v != default_version] + [default_version]
+        versions = [v for v in versions if v != default_version] + [default_version]
         logger.info(f"Collected versions ${versions} from ${src}")
 
     common_templates = gcp.CommonTemplates(template_path)


### PR DESCRIPTION
I believe all Node.js libraries should be using a staging directory for generation, the fallback logic that remained led to a bad PR for gax:

https://github.com/googleapis/gax-nodejs/pull/1204/files

Because the directories in `src/` were seen as versions (_even though they are not_).