### PR TITLE
docs: fix broken link in Node.js README

### DIFF
--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -87,7 +87,7 @@ also contains samples.
 {% endif %}
 ## Supported Node.js Versions
 
-Our client libraries follow the [Node.js release schedule](https://nodejs.org/en/about/releases/).
+Our client libraries follow the [Node.js release schedule](https://github.com/nodejs/release#release-schedule).
 Libraries are compatible with all current _active_ and _maintenance_ versions of
 Node.js.
 If you are using an end-of-life version of Node.js, we recommend that you update

--- a/synthtool/gcp/templates/node_mono_repo_library/README.md
+++ b/synthtool/gcp/templates/node_mono_repo_library/README.md
@@ -87,7 +87,7 @@ also contains samples.
 {% endif %}
 ## Supported Node.js Versions
 
-Our client libraries follow the [Node.js release schedule](https://nodejs.org/en/about/releases/).
+Our client libraries follow the [Node.js release schedule](https://github.com/nodejs/release#release-schedule).
 Libraries are compatible with all current _active_ and _maintenance_ versions of
 Node.js.
 If you are using an end-of-life version of Node.js, we recommend that you update

--- a/tests/fixtures/nodejs-dlp-with-staging/README.md
+++ b/tests/fixtures/nodejs-dlp-with-staging/README.md
@@ -163,7 +163,7 @@ also contains samples.
 
 ## Supported Node.js Versions
 
-Our client libraries follow the [Node.js release schedule](https://nodejs.org/en/about/releases/).
+Our client libraries follow the [Node.js release schedule](https://github.com/nodejs/release#release-schedule).
 Libraries are compatible with all current _active_ and _maintenance_ versions of
 Node.js.
 

--- a/tests/fixtures/nodejs-dlp/README.md
+++ b/tests/fixtures/nodejs-dlp/README.md
@@ -163,7 +163,7 @@ also contains samples.
 
 ## Supported Node.js Versions
 
-Our client libraries follow the [Node.js release schedule](https://nodejs.org/en/about/releases/).
+Our client libraries follow the [Node.js release schedule](https://github.com/nodejs/release#release-schedule).
 Libraries are compatible with all current _active_ and _maintenance_ versions of
 Node.js.
 

--- a/tests/fixtures/nodejs_mono_repo_with_staging/packages/dlp/README.md
+++ b/tests/fixtures/nodejs_mono_repo_with_staging/packages/dlp/README.md
@@ -163,7 +163,7 @@ also contains samples.
 
 ## Supported Node.js Versions
 
-Our client libraries follow the [Node.js release schedule](https://nodejs.org/en/about/releases/).
+Our client libraries follow the [Node.js release schedule](https://github.com/nodejs/release#release-schedule).
 Libraries are compatible with all current _active_ and _maintenance_ versions of
 Node.js.
 


### PR DESCRIPTION
The page on nodejs.org became 404, which unfortunately means we need to regenerate all READMEs.