### PR TITLE
chore(python): update .kokoro/requirements.txt

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/requirements.txt
+++ b/synthtool/gcp/templates/python_library/.kokoro/requirements.txt
@@ -241,6 +241,10 @@ importlib-metadata==4.12.0 \
     # via
     #   -r requirements.in
     #   twine
+jaraco-classes==3.2.2 \
+    --hash=sha256:6745f113b0b588239ceb49532aa09c3ebb947433ce311ef2f8e3ad64ebb74594 \
+    --hash=sha256:e6ef6fd3fcf4579a7a019d87d1e56a883f4e4c35cfe925f86731abc58804e647
+    # via keyring
 jeepney==0.8.0 \
     --hash=sha256:5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806 \
     --hash=sha256:c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755
@@ -299,6 +303,10 @@ markupsafe==2.1.1 \
     --hash=sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a \
     --hash=sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7
     # via jinja2
+more-itertools==8.14.0 \
+    --hash=sha256:1bc4f91ee5b1b31ac7ceacc17c09befe6a40a503907baf9c839c229b5095cfd2 \
+    --hash=sha256:c09443cd3d5438b8dafccd867a6bc1cb0894389e90cb53d227456b0b0bccb750
+    # via jaraco-classes
 nox==2022.8.7 \
     --hash=sha256:1b894940551dc5c389f9271d197ca5d655d40bdc6ccf93ed6880e4042760a34b \
     --hash=sha256:96cca88779e08282a699d672258ec01eb7c792d35bbbf538c723172bce23212c


### PR DESCRIPTION
The release script failed in [this log](https://fusion2.corp.google.com/invocations/0688d329-b69a-4d07-8bea-e011a1993478/log) with 

```
Collecting jaraco.classes
ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    jaraco.classes from [https://files.pythonhosted.org/packages/8f/e6/f92d21f915cee7acf1cfe3e0ec60b8e9888dcf40a9814e3838a87ba487d0/jaraco.classes-3.2.2-py3-none-any.whl#sha256=e6ef6fd3fcf4579a7a019d87d1e56a883f4e4c35cfe925f86731abc58804e647](https://www.google.com/url?q=https://files.pythonhosted.org/packages/8f/e6/f92d21f915cee7acf1cfe3e0ec60b8e9888dcf40a9814e3838a87ba487d0/jaraco.classes-3.2.2-py3-none-any.whl%23sha256%3De6ef6fd3fcf4579a7a019d87d1e56a883f4e4c35cfe925f86731abc58804e647&sa=D) (from keyring==23.9.0->-r github/python-bigquery-data-exchange/.kokoro/requirements.txt (line 254))
```

I believe the issue is that the requirements.txt file is out of date and doesn't include `jaraco.classes`