### PR TITLE
build: have Kokoro grab service account credentials from secret that will be rotated for system tests

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/continuous/node12/system-test.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/continuous/node12/system-test.cfg
@@ -5,3 +5,8 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repository_name'] }}/.kokoro/system-test.sh"
 }
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "long-door-651-kokoro-system-test-service-account"
+}

--- a/synthtool/gcp/templates/node_library/.kokoro/presubmit/node12/system-test.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/presubmit/node12/system-test.cfg
@@ -5,3 +5,8 @@ env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/{{ metadata['repository_name'] }}/.kokoro/system-test.sh"
 }
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "long-door-651-kokoro-system-test-service-account"
+}

--- a/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
@@ -19,7 +19,7 @@ set -eo pipefail
 export NPM_CONFIG_PREFIX=${HOME}/.npm-global
 
 # Setup service account credentials.
-export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/service-account.json
+export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secret_manager/long-door-651-kokoro-system-test-service-account
 export GCLOUD_PROJECT={{ test_project or 'long-door-651' }}
 
 cd $(dirname $0)/..


### PR DESCRIPTION
This should look exactly like: https://github.com/googleapis/synthtool/pull/1724