### PR TITLE
build(node): add new jsteam + enforce branches up-to-date

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/sync-repo-settings.yaml
+++ b/synthtool/gcp/templates/node_library/.github/sync-repo-settings.yaml
@@ -3,7 +3,7 @@ branchProtectionRules:
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true
-    requiresStrictStatusChecks: false
+    requiresStrictStatusChecks: true
     requiredStatusCheckContexts:
       - "ci/kokoro: Samples test"
       - "ci/kokoro: System test"
@@ -15,3 +15,10 @@ branchProtectionRules:
       - cla/google
       - windows
       - OwlBot Post Processor
+permissionRules:
+  - team: yoshi-admins
+    permission: admin
+  - team: jsteam-admins
+    permission: admin
+  - team: jsteam
+    permission: push


### PR DESCRIPTION
* adds the new TeamSynced `jsteam`, which will ensure the right folks have access to libraries.
* enforce branches up-to-date.