### PR TITLE
chore: improve logic to configure release-please for previous major versions

### DIFF
--- a/blargh.yml
+++ b/blargh.yml
@@ -1,7 +1,0 @@
-bumpMinorPreMajor: true
-handleGHRelease: true
-releaseType: java-yoshi
-branches:
-  - handleGHRelease: true
-    releaseType: python
-    branch: java7

--- a/synthtool/languages/python.py
+++ b/synthtool/languages/python.py
@@ -159,27 +159,29 @@ def configure_previous_major_version_branches() -> None:
     if the library version is currently 3.5.1, the release-please config
     will include v2, v1, and v0.
     """
-    if list(Path(".").glob("google/**/version.py")):
-        version_file = list(Path(".").glob("google/**/version.py"))[0]
-    else:
-        version_file = Path("setup.py")
 
     # In version.py:    __version__ = "1.5.2"
     # In setup.py:      version = "1.5.2"
     VERSION_REGEX = (
         r"(?:__)?version(?:__)?\s*=\s*[\"'](?P<major_version>\d)\.[\d\.]+[\"']"
     )
+    version_paths = list(Path(".").glob("google/**/version.py")) + [Path("setup.py")]
 
-    match = re.search(VERSION_REGEX, Path(version_file).read_text())
+    major_version = None
 
-    if match is not None:
-        major_version = int(match.group("major_version"))
-    else:
+    for p in version_paths:
+        match = re.search(VERSION_REGEX, Path(p).read_text())
+
+        if match is not None:
+            major_version = int(match.group("major_version"))
+            break
+
+    if major_version is None:
         raise RuntimeError(
-            "Unable to find library version in {} with regex {}".format(
-                version_file, VERSION_REGEX
+                "Unable to find library version in files {} with regex {}".format(
+                    version_paths, VERSION_REGEX
+                )
             )
-        )
 
     with open(".github/release-please.yml") as f:
         release_please_yml = yaml.load(f, Loader=yaml.SafeLoader)

--- a/synthtool/languages/python.py
+++ b/synthtool/languages/python.py
@@ -178,10 +178,10 @@ def configure_previous_major_version_branches() -> None:
 
     if major_version is None:
         raise RuntimeError(
-                "Unable to find library version in files {} with regex {}".format(
-                    version_paths, VERSION_REGEX
-                )
+            "Unable to find library version in files {} with regex {}".format(
+                version_paths, VERSION_REGEX
             )
+        )
 
     with open(".github/release-please.yml") as f:
         release_please_yml = yaml.load(f, Loader=yaml.SafeLoader)


### PR DESCRIPTION
A handful of libraries have files named `version.py` that do not have the library version. ([example](https://github.com/googleapis/python-spanner/blob/main/google/cloud/spanner_dbapi/version.py))

Cycle through all the paths that might have the library version before raising a runtime error.