### PR TITLE
chore: try some new parameters for renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
-  "extends": [
-    "config:base",
-    ":disableDependencyDashboard"
-  ]
+  "internalChecksFilter": "strict",
+  "stabilityDays": 90,
+  "timezone": "America/Los_Angeles",
+  "schedule": "weekly"
 }


### PR DESCRIPTION
This will turn on the dashboard.  A dashboard will be useful to track new versions that are waiting for their 90 stable days to elapse.