### PR TITLE
fix: [PHP] allow for explicit version_string

### DIFF
--- a/synthtool/languages/php.py
+++ b/synthtool/languages/php.py
@@ -83,6 +83,7 @@ def owlbot_copy_version(
     src: Path,
     dest: Path,
     copy_excludes: typing.Optional[typing.List[str]] = None,
+    version_string = None,
 ) -> None:
     """Copies files from a version subdirectory."""
     logger.debug("owlbot_copy_version called from %s to %s", src, dest)
@@ -95,8 +96,9 @@ def owlbot_copy_version(
     if not entries:
         logger.info("there is no src directory '%s' to copy", src_dir)
         return
-    version_string = os.path.basename(os.path.basename(next(entries))).lower()
-    logger.debug("version_string detected: %s", version_string)
+    if not version_string:
+        version_string = os.path.basename(os.path.basename(next(entries))).lower()
+        logger.debug("version_string detected: %s", version_string)
 
     # copy all src including partial veneer classes
     s.move([src / "src"], dest / "src", merge=_merge, excludes=copy_excludes)

--- a/synthtool/languages/php.py
+++ b/synthtool/languages/php.py
@@ -83,7 +83,7 @@ def owlbot_copy_version(
     src: Path,
     dest: Path,
     copy_excludes: typing.Optional[typing.List[str]] = None,
-    version_string: None,
+    version_string: str = None,
 ) -> None:
     """Copies files from a version subdirectory."""
     logger.debug("owlbot_copy_version called from %s to %s", src, dest)

--- a/synthtool/languages/php.py
+++ b/synthtool/languages/php.py
@@ -83,7 +83,7 @@ def owlbot_copy_version(
     src: Path,
     dest: Path,
     copy_excludes: typing.Optional[typing.List[str]] = None,
-    version_string = None,
+    version_string: None,
 ) -> None:
     """Copies files from a version subdirectory."""
     logger.debug("owlbot_copy_version called from %s to %s", src, dest)


### PR DESCRIPTION
For APIs which do not have a `version_string` (e.g. [google.longrunning](https://github.com/googleapis/googleapis/tree/master/google/longrunning)), we'd like to pass in the "version string" explicitly in order for synthtool / owlbot to be able to copy the protos correctly. In this case, it's not really a version string, but the root path for copying the protobuf message files.