### PR TITLE
chore: update google-gax to 3.5.2, protobuf.js to 7.1.1

### DIFF
--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -47,7 +47,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.3.0 typescript@4.7.4
+RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.5.1 typescript@4.7.4
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -47,7 +47,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.5.1 typescript@4.7.4
+RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.5.2 typescript@4.7.4
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs_mono_repo/Dockerfile
+++ b/docker/owlbot/nodejs_mono_repo/Dockerfile
@@ -47,7 +47,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.5.1 typescript@4.7.4
+RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.5.2 typescript@4.7.4
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs_mono_repo/entrypoint.sh" ]

--- a/docker/owlbot/nodejs_mono_repo/Dockerfile
+++ b/docker/owlbot/nodejs_mono_repo/Dockerfile
@@ -47,7 +47,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
-RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.3.0 typescript@4.7.4
+RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.5.1 typescript@4.7.4
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs_mono_repo/entrypoint.sh" ]


### PR DESCRIPTION
`google-gax` v3.5.2 depends on `protobufjs` v7.1.1 that includes a fix for the bug that breaks generation of nodejs-bigquery-storage.