### PR TITLE
ci: adjust owlbot-java for monorepo

### DIFF
--- a/docker/owlbot/java/bin/entrypoint.sh
+++ b/docker/owlbot/java/bin/entrypoint.sh
@@ -54,8 +54,9 @@ if [ $(find . -type d -name 'java-*' |wc -l) -gt 10 ];then
   if [ -d owl-bot-staging ]; then
     for module in $(ls owl-bot-staging); do
       mv "owl-bot-staging/$module" "$module/owl-bot-staging"
-      cd $module
+      pushd $module
       processModule
+      popd
     done
     rm -r owl-bot-staging
   else

--- a/docker/owlbot/java/bin/entrypoint.sh
+++ b/docker/owlbot/java/bin/entrypoint.sh
@@ -49,8 +49,9 @@ function processModule() {
   echo "...done"
 }
 
-if [ "$(find . -type d -name 'java-*' |wc -l)" -gt 10 ];then
-  # Monorepo (googleapis/google-cloud-java)
+if [ "$(ls */.OwlBot.yaml|wc -l)" -gt 1 ];then
+  # Monorepo (googleapis/google-cloud-java) has multiple OwlBot.yaml config
+  # files in the modules.
   echo "Processing monorepo"
   if [ -d owl-bot-staging ]; then
     # The content of owl-bot-staging is controlled by Owlbot.yaml files in
@@ -90,7 +91,7 @@ if [ "$(find . -type d -name 'java-*' |wc -l)" -gt 10 ];then
     done
   fi
 else
-  # Individual repository
-  echo "Processing a single repo"
+  # Split repository
+  echo "Processing a split repo"
   processModule
 fi

--- a/docker/owlbot/java/bin/entrypoint.sh
+++ b/docker/owlbot/java/bin/entrypoint.sh
@@ -51,7 +51,7 @@ function processModule() {
 
 if [ "$(find . -type d -name 'java-*' |wc -l)" -gt 10 ];then
   # Monorepo
-  ehco "Processing monorepo"
+  echo "Processing monorepo"
   if [ -d owl-bot-staging ]; then
     for module in $(ls owl-bot-staging); do
       mv "owl-bot-staging/$module" "$module/owl-bot-staging"
@@ -78,6 +78,6 @@ if [ "$(find . -type d -name 'java-*' |wc -l)" -gt 10 ];then
   fi
 else
   # Individual repository
-  ehco "Processing a single repo"
+  echo "Processing a single repo"
   processModule
 fi

--- a/docker/owlbot/java/bin/entrypoint.sh
+++ b/docker/owlbot/java/bin/entrypoint.sh
@@ -15,33 +15,54 @@
 
 set -e
 
-# templates
-echo "Generating templates..."
-/owlbot/bin/write_templates.sh
-echo "...done"
+# Runs template and etc in current working directory
+function processModule() {
+  # templates
+  echo "Generating templates..."
+  /owlbot/bin/write_templates.sh
+  echo "...done"
 
-# write or restore pom.xml files
-echo "Generating missing pom.xml..."
-/owlbot/bin/write_missing_pom_files.sh
-echo "...done"
+  # write or restore pom.xml files
+  echo "Generating missing pom.xml..."
+  /owlbot/bin/write_missing_pom_files.sh
+  echo "...done"
 
-# write or restore clirr-ignored-differences.xml
-echo "Generating clirr-ignored-differences.xml..."
-/owlbot/bin/write_clirr_ignore.sh
-echo "...done"
+  # write or restore clirr-ignored-differences.xml
+  echo "Generating clirr-ignored-differences.xml..."
+  /owlbot/bin/write_clirr_ignore.sh
+  echo "...done"
 
-# fix license headers
-echo "Fixing missing license headers..."
-/owlbot/bin/fix_license_headers.sh
-echo "...done"
+  # fix license headers
+  echo "Fixing missing license headers..."
+  /owlbot/bin/fix_license_headers.sh
+  echo "...done"
 
-# TODO: re-enable this once we resolve thrashing
-# restore license headers years
-# echo "Restoring copyright years..."
-# /owlbot/bin/restore_license_headers.sh
-# echo "...done"
+  # TODO: re-enable this once we resolve thrashing
+  # restore license headers years
+  # echo "Restoring copyright years..."
+  # /owlbot/bin/restore_license_headers.sh
+  # echo "...done"
 
-# ensure formatting on all .java files in the repository
-echo "Reformatting source..."
-/owlbot/bin/format_source.sh
-echo "...done"
+  # ensure formatting on all .java files in the repository
+  echo "Reformatting source..."
+  /owlbot/bin/format_source.sh
+  echo "...done"
+}
+
+if [ $(find . -type d -name 'java-*' |wc -l) -gt 10 ];then
+  # Monorepo
+  if [ -d owl-bot-staging ]; then
+    for module in $(ls owl-bot-staging); do
+      mv "owl-bot-staging/$module" "$module/owl-bot-staging"
+      cd $module
+      processModule
+    done
+    rm -r owl-bot-staging
+  else
+    echo "In monorepo but no owl-bot-staging. Not sure which module to process"
+    # Find the files that were touched by the last commit.
+  fi
+else
+  # Individual repository
+  processModule
+fi


### PR DESCRIPTION
Updating OwlBot Java Postprocessor (owlbot-java) to work for monorepo (google-cloud-java).

Here are 3 example commits in 3 pull requests with my local Dockerfile build:

- https://github.com/googleapis/google-cloud-java/pull/8026/commits/6ce601572bf85cf4b2e7da4de6716a2342c0c4b2
- https://github.com/googleapis/google-cloud-java/pull/8020/commits/83d0bffc36989e4c191522ff4a3e9972343183e1
- https://github.com/googleapis/google-cloud-java/pull/8018/commits/00ec0a09e314b1a1f5c8ad00465bfb27aff231fa

(In the pull request check, OwlBot Postprocessor was failing because I didn't update the owlbot-java image used in the check yet)

# Test

Here is how I tested this change:

```
# In synthtool directory
$ git pull && docker build -f docker/owlbot/java/Dockerfile .
...
Successfully built 07d37702324a
```

```
# In google-cloud-java directory
$ gh pr checkout 8026
$ docker run --rm -v $(pwd):/workspace -w /workspace 07d37702324a # This is the id of container built above
$ sudo chown -R $(id -u):$(id -g) java-assured-workloads
$ git add --all
$ git commit -m 'ci: manual owlbot'
```

Then I checked the pull requests to see files from owl-bot-staging has been extracted.

