### PR TITLE
fix: do not import the whole google-gax from proto JS

### DIFF
--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -47,7 +47,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.2.1 typescript@4.7.4
+RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.3.0 typescript@4.7.4
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs_mono_repo/Dockerfile
+++ b/docker/owlbot/nodejs_mono_repo/Dockerfile
@@ -47,7 +47,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.2.1 typescript@4.7.4
+RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.3.0 typescript@4.7.4
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs_mono_repo/entrypoint.sh" ]


### PR DESCRIPTION
Update `google-gax` version to 3.3.0. The PR title corresponds to what I would like to see in the libraries' release notes.

We will need this since it has the new `compileProtos` script that will help us uncouple gRPC and REST transports for Firestore.