### PR TITLE
fix: enable longpaths support for windows test

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -39,6 +39,8 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
+    - name: Support longpaths
+      run: git config --system core.longpaths true
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
The `windows` test is is failing in some repos because the generated snippet files are using names that are longer than the standard 260 characters. For instance:

```
Error: error: unable to create file samples/snippets/generated/com/google/cloud/recaptchaenterprise/v1beta1/recaptchaenterpriseservicev1beta1client/annotateassessment/SyncAnnotateAssessmentAssessmentnameAnnotateassessmentrequestannotation.java: Filename too long
```

This should enable usage of filenames that are longer than 260 characters.