### PR TITLE
chore(python): Use python 3.10.4 base image for post processor

### DIFF
--- a/docker/owlbot/python/Dockerfile
+++ b/docker/owlbot/python/Dockerfile
@@ -16,7 +16,7 @@
 
 # build from the root of this repo:
 # docker build -t gcr.io/repo-automation-bots/owlbot-python -f docker/owlbot/python/Dockerfile .
-FROM python:3.9.5-buster
+FROM python:3.10.4-buster
 
 WORKDIR /
 


### PR DESCRIPTION
I tested the change by building the post processor owlbot image locally using the following:
```
docker build -f docker/owlbot/python/Dockerfile -t testpy310 .
```

I then ran the post processor in a downstream repo:
```
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo testpy310
```