### PR TITLE
chore: update dependencies for regapic

### DIFF
--- a/docker/owlbot/java/templates/poms/cloud_pom.xml.j2
+++ b/docker/owlbot/java/templates/poms/cloud_pom.xml.j2
@@ -59,6 +59,10 @@
       <artifactId>gax-grpc</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-httpjson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
     </dependency>
@@ -79,7 +83,19 @@
     <!-- Need testing utility classes for generated gRPC clients tests -->
     <dependency>
       <groupId>com.google.api</groupId>
+      <artifactId>gax</artifactId>
+      <classifier>testlib</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
+      <classifier>testlib</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-httpjson</artifactId>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>

--- a/docker/owlbot/java/templates/poms/cloud_pom.xml.j2
+++ b/docker/owlbot/java/templates/poms/cloud_pom.xml.j2
@@ -63,6 +63,18 @@
       <artifactId>gax-httpjson</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-common-protos</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-iam-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-iam-v1</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
     </dependency>

--- a/docker/owlbot/java/tests/new-client/golden/google-cloud-foo/pom.xml
+++ b/docker/owlbot/java/tests/new-client/golden/google-cloud-foo/pom.xml
@@ -75,18 +75,6 @@
       <artifactId>grpc-google-iam-v1</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.api.grpc</groupId>
-      <artifactId>grpc-google-common-protos</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api.grpc</groupId>
-      <artifactId>proto-google-iam-v1</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api.grpc</groupId>
-      <artifactId>grpc-google-iam-v1</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
     </dependency>

--- a/docker/owlbot/java/tests/new-client/golden/google-cloud-foo/pom.xml
+++ b/docker/owlbot/java/tests/new-client/golden/google-cloud-foo/pom.xml
@@ -75,10 +75,6 @@
       <artifactId>grpc-google-iam-v1</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.api</groupId>
-      <artifactId>gax-httpjson</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-common-protos</artifactId>
     </dependency>

--- a/docker/owlbot/java/tests/new-client/golden/google-cloud-foo/pom.xml
+++ b/docker/owlbot/java/tests/new-client/golden/google-cloud-foo/pom.xml
@@ -58,38 +58,38 @@
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
     </dependency>
-      <dependency>
-          <groupId>com.google.api</groupId>
-          <artifactId>gax-httpjson</artifactId>
-      </dependency>
-      <dependency>
-          <groupId>com.google.api.grpc</groupId>
-          <artifactId>grpc-google-common-protos</artifactId>
-      </dependency>
-      <dependency>
-          <groupId>com.google.api.grpc</groupId>
-          <artifactId>proto-google-iam-v1</artifactId>
-      </dependency>
-      <dependency>
-          <groupId>com.google.api.grpc</groupId>
-          <artifactId>grpc-google-iam-v1</artifactId>
-      </dependency>
-      <dependency>
-          <groupId>com.google.api</groupId>
-          <artifactId>gax-httpjson</artifactId>
-      </dependency>
-      <dependency>
-          <groupId>com.google.api.grpc</groupId>
-          <artifactId>grpc-google-common-protos</artifactId>
-      </dependency>
-      <dependency>
-          <groupId>com.google.api.grpc</groupId>
-          <artifactId>proto-google-iam-v1</artifactId>
-      </dependency>
-      <dependency>
-          <groupId>com.google.api.grpc</groupId>
-          <artifactId>grpc-google-iam-v1</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-httpjson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-common-protos</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-iam-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-iam-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-httpjson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-common-protos</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-iam-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-iam-v1</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
@@ -109,24 +109,24 @@
       <scope>test</scope>
     </dependency>
     <!-- Need testing utility classes for generated gRPC clients tests -->
-      <dependency>
-          <groupId>com.google.api</groupId>
-          <artifactId>gax</artifactId>
-          <classifier>testlib</classifier>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax</artifactId>
+      <classifier>testlib</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>com.google.api</groupId>
-          <artifactId>gax-httpjson</artifactId>
-          <classifier>testlib</classifier>
-          <scope>test</scope>
-      </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-httpjson</artifactId>
+      <classifier>testlib</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/docker/owlbot/java/tests/new-client/golden/google-cloud-foo/pom.xml
+++ b/docker/owlbot/java/tests/new-client/golden/google-cloud-foo/pom.xml
@@ -58,6 +58,38 @@
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
     </dependency>
+      <dependency>
+          <groupId>com.google.api</groupId>
+          <artifactId>gax-httpjson</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>com.google.api.grpc</groupId>
+          <artifactId>grpc-google-common-protos</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>com.google.api.grpc</groupId>
+          <artifactId>proto-google-iam-v1</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>com.google.api.grpc</groupId>
+          <artifactId>grpc-google-iam-v1</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>com.google.api</groupId>
+          <artifactId>gax-httpjson</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>com.google.api.grpc</groupId>
+          <artifactId>grpc-google-common-protos</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>com.google.api.grpc</groupId>
+          <artifactId>proto-google-iam-v1</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>com.google.api.grpc</groupId>
+          <artifactId>grpc-google-iam-v1</artifactId>
+      </dependency>
     <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
@@ -77,12 +109,24 @@
       <scope>test</scope>
     </dependency>
     <!-- Need testing utility classes for generated gRPC clients tests -->
-    <dependency>
+      <dependency>
+          <groupId>com.google.api</groupId>
+          <artifactId>gax</artifactId>
+          <classifier>testlib</classifier>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>com.google.api</groupId>
+          <artifactId>gax-httpjson</artifactId>
+          <classifier>testlib</classifier>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <profiles>

--- a/synthtool/gcp/templates/java_library/.kokoro/common.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/common.sh
@@ -56,3 +56,5 @@ function retry_with_backoff {
 function now() { date +"%Y-%m-%d %H:%M:%S" | tr -d '\n'; }
 function msg() { println "$*" >&2; }
 function println() { printf '%s\n' "$(now) $*"; }
+
+## Helper comment to trigger updated repo dependency release


### PR DESCRIPTION
Adding in new dependencies into the template that are needed for REGAPIC. 

This change should also trigger an update to all repos to use the latest version of the postprocessor image.