### PR TITLE
chore(deps): update docfx session to require py3.9

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -366,7 +366,7 @@ def docs(session):
     )
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python="3.9")
 def docfx(session):
     """Build the docfx yaml files for this library."""
 


### PR DESCRIPTION
The new release for `gcp-sphinx-docfx-yaml` requires Python3.9. Pinning only for docfx session, this is not required for other jobs.