### PR TITLE
feat: java template no longer require clirr

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/sync-repo-settings.yaml
+++ b/synthtool/gcp/templates/java_library/.github/sync-repo-settings.yaml
@@ -44,7 +44,6 @@ branchProtectionRules:
   - "dependencies (8)"
   - "dependencies (11)"
   - "lint"
-  - "clirr"
   - "units (8)"
   - "units (11)"
   - "Kokoro - Test: Integration"


### PR DESCRIPTION
The Java repository template does not require clirr any more.