### PR TITLE
ci: fix required GCB presubmit checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -6,9 +6,9 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - 'Kokoro CI'
     - 'cla/google'
-    - 'owlbot-nodejs-mono-repo-presubmit'
-    - 'owlbot-nodejs-presubmit'
-    - 'owlbot-java-presubmit'
+    - 'owlbot-nodejs-mono-repo-presubmit (repo-automation-bots)'
+    - 'owlbot-nodejs-presubmit (repo-automation-bots)'
+    - 'owlbot-java-presubmit (repo-automation-bots)'
   requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: true
   requiresStrictStatusChecks: true


### PR DESCRIPTION
Looks like the project name is required in the check name.