### PR TITLE
chore(python): fix formatting in noxfile and docs/conf.py

### DIFF
--- a/synthtool/gcp/templates/python_library/docs/conf.py.j2
+++ b/synthtool/gcp/templates/python_library/docs/conf.py.j2
@@ -368,7 +368,7 @@ intersphinx_mapping = {
     "grpc": ("https://grpc.github.io/grpc/python/", None),
     "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
-    {% if intersphinx_dependencies %}
+    {%- if intersphinx_dependencies %}
         {% for name, url in intersphinx_dependencies.items() %}
             "{{ name }}": ("{{ url }}", None),
         {% endfor %}

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -29,9 +29,9 @@ BLACK_VERSION = "black==22.3.0"
 ISORT_VERSION = "isort==5.10.1"
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION="{{ default_python_version }}"
+DEFAULT_PYTHON_VERSION = "{{ default_python_version }}"
 
-UNIT_TEST_PYTHON_VERSIONS=[{% for v in unit_test_python_versions %}"{{v}}"{% if not loop.last %}, {% endif %}{% endfor %}]
+UNIT_TEST_PYTHON_VERSIONS = [{% for v in unit_test_python_versions %}"{{v}}"{% if not loop.last %}, {% endif %}{% endfor %}]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "asyncmock",
@@ -39,45 +39,91 @@ UNIT_TEST_STANDARD_DEPENDENCIES = [
     "pytest-cov",
     "pytest-asyncio",
 ]
+{%- if unit_test_external_dependencies %}
 UNIT_TEST_EXTERNAL_DEPENDENCIES = [{% for v in unit_test_external_dependencies %}
     "{{v}}",{% endfor %}
 ]
+{%- else %}
+UNIT_TEST_EXTERNAL_DEPENDENCIES = []
+{%- endif %}
+{%- if unit_test_local_dependencies %}
 UNIT_TEST_LOCAL_DEPENDENCIES = [{% for v in unit_test_local_dependencies %}
     "{{v}}",{% endfor %}
 ]
+{%- else %}
+UNIT_TEST_LOCAL_DEPENDENCIES = []
+{%- endif %}
+{%- if unit_test_dependencies %}
 UNIT_TEST_DEPENDENCIES = [{% for v in unit_test_dependencies %}
     "{{v}}",{% endfor %}
 ]
+{%- else %}
+UNIT_TEST_DEPENDENCIES = []
+{%- endif %}
+{%- if unit_test_extras %}
 UNIT_TEST_EXTRAS = [{% for v in unit_test_extras %}
     "{{v}}",{% endfor %}
 ]
+{%- else %}
+UNIT_TEST_EXTRAS = []
+{%- endif %}
+
+{%- if unit_test_extras_by_python %}
 UNIT_TEST_EXTRAS_BY_PYTHON = {{ '{' }}{% if unit_test_extras_by_python %}{% for python_version, extras in unit_test_extras_by_python.items() %}
     "{{python_version}}": [{% for v in extras %}
         "{{v}}",{% endfor %}
     ],{% endfor %}{% endif %}
 }
-
-SYSTEM_TEST_PYTHON_VERSIONS=[{% for v in system_test_python_versions %}"{{v}}"{% if not loop.last %}, {% endif %}{% endfor %}]
+{%- else %}
+UNIT_TEST_EXTRAS_BY_PYTHON = {}
+{%- endif %}
+{% if system_test_python_versions %}
+SYSTEM_TEST_PYTHON_VERSIONS = [{% for v in system_test_python_versions %}"{{v}}"{% if not loop.last %}, {% endif %}{% endfor %}]
+{%- else %}
+SYSTEM_TEST_PYTHON_VERSIONS = []
+{%- endif %}
 SYSTEM_TEST_STANDARD_DEPENDENCIES = [
-    "mock", "pytest", "google-cloud-testutils",
+    "mock",
+    "pytest",
+    "google-cloud-testutils",
 ]
+{%- if system_test_external_dependencies %}
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES = [{% for v in system_test_external_dependencies %}
     "{{v}}",{% endfor %}
 ]
+{%- else %}
+SYSTEM_TEST_EXTERNAL_DEPENDENCIES = []
+{%- endif %}
+{%- if system_test_local_dependencies %}
 SYSTEM_TEST_LOCAL_DEPENDENCIES = [{% for v in system_test_local_dependencies %}
     "{{v}}",{% endfor %}
 ]
+{%- else %}
+SYSTEM_TEST_LOCAL_DEPENDENCIES = []
+{%- endif %}
+{%- if system_test_dependencies %}
 SYSTEM_TEST_DEPENDENCIES = [{% for v in system_test_dependencies %}
     "{{v}}",{% endfor %}
 ]
+{%- else %}
+SYSTEM_TEST_DEPENDENCIES = []
+{%- endif %}
+{%- if system_test_extras %}
 SYSTEM_TEST_EXTRAS = [{% for v in system_test_extras %}
     "{{v}}",{% endfor %}
 ]
+{%- else %}
+SYSTEM_TEST_EXTRAS = []
+{%- endif %}
+{%- if system_test_extras_by_python %}
 SYSTEM_TEST_EXTRAS_BY_PYTHON = {{ '{' }}{% if system_test_extras_by_python %}{% for python_version, extras in system_test_extras_by_python.items() %}
     "{{python_version}}": [{% for v in extras %}
         "{{v}}",{% endfor %}
     ],{% endfor %}{% endif %}
 }
+{%- else %}
+SYSTEM_TEST_EXTRAS_BY_PYTHON = {}
+{%- endif %}
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
@@ -200,6 +246,7 @@ def default(session):
         *session.posargs,
     )
 
+
 @nox.session(python=UNIT_TEST_PYTHON_VERSIONS)
 def unit(session):
     """Run the unit test suite."""
@@ -247,7 +294,7 @@ def system(session):
     system_test_folder_path = os.path.join("tests", "system")
 
     # Check the value of `RUN_SYSTEM_TESTS` env var. It defaults to true.
-    if os.environ.get("RUN_SYSTEM_TESTS", "true") == 'false':
+    if os.environ.get("RUN_SYSTEM_TESTS", "true") == "false":
         session.skip("RUN_SYSTEM_TESTS is set to false, skipping")
     # Install pyopenssl for mTLS testing.
     if os.environ.get("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false") == "true":
@@ -268,7 +315,7 @@ def system(session):
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
-            *session.posargs
+            *session.posargs,
         )
     if system_test_folder_exists:
         session.run(
@@ -276,8 +323,9 @@ def system(session):
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,
-            *session.posargs
+            *session.posargs,
         )
+
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def cover(session):
@@ -291,12 +339,17 @@ def cover(session):
 
     session.run("coverage", "erase")
 
+
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx==4.0.1", "alabaster", "recommonmark")
+    session.install(
+        "sphinx==4.0.1",
+        "alabaster",
+        "recommonmark",
+    )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(
@@ -304,8 +357,10 @@ def docs(session):
         "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
-        "-b", "html",
-        "-d", os.path.join("docs", "_build", "doctrees", ""),
+        "-b",
+        "html",
+        "-d",
+        os.path.join("docs", "_build", "doctrees", ""),
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
     )
@@ -316,7 +371,12 @@ def docfx(session):
     """Build the docfx yaml files for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx==4.0.1", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml")
+    session.install(
+        "sphinx==4.0.1",
+        "alabaster",
+        "recommonmark",
+        "gcp-sphinx-docfx-yaml",
+    )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(
@@ -352,7 +412,11 @@ def prerelease_deps(session):
     session.install("-e", ".[all, tests, tracing]")
     unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
     session.install(*unit_deps_all)
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python


### PR DESCRIPTION
This PR fixes formatting issues in `noxfile.py` which are hidden because we run `nox -s blacken` in the downstream repositories.

I tested the changes by running `docker build -f docker/owlbot/python/Dockerfile -t fixnoxfile .` in this repo with the changes from this branch, followed by `docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo fixnoxfile` in a downstream repo. 

You can see an example of the changes for python-access-approval [here](https://github.com/googleapis/python-access-approval/pull/new/testnoxfileformatting).

Fixes https://github.com/googleapis/synthtool/issues/1662