### PR TITLE
chore(python): auto approve template changes

### DIFF
--- a/synthtool/gcp/templates/python_library/.github/auto-approve.yml
+++ b/synthtool/gcp/templates/python_library/.github/auto-approve.yml
@@ -1,0 +1,3 @@
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve
+processes:
+  - "OwlBotTemplateChanges"


### PR DESCRIPTION
This PR will allow changes from https://github.com/googleapis/synthtool/tree/master/synthtool/gcp/templates/python_library that have [autoapprove] in the synthtool PR title in to be autoapproved in downstream repos to reduce toilsome tasks. 

See the criteria autoapproving under the `OwlBotTemplateChanges` heading here  https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve#latest-release-notes-112321

I tested the changes in the `python-access-approval`  repository

Here is a PR where I added auto-approve.yml:
https://github.com/googleapis/python-access-approval/pull/197

Here is a PRs that shows the auto-approve feature is working:
https://github.com/googleapis/python-access-approval/pull/198 




