### PR TITLE
ci: update to use hashed requirements.txt for pip

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/build.sh
@@ -36,7 +36,7 @@ export PROJECT_ID=$(cat "${KOKORO_GFILE_DIR}/project-id.json")
 # Remove old nox
 python3 -m pip uninstall --yes --quiet nox-automation
 
-# Install nox
+# Install dependencies
 python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 python3 -m nox --version
 

--- a/synthtool/gcp/templates/python_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/build.sh
@@ -37,7 +37,7 @@ export PROJECT_ID=$(cat "${KOKORO_GFILE_DIR}/project-id.json")
 python3 -m pip uninstall --yes --quiet nox-automation
 
 # Install dependencies
-python3 -m pip install --require-hashes -r .kokoro/requirements.txt
+python3 -m pip install --require-hashes -r ./.kokoro/requirements.txt
 python3 -m nox --version
 
 # If this is a continuous build, send the test log to the FlakyBot.

--- a/synthtool/gcp/templates/python_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/build.sh
@@ -37,7 +37,7 @@ export PROJECT_ID=$(cat "${KOKORO_GFILE_DIR}/project-id.json")
 python3 -m pip uninstall --yes --quiet nox-automation
 
 # Install nox
-python3 -m pip install --upgrade --quiet nox
+python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 python3 -m nox --version
 
 # If this is a continuous build, send the test log to the FlakyBot.

--- a/synthtool/gcp/templates/python_library/.kokoro/test-samples-impl.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/test-samples-impl.sh
@@ -32,8 +32,8 @@ export PYTHONUNBUFFERED=1
 # Debug: show build environment
 env | grep KOKORO
 
-# Install nox
-python3.9 -m pip install --upgrade --quiet nox
+# Install dependencies
+python3.9 -m pip install --require-hashes -r .kokoro/requirements.txt
 
 # Use secrets acessor service account to get secrets
 if [[ -f "${KOKORO_GFILE_DIR}/secrets_viewer_service_account.json" ]]; then

--- a/synthtool/gcp/templates/python_library/.kokoro/test-samples-impl.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/test-samples-impl.sh
@@ -33,7 +33,7 @@ export PYTHONUNBUFFERED=1
 env | grep KOKORO
 
 # Install dependencies
-python3.9 -m pip install --require-hashes -r .kokoro/requirements.txt
+python3.9 -m pip install --require-hashes -r ./.kokoro/requirements.txt
 
 # Use secrets acessor service account to get secrets
 if [[ -f "${KOKORO_GFILE_DIR}/secrets_viewer_service_account.json" ]]; then


### PR DESCRIPTION
Updating the rest of `pip install` found without using hashes. I think the directory can be just `.kokoro/requirements.txt` rather than `github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/requirements.txt`, confirmed it for `build.sh` but unsure about `test-samples-impl.sh` file. Please let me know if otherwise.

Although for testing purposes they do not need to be updated, wanted to make sure there's full coverage while we're working on this.

Updating GitHub Actions seemed a lot more harder to do this with hashes, and I think they'd be much harder for unexpected results to arise so going to leave them as is.