### PR TITLE
chore: pin versions of certifi and google-resumable-media 

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/requirements.in
+++ b/synthtool/gcp/templates/java_library/.kokoro/requirements.in
@@ -16,10 +16,12 @@ pycparser==2.21
 pyperclip==1.8.2
 python-dateutil==2.8.2
 requests==2.27.1
+certifi==2022.9.24
 importlib-metadata==4.8.3
 zipp==3.6.0
 google_api_core==2.8.2
 google-cloud-storage==2.0.0
+google-resumable-media==2.3.3
 google-cloud-core==2.3.1
 typing-extensions==4.1.1
 urllib3==1.26.12

--- a/synthtool/gcp/templates/java_library/.kokoro/requirements.txt
+++ b/synthtool/gcp/templates/java_library/.kokoro/requirements.txt
@@ -16,10 +16,12 @@ cachetools==4.2.4 \
     # via
     #   -r requirements.in
     #   google-auth
-certifi==2022.9.14 \
-    --hash=sha256:36973885b9542e6bd01dea287b2b4b3b21236307c56324fcc3f1160f2d655ed5 \
-    --hash=sha256:e232343de1ab72c2aa521b625c80f699e356830fd0e2c620b465b304b17b0516
-    # via requests
+certifi==2022.9.24 \
+    --hash=sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14 \
+    --hash=sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382
+    # via
+    #   -r requirements.in
+    #   requests
 cffi==1.15.1 \
     --hash=sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5 \
     --hash=sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef \
@@ -218,7 +220,9 @@ google-crc32c==1.3.0 \
 google-resumable-media==2.3.3 \
     --hash=sha256:27c52620bd364d1c8116eaac4ea2afcbfb81ae9139fb3199652fcac1724bfb6c \
     --hash=sha256:5b52774ea7a829a8cdaa8bd2d4c3d4bc660c91b30857ab2668d0eb830f4ea8c5
-    # via google-cloud-storage
+    # via
+    #   -r requirements.in
+    #   google-cloud-storage
 googleapis-common-protos==1.56.3 \
     --hash=sha256:6f1369b58ed6cf3a4b7054a44ebe8d03b29c309257583a2bbdc064cd1e4a1442 \
     --hash=sha256:87955d7b3a73e6e803f2572a33179de23989ebba725e05ea42f24838b792e461


### PR DESCRIPTION
Verified that certifi 2022.9.24 and google-resumable-media 2.3.3 support Python 3.6. See https://pypi.org/project/google-resumable-media/ and https://pypi.org/project/google-resumable-media/2.3.3/