### PR TITLE
chore(python): Detecting tests in nested directories.

### DIFF
--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -207,8 +207,8 @@ def _session_tests(
     session: nox.sessions.Session, post_install: Callable = None
 ) -> None:
     # check for presence of tests
-    test_list = glob.glob("*_test.py") + glob.glob("test_*.py")
-    test_list.extend(glob.glob("tests"))
+    test_list = glob.glob("*_test.py", recursive=True) + glob.glob("test_*.py", recursive=True)
+    test_list.extend(glob.glob("tests", recursive=True))
 
     if len(test_list) == 0:
         print("No tests found, skipping directory.")

--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -207,8 +207,8 @@ def _session_tests(
     session: nox.sessions.Session, post_install: Callable = None
 ) -> None:
     # check for presence of tests
-    test_list = glob.glob("*_test.py", recursive=True) + glob.glob("test_*.py", recursive=True)
-    test_list.extend(glob.glob("tests", recursive=True))
+    test_list = glob.glob("**/*_test.py", recursive=True) + glob.glob("**/test_*.py", recursive=True)
+    test_list.extend(glob.glob("**/tests", recursive=True))
 
     if len(test_list) == 0:
         print("No tests found, skipping directory.")


### PR DESCRIPTION
Sometimes tests are not on the same level as the current working directory. PyTest doesn't have a problem with this, neither should we.