### PR TITLE
chore: Enable Size-Label bot in all googleapis Python notebook testin…

### DIFF
--- a/synthtool/gcp/templates/python_notebooks_testing_pipeline/.github/auto-label.yaml
+++ b/synthtool/gcp/templates/python_notebooks_testing_pipeline/.github/auto-label.yaml
@@ -1,3 +1,2 @@
-product: true
 requestsize:
   enabled: true

--- a/synthtool/gcp/templates/python_notebooks_testing_pipeline/.github/auto-label.yaml
+++ b/synthtool/gcp/templates/python_notebooks_testing_pipeline/.github/auto-label.yaml
@@ -1,0 +1,3 @@
+product: true
+requestsize:
+  enabled: true


### PR DESCRIPTION
…g repositories

Auto-label T-shirt size indicator should be assigned on every new pull request in all googleapis Python notebook testing repositories