### PR TITLE
fix: update google-gax and remove obsolete deps

### DIFF
--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -47,9 +47,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@2.29.1 typescript@3.9.9 \
-    chalk@4.1.2 escodegen@2.0.0 espree@7.3.1 estraverse@5.2.0 glob@7.2.0 jsdoc@3.6.7 \
-    minimist@1.2.5 semver@7.3.5 tmp@0.2.1 uglify-js@3.14.2
+RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.2.1 typescript@4.7.4
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs_mono_repo/Dockerfile
+++ b/docker/owlbot/nodejs_mono_repo/Dockerfile
@@ -47,9 +47,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.1.4 typescript@4.6.4 \
-    chalk@4.1.2 escodegen@2.0.0 espree@7.3.1 estraverse@5.2.0 glob@7.2.0 jsdoc@3.6.7 \
-    minimist@1.2.5 semver@7.3.5 tmp@0.2.1 uglify-js@3.14.2
+RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.2.1 typescript@4.7.4
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs_mono_repo/entrypoint.sh" ]


### PR DESCRIPTION
@SurferJeffAtGoogle I think I found the right place to update, please let me know what should be done to rebuild these images for owlbot.

The new version of `google-gax` should pull all the extra dependencies that were listed explicitly, so I believe there's no need to list them one by one anymore.