### PR TITLE
chore: add library version to snippet metadata

### DIFF
--- a/synthtool/languages/python.py
+++ b/synthtool/languages/python.py
@@ -184,7 +184,9 @@ def get_library_version() -> packaging_version.Version:
         match = re.search(VERSION_REGEX, Path(p).read_text())
 
         if match is not None:
-            library_version = packaging_version.Version(match.group("library_version_string"))
+            library_version = packaging_version.Version(
+                match.group("library_version_string")
+            )
             break
 
     else:

--- a/synthtool/languages/python.py
+++ b/synthtool/languages/python.py
@@ -172,10 +172,11 @@ def get_library_version() -> packaging_version.Version:
     Raises:
         RuntimeError: If no version string found.
     """
-    version_paths = list(Path(".").glob("google/**/version.py")) + [Path("setup.py")]
+    version_paths = list(Path(".").glob("google/**/*version.py")) + [Path("setup.py")]
 
-    # In version.py:    __version__ = "1.5.2"
-    # In setup.py:      version = "1.5.2"
+    # In version.py:       __version__ = "1.5.2"
+    # In gapic_version.py: __version__ = "1.5.2"
+    # In setup.py:             version = "1.5.2"
     VERSION_REGEX = (
         r"(?:__)?version(?:__)?\s*=\s*[\"'](?P<library_version_string>\d\.[\d\.]+)[\"']"
     )
@@ -290,6 +291,10 @@ def owlbot_main() -> None:
 
     configure_previous_major_version_branches()
     library_version_string = str(get_library_version())
+
+    # The library version number added here is the most recently released version.
+    # At the next library release time, release-please updates the version number
+    # to the correct one.
     common.update_library_version(library_version_string, _GENERATED_SAMPLES_DIRECTORY)
 
 

--- a/tests/test_python_library.py
+++ b/tests/test_python_library.py
@@ -192,7 +192,7 @@ def test_get_library_version(fixtures_dir):
         shutil.copy(result, Path(".github/release-please.yml"))
 
         version = python.get_library_version()
-        assert version == packaging_version.Version('2.11.0')
+        assert version == packaging_version.Version("2.11.0")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_python_library.py
+++ b/tests/test_python_library.py
@@ -16,6 +16,7 @@ import os
 import shutil
 from pathlib import Path
 
+from packaging import version as packaging_version
 import pytest
 
 from synthtool import gcp
@@ -173,6 +174,25 @@ def test_split_system_tests():
         with open(templated_files / ".kokoro/presubmit/system-3.8.cfg", "r") as f:
             contents = f.read()
             assert "system-3.8" in contents
+
+
+@pytest.mark.parametrize(
+    "fixtures_dir",
+    [
+        Path(__file__).parent / "fixtures/python_library",  # just setup.py
+        Path(__file__).parent
+        / "fixtures/python_library_w_version_py",  # has google/cloud/texttospeech/version.py
+    ],
+)
+def test_get_library_version(fixtures_dir):
+    with util.copied_fixtures_dir(fixtures_dir):
+        t = templates.Templates(PYTHON_LIBRARY)
+        result = t.render(".github/release-please.yml")
+        os.makedirs(".github")
+        shutil.copy(result, Path(".github/release-please.yml"))
+
+        version = python.get_library_version()
+        assert version == packaging_version.Version('2.11.0')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Update synthtool/languages/python.py to update generated snippet's metadata to include client library version.

Note that technically the version added here is only the most recent library release version, and not necessarily the expected version for the snippets (which may be generated for a new feature, not yet released and therefore without a library version).  A library's release version is known only at release time, and so release-please should be updating it: https://github.com/googleapis/google-cloud-python/pull/10677

Reference: https://github.com/googleapis/synthtool/pull/1356