### PR TITLE
fix(nodejs-mono-repo): ignore gapic-node-templating that has an OwlBot.yaml file as a template

### DIFF
--- a/synthtool/languages/node_mono_repo.py
+++ b/synthtool/languages/node_mono_repo.py
@@ -253,9 +253,11 @@ def walk_through_owlbot_dirs(dir: Path):
     A list of client libs
     """
     owlbot_dirs = []
-    packages_to_exclude = [r'gapic-node-templating']
+    packages_to_exclude = [r"gapic-node-templating"]
     for path_object in dir.glob("packages/**/.OwlBot.yaml"):
-        if path_object.is_file() and not re.search('(?:% s)' % '|'.join(packages_to_exclude), str(Path(path_object))):
+        if path_object.is_file() and not re.search(
+            "(?:% s)" % "|".join(packages_to_exclude), str(Path(path_object))
+        ):
             owlbot_dirs.append(str(Path(path_object).parents[0]))
 
     return owlbot_dirs

--- a/synthtool/languages/node_mono_repo.py
+++ b/synthtool/languages/node_mono_repo.py
@@ -253,8 +253,9 @@ def walk_through_owlbot_dirs(dir: Path):
     A list of client libs
     """
     owlbot_dirs = []
+    packages_to_exclude = [r'gapic-node-templating']
     for path_object in dir.glob("packages/**/.OwlBot.yaml"):
-        if path_object.is_file():
+        if path_object.is_file() and not re.search('(?:% s)' % '|'.join(packages_to_exclude), str(Path(path_object))):
             owlbot_dirs.append(str(Path(path_object).parents[0]))
 
     return owlbot_dirs

--- a/tests/fixtures/nodejs_mono_repo_with_staging/packages/gapic-node-templating/.OwlBot.yaml
+++ b/tests/fixtures/nodejs_mono_repo_with_staging/packages/gapic-node-templating/.OwlBot.yaml
@@ -1,0 +1,1 @@
+empty file


### PR DESCRIPTION
see: https://github.com/googleapis/google-cloud-node/pull/3228

Fails because the directory walk-through attempts to run the post-processor on gapic-node-templating because it contains a .Owlbot.yaml file, but just as a template


Note: current tests capture this behavior by adding the appropriate fixture