### PR TITLE
fix(node-mono-repo): add dot to make regex match anything

### DIFF
--- a/synthtool/languages/node_mono_repo.py
+++ b/synthtool/languages/node_mono_repo.py
@@ -70,7 +70,7 @@ def copy_list_sample_to_quickstart(relative_dir: str):
     # If there aren't any list-methods, just pick the first generated sample
     if not samples:
         samples = common.get_sample_metadata_files(
-            Path(relative_dir, _GENERATED_SAMPLES_DIRECTORY).resolve(), regex=r"*"
+            Path(relative_dir, _GENERATED_SAMPLES_DIRECTORY).resolve(), regex=r".*"
         )
     # Confirm that the file exists (array could be empty)
     if Path(relative_dir, samples[0]).resolve():


### PR DESCRIPTION
Fixes error in post processor here: https://github.com/googleapis/google-cloud-node/pull/3308

```
raise source.error("nothing to repeat",
```

https://stackoverflow.com/questions/3675144/regex-error-nothing-to-repeat