### PR TITLE
chore(python): exclude `grpcio==1.49.0rc1` in tests

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -209,7 +209,9 @@ def unit(session):
 def install_systemtest_dependencies(session, *constraints):
 
     # Use pre-release gRPC for system tests.
-    session.install("--pre", "grpcio")
+    # Exclude version 1.49.0rc1 which has a known issue.
+    # See https://github.com/grpc/grpc/pull/30642
+    session.install("--pre", "grpcio!=1.49.0rc1")
 
     session.install(*SYSTEM_TEST_STANDARD_DEPENDENCIES, *constraints)
 
@@ -379,7 +381,8 @@ def prerelease_deps(session):
         # dependency of grpc
         "six",
         "googleapis-common-protos",
-        "grpcio",
+        # Exclude version 1.49.0rc1 which has a known issue. See https://github.com/grpc/grpc/pull/30642
+        "grpcio!=1.49.0rc1",
         "grpcio-status",
         "google-api-core",
         "proto-plus",


### PR DESCRIPTION
This PR excludes `grpcio==1.49.0rc1` in tests due to a [known issue](https://github.com/grpc/grpc/pull/30642) which is causing pre-release tests in downstream repositories to fail.  For example, see [this build log](https://source.cloud.google.com/results/invocations/5e0801a2-992b-4bf2-908f-492f24121e66/log).

I tested the change by building the post processor owlbot image locally using the following:
```
docker build -f docker/owlbot/python/Dockerfile -t removegrpcio149rc1 .
```

I then ran the post processor in a downstream repo:
```
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo removegrpcio149rc1
```

See the changes in the following PR:
https://github.com/googleapis/python-asset/pull/482