### PR TITLE
chore: Enable Size-Label bot in all googleapis Python repositories

### DIFF
--- a/auto-label.yaml
+++ b/auto-label.yaml
@@ -1,3 +1,2 @@
-product: true
 requestsize:
   enabled: true

--- a/auto-label.yaml
+++ b/auto-label.yaml
@@ -1,0 +1,3 @@
+product: true
+requestsize:
+  enabled: true


### PR DESCRIPTION
Auto-label T-shirt size indicator should be assigned on every new pull request in all googleapis Python repositories