### PR TITLE
chore: delete auto-label and snippet-bot .yaml from .github folder

### DIFF
--- a/synthtool/gcp/templates/python_notebooks_testing_pipeline/.github/auto-label.yaml
+++ b/synthtool/gcp/templates/python_notebooks_testing_pipeline/.github/auto-label.yaml
@@ -1,2 +1,0 @@
-requestsize:
-  enabled: true


### PR DESCRIPTION
Deleting `auto-label.yaml` and `snippet-bot.yaml` from the template as it causes redundancies and issues with downstream repos.