### PR TITLE
chore(python): fix prerelease session [autoapprove]

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -374,12 +374,6 @@ def prerelease_deps(session):
 
     session.install(*constraints_deps)
 
-    if os.path.exists("samples/snippets/requirements.txt"):
-        session.install("-r", "samples/snippets/requirements.txt")
-
-    if os.path.exists("samples/snippets/requirements-test.txt"):
-        session.install("-r", "samples/snippets/requirements-test.txt")
-
     prerel_deps = [
         "protobuf",
         # dependency of grpc
@@ -430,17 +424,5 @@ def prerelease_deps(session):
             "--verbose",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,
-            *session.posargs,
-        )
-
-    snippets_test_path = os.path.join("samples", "snippets")
-
-    # Only run samples tests if found.
-    if os.path.exists(snippets_test_path):
-        session.run(
-            "py.test",
-            "--verbose",
-            f"--junitxml=system_{session.python}_sponge_log.xml",
-            snippets_test_path,
             *session.posargs,
         )

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -348,7 +348,8 @@ def prerelease_deps(session):
 
     # Install all dependencies
     session.install("-e", ".[all, tests, tracing]")
-    session.install(*UNIT_TEST_STANDARD_DEPENDENCIES)
+    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_DEPENDENCIES
+    session.install(*unit_deps_all)
     system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
     session.install(*system_deps_all)
 
@@ -415,11 +416,31 @@ def prerelease_deps(session):
     system_test_folder_path = os.path.join("tests", "system")
 
     # Only run system tests if found.
-    if os.path.exists(system_test_path) or os.path.exists(system_test_folder_path):
-        session.run("py.test", "tests/system")
+    if os.path.exists(system_test_path):
+        session.run(
+            "py.test",
+            "--verbose",
+            f"--junitxml=system_{session.python}_sponge_log.xml",
+            system_test_path,
+            *session.posargs,
+        )
+    if os.path.exists(system_test_folder_path):
+        session.run(
+            "py.test",
+            "--verbose",
+            f"--junitxml=system_{session.python}_sponge_log.xml",
+            system_test_folder_path,
+            *session.posargs,
+        )
 
     snippets_test_path = os.path.join("samples", "snippets")
 
     # Only run samples tests if found.
     if os.path.exists(snippets_test_path):
-        session.run("py.test", "samples/snippets")
+        session.run(
+            "py.test",
+            "--verbose",
+            f"--junitxml=system_{session.python}_sponge_log.xml",
+            snippets_test_path,
+            *session.posargs,
+        )

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -348,7 +348,7 @@ def prerelease_deps(session):
 
     # Install all dependencies
     session.install("-e", ".[all, tests, tracing]")
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_DEPENDENCIES
+    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
     session.install(*unit_deps_all)
     system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
     session.install(*system_deps_all)


### PR DESCRIPTION
This PR fixes the prerelease session. I tested the changes by running `docker build -f docker/owlbot/python/Dockerfile -t prerelease .` in this repo, then running `docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo prerelease` in downstream repositories. 

I removed the samples testing from the prerelease session as the testing for samples is more complicated as there is a separate docker image and a lot of custom logic. A separate presubmit check should be added for testing prerelease versions of samples.