### PR TITLE
chore: let renovate ignore all the subdirectories

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "schedule:weekly"
   ],
+  "ignorePaths": ["/*/**"],
   "internalChecksFilter": "strict",
   "stabilityDays": 30,
   "timezone": "America/Los_Angeles"


### PR DESCRIPTION
We still want to update the top level requirements.txt.