### PR TITLE
feat(python): add support for python 3.11

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -265,7 +265,7 @@ class CommonTemplates:
         if "default_python_version" not in kwargs:
             kwargs["default_python_version"] = "3.8"
         if "unit_test_python_versions" not in kwargs:
-            kwargs["unit_test_python_versions"] = ["3.7", "3.8", "3.9", "3.10"]
+            kwargs["unit_test_python_versions"] = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
         if "system_test_python_versions" not in kwargs:
             kwargs["system_test_python_versions"] = ["3.8"]

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.11/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.11/common.cfg
@@ -1,0 +1,51 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Build logs will be here
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}
+
+# Specify which tests to run
+env_vars: {
+    key: "RUN_TESTS_SESSION"
+    value: "py-3.11"
+}
+
+# Declare build specific Cloud project.
+env_vars: {
+    key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
+    value: "python-docs-samples-tests-311"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples.sh"
+}
+{% if custom_samples_dockerfile %}
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/{{ metadata['repo']['repo'].split('/')[1] }}-samples-docker"
+}
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_DOCKERFILE"
+    value: ".kokoro/docker/samples/Dockerfile"
+}
+{% else %}
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
+}
+{% endif %}
+# Download secrets for samples
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/trampoline_v2.sh"

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.11/continuous.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.11/continuous.cfg
@@ -1,0 +1,6 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+    key: "INSTALL_LIBRARY_FROM_SOURCE"
+    value: "True"
+}

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.11/periodic-head.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.11/periodic-head.cfg
@@ -1,0 +1,18 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+    key: "INSTALL_LIBRARY_FROM_SOURCE"
+    value: "True"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/{{ metadata['repo']['repo'].split('/')[1] }}/.kokoro/test-samples-against-head.sh"
+}
+{% if custom_samples_dockerfile %}
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+{% endif %}

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.11/periodic.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.11/periodic.cfg
@@ -1,0 +1,13 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+    key: "INSTALL_LIBRARY_FROM_SOURCE"
+    value: "False"
+}
+{% if custom_samples_dockerfile %}
+# Upload the docker image after successful builds.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}
+{% endif %}

--- a/synthtool/gcp/templates/python_library/.kokoro/samples/python3.11/presubmit.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/samples/python3.11/presubmit.cfg
@@ -1,0 +1,6 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+    key: "INSTALL_LIBRARY_FROM_SOURCE"
+    value: "True"
+}

--- a/synthtool/gcp/templates/python_samples/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_samples/noxfile.py.j2
@@ -89,7 +89,7 @@ def get_pytest_env_vars() -> Dict[str, str]:
 
 # DO NOT EDIT - automatically generated.
 # All versions used to test samples.
-ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
+ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 # Any default versions that should be ignored.
 IGNORED_VERSIONS = TEST_CONFIG["ignored_versions"]

--- a/synthtool/languages/python_mono_repo.py
+++ b/synthtool/languages/python_mono_repo.py
@@ -195,7 +195,7 @@ def owlbot_main(package_dir: str) -> None:
             relative_dir=f"packages/{Path(package_dir).name}",
             microgenerator=True,
             default_python_version="3.9",
-            unit_test_python_versions=["3.7", "3.8", "3.9", "3.10"],
+            unit_test_python_versions=["3.7", "3.8", "3.9", "3.10", "3.11"],
             cov_level=100,
             versions=gcp.common.detect_versions(
                 path=f"{package_dir}/google", default_first=True


### PR DESCRIPTION
This PR adds python 3.11 to python templates.

I tested the changes in `python-access-approval`. See https://github.com/googleapis/python-access-approval/pull/261/files