### PR TITLE
docs(python): Use rst-style links in README template for python branches

### DIFF
--- a/synthtool/gcp/templates/python_library/README.rst
+++ b/synthtool/gcp/templates/python_library/README.rst
@@ -55,18 +55,22 @@ Code samples and snippets live in the `samples/` folder.
 
 Supported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Our client libraries are compatible with all current [active](https://devguide.python.org/devcycle/#in-development-main-branch) and [maintenance](https://devguide.python.org/devcycle/#maintenance-branches) versions of
+Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
 Python >= 3.7
+
+.. _active: https://devguide.python.org/devcycle/#in-development-main-branch
+.. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Python <= 3.6
 
-If you are using an [end-of-life](https://devguide.python.org/devcycle/#end-of-life-branches)
+If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.
 
+.. _end-of-life: https://devguide.python.org/devcycle/#end-of-life-branches
 
 Mac/Linux
 ^^^^^^^^^


### PR DESCRIPTION
The Markdown-style links do not render as intended when viewed by
GitHub.