### PR TITLE
feat(node): add default cred service account for tests

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/continuous/node12/test.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/continuous/node12/test.cfg
@@ -1,0 +1,4 @@
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "long-door-651-kokoro-system-test-service-account"
+}

--- a/synthtool/gcp/templates/node_library/.kokoro/presubmit/node12/test.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/presubmit/node12/test.cfg
@@ -1,0 +1,4 @@
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "long-door-651-kokoro-system-test-service-account"
+}

--- a/synthtool/gcp/templates/node_library/.kokoro/test.bat
+++ b/synthtool/gcp/templates/node_library/.kokoro/test.bat
@@ -21,6 +21,10 @@ cd ..
 @rem we upgrade Node.js in the image:
 SET PATH=%PATH%;/cygdrive/c/Program Files/nodejs/npm
 
+@rem setup service account credentials.
+SET GOOGLE_APPLICATION_CREDENTIALS=%KOKORO_GFILE_DIR%/secret_manager/long-door-651-kokoro-system-test-service-account
+SET GCLOUD_PROJECT={{ test_project or 'long-door-651' }}
+
 call nvm use v12.14.1
 call which node
 

--- a/synthtool/gcp/templates/node_library/.kokoro/test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/test.sh
@@ -18,6 +18,10 @@ set -eo pipefail
 
 export NPM_CONFIG_PREFIX=${HOME}/.npm-global
 
+# Setup service account credentials.
+export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secret_manager/long-door-651-kokoro-system-test-service-account
+export GCLOUD_PROJECT={{ test_project or 'long-door-651' }}
+
 cd $(dirname $0)/..
 
 npm install


### PR DESCRIPTION
For this new feature on the BigQuery Storage API client, I was trying to write tests that hit the actual service running, as the service uses aBiDi gRPC communication, has a complex interaction pattern and is just more feasible to just test against the real thing ( we do that on the BigQuery Go SDK ). 

The problem is that today, test scripts on CI for Node doesn't have the service account credentials there, but they do exist for samples and system tests. This PR adds the service account credentials to the test scripts.

PR that is blocked by this: https://github.com/googleapis/nodejs-bigquery-storage/pull/328

I wasn't able to test this on Windows, not entirely sure if what I wrote is gonna work correct fro that environment.