### PR TITLE
chore: use gcp-docuploader 0.6.3

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/requirements.in
+++ b/synthtool/gcp/templates/java_library/.kokoro/requirements.in
@@ -1,4 +1,4 @@
-gcp-docuploader==0.6.4
+gcp-docuploader==0.6.3
 google-crc32c==1.3.0
 googleapis-common-protos==1.56.3
 gcp-releasetool==1.9.1

--- a/synthtool/gcp/templates/java_library/.kokoro/requirements.txt
+++ b/synthtool/gcp/templates/java_library/.kokoro/requirements.txt
@@ -135,9 +135,9 @@ cryptography==38.0.3 \
     #   -r requirements.in
     #   gcp-releasetool
     #   secretstorage
-gcp-docuploader==0.6.4 \
-    --hash=sha256:01486419e24633af78fd0167db74a2763974765ee8078ca6eb6964d0ebd388af \
-    --hash=sha256:70861190c123d907b3b067da896265ead2eeb9263969d6955c9e0bb091b5ccbf
+gcp-docuploader==0.6.3 \
+    --hash=sha256:ba8c9d76b3bbac54b0311c503a373b00edc2dc02d6d54ea9507045adb8e870f7 \
+    --hash=sha256:c0f5aaa82ce1854a386197e4e359b120ad6d4e57ae2c812fce42219a3288026b
     # via -r requirements.in
 gcp-releasetool==1.9.1 \
     --hash=sha256:952f4055d5d986b070ae2a71c4410b250000f9cc5a1e26398fcd55a5bbc5a15f \


### PR DESCRIPTION
Using the latest version of gcp-docuploader (0.6.4) was resulting in:
```
Traceback (most recent call last):
  File "/root/.pyenv/versions/3.6.12/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/root/.pyenv/versions/3.6.12/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/root/.pyenv/versions/3.6.12/lib/python3.6/site-packages/docuploader/__main__.py", line 26, in <module>
    from docuploader.protos import metadata_pb2
  File "/root/.pyenv/versions/3.6.12/lib/python3.6/site-packages/docuploader/protos/metadata_pb2.py", line 5, in <module>
    from google.protobuf.internal import builder as _builder
ImportError: cannot import name 'builder'
cleanup
```

It looks like the latest version requires a newer version of the protobuf dependency (See: https://github.com/googleapis/docuploader/pull/137/files) . However versions greater than 3.19.6 are not compatible with Python 3.6.