### PR TITLE
chore(node): handle when package.json does not have a version

### DIFF
--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -340,8 +340,9 @@ def owlbot_main(
         templates = common_templates.node_library(source_location="build/src")
         s_copy([templates], excludes=templates_excludes)
 
-    library_version = template_metadata()["version"]
-    common.update_library_version(library_version, _GENERATED_SAMPLES_DIRECTORY)
+    library_version = template_metadata().get("version")
+    if library_version:
+        common.update_library_version(library_version, _GENERATED_SAMPLES_DIRECTORY)
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/node_templates/no_version/.repo-metadata.json
+++ b/tests/fixtures/node_templates/no_version/.repo-metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "repo-automation-bots",
+  "name_pretty": "Repo Automation Bots",
+  "release_level": "stable",
+  "language": "nodejs",
+  "repo": "googleapis/repo-automation-bots",
+  "distribution_name": "repo-automation-bots",
+  "codeowner_team": "@googleapis/github-automation",
+  "client_documentation": "https://cloud.google.com/nodejs/docs/reference/repo-automation-bots/latest",
+  "library_type": "OTHER"
+}

--- a/tests/fixtures/node_templates/no_version/package.json
+++ b/tests/fixtures/node_templates/no_version/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "repo-automation-bots",
+  "private": true,
+  "license": "Apache-2.0",
+  "repository": "googleapis/repo-automation-bots",
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "scripts": {
+    "run": "./scripts/scripts.js",
+    "fix": "npm run run -- npm run fix",
+    "test": "c8 npm run run -- npm test",
+    "proxy": "smee",
+    "generate-bot": "node ./packages/generate-bot/run.js"
+  },
+  "devDependencies": {
+    "c8": "^7.1.0",
+    "gaxios": "^5.0.0",
+    "smee-client": "^1.1.0",
+    "@google-cloud/mono-repo-publish": "^1.0.0"
+  }
+}

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -276,3 +276,8 @@ def test_owlbot_main_with_staging_patch_staging(hermetic_mock, nodejs_dlp):
     assert "import * as v2" in staging_text
     assert "export * as v2" not in staging_text
     assert "export * as v2" in text
+
+def test_owlbot_main_without_version():
+    with util.copied_fixtures_dir(FIXTURES / "node_templates" / "no_version"):
+        # just confirm it doesn't throw an exception.
+        node.owlbot_main(TEMPLATES)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -277,6 +277,7 @@ def test_owlbot_main_with_staging_patch_staging(hermetic_mock, nodejs_dlp):
     assert "export * as v2" not in staging_text
     assert "export * as v2" in text
 
+
 def test_owlbot_main_without_version():
     with util.copied_fixtures_dir(FIXTURES / "node_templates" / "no_version"):
         # just confirm it doesn't throw an exception.


### PR DESCRIPTION
Fixes #1433 

Making this a `chore` so it doesn't affect versioning of downstream repositories