### PR TITLE
chore(java): omit `-Penable-integration-tests` parameter from native image test run command

### DIFF
--- a/synthtool/gcp/templates/java_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.sh
@@ -71,12 +71,12 @@ integration)
     ;;
 graalvm)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Penable-integration-tests test
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative test
     RETURN_CODE=$?
     ;;
 graalvm17)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Penable-integration-tests test
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative test
     RETURN_CODE=$?
     ;;
 samples)


### PR DESCRIPTION
The opting in of tests for native image testing is explicitly done in the `native` profile's maven-surefire-plugin. See https://github.com/googleapis/java-shared-config/blob/44a77b0faf5b4f3f9208117ccab0a3717d059efd/pom.xml#L806-L817 for reference. Therefore, the `-Penable-integration-tests` profile is redundant.