### PR TITLE
chore(python): use python 3.9 for docs build

### DIFF
--- a/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "{{ default_python_version }}"
+        python-version: "3.9"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel
@@ -28,7 +28,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "{{ default_python_version }}"
+        python-version: "3.9"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
+++ b/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
@@ -60,16 +60,16 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   && rm -f /var/cache/apt/archives/*.deb
 
-###################### Install python 3.8.11
+###################### Install python 3.9.13
 
-# Download python 3.8.11
-RUN wget https://www.python.org/ftp/python/3.8.11/Python-3.8.11.tgz
+# Download python 3.9.13
+RUN wget https://www.python.org/ftp/python/3.9.13/Python-3.9.13.tgz
 
 # Extract files
-RUN tar -xvf Python-3.8.11.tgz
+RUN tar -xvf Python-3.9.13.tgz
 
-# Install python 3.8.11
-RUN ./Python-3.8.11/configure --enable-optimizations
+# Install python 3.9.11
+RUN ./Python-3.9.13/configure --enable-optimizations
 RUN make altinstall
 
 ###################### Install pip

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -340,7 +340,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python="3.9")
 def docs(session):
     """Build the docs for this library."""
 


### PR DESCRIPTION
This PR fixes an issue where the `docfx` nox session fails with `Python interpreter 3.9 not found`.

PR https://github.com/googleapis/synthtool/pull/1711 modified the `docfx` nox session to use python 3.9 but the docker image [here](https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile) doesn't have the python 3.9 interpreter. The session also fails with github actions because the [interpreter](https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/.github/workflows/docs.yml#L31) is set to `default_python_version` which is python 3.8 . See build log [here](https://fusion2.corp.google.com/ci/kokoro/prod:cloud-devrel%2Fclient-libraries%2Fpython%2Fgoogleapis%2Fpython-analytics-admin%2Fdocs%2Fdocs-presubmit/activity/f45a9d43-c935-4198-a86f-3b38a11a2955/log) and [here](https://github.com/googleapis/python-analytics-admin/actions/runs/3479419079/jobs/5817942039).

```
nox > Session docs was successful.
nox > Running session docfx
nox > Session docfx failed: Python interpreter 3.9 not found.
nox > Ran multiple sessions:
nox > * docs: success
nox > * docfx: failed
```

```
Run nox -s docfx
nox > Running session docfx
nox > Session docfx failed: Python interpreter 3.9 not found.
Error: Process completed with exit code 1.
```

I've also updated the `docs` nox session to use python 3.9.