### PR TITLE
chore(python): use autogenerated setup.py

### DIFF
--- a/synthtool/languages/python.py
+++ b/synthtool/languages/python.py
@@ -255,7 +255,7 @@ def owlbot_main() -> None:
             if clean_up_generated_samples:
                 shutil.rmtree("samples/generated_samples", ignore_errors=True)
                 clean_up_generated_samples = False
-            s.move([library], excludes=["setup.py", "README.rst", "docs/index.rst"])
+            s.move([library], excludes=["README.rst", "docs/index.rst"])
         s.remove_staging_dirs()
 
         templated_files = CommonTemplates().py_library(


### PR DESCRIPTION
Towards [b/234878122](http://b/234878122)

This PR modifies `owlbot_main()`, which is used in the absence of `owlbot.py`[1], to copy the autogenerated `setup.py` rather than use a handwritten version.

[1] See the code below

https://github.com/googleapis/synthtool/blob/6d304d5520aee517aa8b54c2eb8bd1d9fcca8d0f/docker/owlbot/python/entrypoint.sh#L19-L23

https://github.com/googleapis/synthtool/blob/6d304d5520aee517aa8b54c2eb8bd1d9fcca8d0f/synthtool/languages/python.py#L278-L279