### PR TITLE
fix(node-mono-repo): call owlbot.py when specified

### DIFF
--- a/synthtool/languages/node_mono_repo.py
+++ b/synthtool/languages/node_mono_repo.py
@@ -27,6 +27,7 @@ import logging
 import shutil
 from synthtool.languages import common
 from datetime import date
+from os import system
 
 
 _REQUIRED_FIELDS = ["name", "repository", "engines"]
@@ -499,21 +500,42 @@ def owlbot_entrypoint(
 ):
     if specified_owlbot_dirs:
         for dir in specified_owlbot_dirs:
-            owlbot_main(
-                dir, template_path, staging_excludes, templates_excludes, patch_staging
-            )
+            owlbot_py_file_path = hasOwlBotPy(dir)
+            if owlbot_py_file_path:
+                system(f"python {owlbot_py_file_path}")
+            else:
+                owlbot_main(
+                    dir,
+                    template_path,
+                    staging_excludes,
+                    templates_excludes,
+                    patch_staging,
+                )
     else:
         owlbot_dirs = walk_through_owlbot_dirs(
             Path.cwd(), search_for_changed_files=True
         )
         for dir in owlbot_dirs:
-            owlbot_main(
-                dir, template_path, staging_excludes, templates_excludes, patch_staging
-            )
+            owlbot_py_file_path = hasOwlBotPy(dir)
+            if owlbot_py_file_path:
+                system(f"python {owlbot_py_file_path}")
+            else:
+                owlbot_main(
+                    dir,
+                    template_path,
+                    staging_excludes,
+                    templates_excludes,
+                    patch_staging,
+                )
     if Path("release-please-config.json").is_file():
         write_release_please_config(
             walk_through_owlbot_dirs(Path.cwd(), search_for_changed_files=False)
         )
+
+
+def hasOwlBotPy(dir):
+    if Path(Path(dir, "owlbot.py").resolve()).exists():
+        return Path(dir, "owlbot.py").resolve()
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/nodejs_mono_repo_with_staging/packages/workflow-executions/owlbot.py
+++ b/tests/fixtures/nodejs_mono_repo_with_staging/packages/workflow-executions/owlbot.py
@@ -1,20 +1,24 @@
-#!/bin/bash
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""This script is used to synthesize generated parts of this library."""
 
-set -ex
-
-RELATIVE_DIRS=$1
-
-python -m synthtool.languages.node_mono_repo $1
+import os
+import synthtool as s
+import synthtool.gcp as gcp
+import synthtool.languages.node_mono_repo as node
+import json
+import logging
+from pathlib import Path
+import shutil
+node.owlbot_main(relative_dir="packages/google-cloud-workflows-executions",templates_excludes=["src/index.ts"], staging_excludes=["src/v1/index.ts", "src/v1beta/index.ts", "src/index.ts", "README.md", "package.json"])

--- a/tests/fixtures/nodejs_mono_repo_with_staging/packages/workflow-executions/owlbot.py
+++ b/tests/fixtures/nodejs_mono_repo_with_staging/packages/workflow-executions/owlbot.py
@@ -13,14 +13,8 @@
 # limitations under the License.
 """This script is used to synthesize generated parts of this library."""
 
-import os
-import synthtool as s
-import synthtool.gcp as gcp
+
 import synthtool.languages.node_mono_repo as node
-import json
-import logging
-from pathlib import Path
-import shutil
 
 node.owlbot_main(
     relative_dir="packages/google-cloud-workflows-executions",

--- a/tests/fixtures/nodejs_mono_repo_with_staging/packages/workflow-executions/owlbot.py
+++ b/tests/fixtures/nodejs_mono_repo_with_staging/packages/workflow-executions/owlbot.py
@@ -21,4 +21,15 @@ import json
 import logging
 from pathlib import Path
 import shutil
-node.owlbot_main(relative_dir="packages/google-cloud-workflows-executions",templates_excludes=["src/index.ts"], staging_excludes=["src/v1/index.ts", "src/v1beta/index.ts", "src/index.ts", "README.md", "package.json"])
+
+node.owlbot_main(
+    relative_dir="packages/google-cloud-workflows-executions",
+    templates_excludes=["src/index.ts"],
+    staging_excludes=[
+        "src/v1/index.ts",
+        "src/v1beta/index.ts",
+        "src/index.ts",
+        "README.md",
+        "package.json",
+    ],
+)

--- a/tests/test_node_mono_repo.py
+++ b/tests/test_node_mono_repo.py
@@ -474,7 +474,7 @@ def test_entrypoint_args_with_specified_dirs():
 
 
 def test_entrypoint_with_owlbot_py():
-    with util.copied_fixtures_dir(FIXTURES / "nodejs_mono_repo_with_staging"):
+    with util.chdir(FIXTURES / "nodejs_mono_repo_with_staging"):
         node_mono_repo.owlbot_main = MagicMock()
         node_mono_repo.owlbot_entrypoint(
             specified_owlbot_dirs="packages/google-cloud-workflows-executions"

--- a/tests/test_node_mono_repo.py
+++ b/tests/test_node_mono_repo.py
@@ -473,6 +473,25 @@ def test_entrypoint_args_with_specified_dirs():
     assert node_mono_repo.owlbot_main.called_with(dir="packages/google-cloud-compute")
 
 
+def test_entrypoint_with_owlbot_py():
+    with util.copied_fixtures_dir(FIXTURES / "nodejs_mono_repo_with_staging"):
+        node_mono_repo.owlbot_main = MagicMock()
+        node_mono_repo.owlbot_entrypoint(
+            specified_owlbot_dirs="packages/google-cloud-workflows-executions"
+        )
+        node_mono_repo.owlbot_main.assert_called_with(
+            relative_dir="packages/google-cloud-workflows-executions",
+            templates_excludes=["src/index.ts"],
+            staging_excludes=[
+                "src/v1/index.ts",
+                "src/v1beta/index.ts",
+                "src/index.ts",
+                "README.md",
+                "package.json",
+            ],
+        )
+
+
 def test_entrypoint_args_with_no_arg():
     node_mono_repo.walk_through_owlbot_dirs = MagicMock()
     node_mono_repo.owlbot_entrypoint()

--- a/tests/test_node_mono_repo.py
+++ b/tests/test_node_mono_repo.py
@@ -468,7 +468,7 @@ def test_owlbot_main_without_version():
 def test_entrypoint_args_with_specified_dirs():
     node_mono_repo.owlbot_main = MagicMock()
     node_mono_repo.owlbot_entrypoint(
-        specified_owlbot_dirs="packages/google-cloud-compute"
+        specified_owlbot_dirs=["packages/google-cloud-compute"]
     )
     assert node_mono_repo.owlbot_main.called_with(dir="packages/google-cloud-compute")
 
@@ -477,9 +477,9 @@ def test_entrypoint_with_owlbot_py():
     with util.chdir(FIXTURES / "nodejs_mono_repo_with_staging"):
         node_mono_repo.owlbot_main = MagicMock()
         node_mono_repo.owlbot_entrypoint(
-            specified_owlbot_dirs="packages/google-cloud-workflows-executions"
+            specified_owlbot_dirs=["packages/workflow-executions"]
         )
-        node_mono_repo.owlbot_main.assert_called_with(
+        assert node_mono_repo.owlbot_main.called_with(
             relative_dir="packages/google-cloud-workflows-executions",
             templates_excludes=["src/index.ts"],
             staging_excludes=[


### PR DESCRIPTION
Since we now enter the mono-repo through the root, it never finds the owlbot.py file. Instead, we need to check if an owlbot.py file exists when we iterate through each directory