### PR TITLE
chore(python): [autoapprove] add missing import for prerelease testing

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -19,6 +19,7 @@
 from __future__ import absolute_import
 import os
 import pathlib
+import re
 import shutil
 import warnings
 


### PR DESCRIPTION
https://github.com/googleapis/synthtool/pull/1455 added a nox session for prerelease testing however an `import` statement was missing.  My local code had the fix but PR 1455 did not. 

See https://source.cloud.google.com/results/invocations/f841273b-2479-4438-a4bf-65ed61d73907/log
```
nox > Running session prerelease_deps-3.8
nox > Creating virtual environment (virtualenv) using python3.8 in .nox/prerelease_deps-3-8
nox > python -m pip install --pre --no-deps --upgrade protobuf
nox > python -m pip install --pre --no-deps --upgrade googleapis-common-protos
nox > python -m pip install --pre --no-deps --upgrade google-auth
nox > python -m pip install --pre --no-deps --upgrade grpcio
nox > python -m pip install --pre --no-deps --upgrade grpcio-status
nox > python -m pip install --pre --no-deps --upgrade google-api-core
nox > python -m pip install --pre --no-deps --upgrade proto-plus
nox > python -m pip install --pre --no-deps --upgrade cryptography
nox > python -m pip install --pre --no-deps --upgrade pyasn1
nox > python -m pip install requests
nox > python -m pip install mock asyncmock pytest pytest-cov pytest-asyncio
nox > python -m pip install mock pytest google-cloud-testutils
nox > Session prerelease_deps-3.8 raised exception NameError("name 're' is not defined")
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/nox/sessions.py", line 695, in execute
    self.func(session)
  File "/usr/local/lib/python3.10/site-packages/nox/_decorators.py", line 68, in __call__
    return self.func(*args, **kwargs)
  File "/tmpfs/src/github/python-monitoring/noxfile.py", line 374, in prerelease_deps
    for match in re.finditer(
NameError: name 're' is not defined
```