### PR TITLE
chore(python): exclude setup.py in renovate config

### DIFF
--- a/synthtool/gcp/templates/python_library/renovate.json
+++ b/synthtool/gcp/templates/python_library/renovate.json
@@ -5,7 +5,7 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt"],
+  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }


### PR DESCRIPTION
I'd like to make a change to the renovate bot config to exclude `setup.py` for 2 reasons:
1) It's proposing incorrect changes. For example, see https://github.com/googleapis/python-bigtable/pull/664/files where it is proposing to restrict the allowed range of google-api-core
2) The `setup.py` for autogenerated libraries is currently handwritten. We're planning to migrate to an autogenerated setup.py in certain repositories. In that case, we wouldn't want renovatebot to propose changes since we would be autogenerating it.