### PR TITLE
chore(python): exclude path .kokoro/requirements.txt in renovate.json [autoapprove]

### DIFF
--- a/synthtool/gcp/templates/python_library/renovate.json
+++ b/synthtool/gcp/templates/python_library/renovate.json
@@ -5,7 +5,7 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [".pre-commit-config.yaml"],
+  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }


### PR DESCRIPTION
This PR will prevent renovate bot from opening PRs such as [this one](https://github.com/googleapis/python-apigee-registry/pull/18/commits/3d51e0fdabaefee68d4cf78777ac26f84fc09262) for the templated file [here](https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/.kokoro/requirements.txt). 