### PR TITLE
fix: Pin flake8 to v < 6.0.0

### DIFF
--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -149,9 +149,9 @@ FLAKE8_COMMON_ARGS = [
 @nox.session
 def lint(session: nox.sessions.Session) -> None:
     if not TEST_CONFIG["enforce_type_hints"]:
-        session.install("flake8", "flake8-import-order")
+        session.install("flake8<6.0.0", "flake8-import-order")
     else:
-        session.install("flake8", "flake8-import-order", "flake8-annotations")
+        session.install("flake8<6.0.0", "flake8-import-order", "flake8-annotations")
 
     local_names = _determine_local_import_names(".")
     args = FLAKE8_COMMON_ARGS + [

--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -149,9 +149,9 @@ FLAKE8_COMMON_ARGS = [
 @nox.session
 def lint(session: nox.sessions.Session) -> None:
     if not TEST_CONFIG["enforce_type_hints"]:
-        session.install("flake8<6.0.0", "flake8-import-order")
+        session.install("flake8")
     else:
-        session.install("flake8<6.0.0", "flake8-import-order", "flake8-annotations")
+        session.install("flake8", "flake8-annotations")
 
     local_names = _determine_local_import_names(".")
     args = FLAKE8_COMMON_ARGS + [


### PR DESCRIPTION
flake8 v 6.0.0 introduces backward incompatible change. flake8-import-order is broken because of it.
Until there is an updated version of flake8-import-order, we will need to pin flake8 to v<6.0.0