### PR TITLE
samples: pull in latest typeless bot, clean up some comments

### DIFF
--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -48,7 +48,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
 RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.5.2 \
-    typescript@4.7.4 @google-cloud/typeless-sample-bot@1.0.2
+    typescript@4.7.4 @google-cloud/typeless-sample-bot@1.0.3
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs_mono_repo/Dockerfile
+++ b/docker/owlbot/nodejs_mono_repo/Dockerfile
@@ -48,7 +48,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # * gts/typescript are used for linting.
 # * google-gax is used for compiling protos.
 RUN cd /synthtool && mkdir node_modules && npm i gts@3.1.0 google-gax@3.5.2 \
-    typescript@4.7.4 @google-cloud/typeless-sample-bot@1.0.2
+    typescript@4.7.4 @google-cloud/typeless-sample-bot@1.0.3
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs_mono_repo/entrypoint.sh" ]

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -176,14 +176,15 @@ def install(hide_output=False):
     shell.run(["npm", "install"], hide_output=hide_output)
 
 
-# This is currently an optional, opt-in part of an individual repo's
-# OwlBot.py, and must be called from there before calling owlbot_main.
 def typeless_samples_hermetic(hide_output=False):
     """
     Converts TypeScript samples in the current Node.js library
     to JavaScript samples. Run this step before fix() and friends.
     Assumes that typeless-sample-bot is already installed in a well
     known location on disk (node_modules/.bin).
+
+    This is currently an optional, opt-in part of an individual repo's
+    OwlBot.py, and must be called from there before calling owlbot_main.
     """
     logger.debug("Run typeless sample bot")
     shell.run(

--- a/synthtool/languages/node_mono_repo.py
+++ b/synthtool/languages/node_mono_repo.py
@@ -221,14 +221,15 @@ def install(hide_output=False):
     shell.run(["npm", "install"], hide_output=hide_output)
 
 
-# This is currently an optional, opt-in part of an individual repo's
-# OwlBot.py, and must be called from there before calling owlbot_main.
 def typeless_samples_hermetic(hide_output=False):
     """
     Converts TypeScript samples in the current Node.js library
     to JavaScript samples. Run this step before fix() and friends.
     Assumes that typeless-sample-bot is already installed in a well
     known location on disk (node_modules/.bin).
+
+    This is currently an optional, opt-in part of an individual repo's
+    OwlBot.py, and must be called from there before calling owlbot_main.
     """
     logger.debug("Run typeless sample bot")
     shell.run(


### PR DESCRIPTION
@google-cloud/typeless-sample-bot 1.0.2 has a bug in path resolution that prevents Babel from finding its plugins in the right place. This will pull in 1.0.3, as well as making a few comments better in the `node[_monorepo].py`.


Fixes: https://github.com/googleapis/synthtool/issues/1697
