### PR TITLE
fix(php): handle missing directories gracefully

### DIFF
--- a/synthtool/languages/php.py
+++ b/synthtool/languages/php.py
@@ -117,7 +117,9 @@ def owlbot_copy_version(
     proto_src = src / "proto/src"
     if os.path.isdir(proto_src):
         if not version_string:
-            logger.info("cannot move protos without a version_string detected or provided")
+            logger.info(
+                "cannot move protos without a version_string detected or provided"
+            )
             return
         entries = os.scandir(proto_src)
         proto_dir = None

--- a/synthtool/languages/php.py
+++ b/synthtool/languages/php.py
@@ -107,7 +107,9 @@ def owlbot_copy_version(
         # copy snippets
         snippet_dir = src / "samples"
         if os.path.isdir(snippet_dir):
-            s.move([snippet_dir], dest / "samples", merge=_merge, excludes=copy_excludes)
+            s.move(
+                [snippet_dir], dest / "samples", merge=_merge, excludes=copy_excludes
+            )
     else:
         logger.info("there is no src directory '%s' to copy", src_dir)
 
@@ -119,9 +121,13 @@ def owlbot_copy_version(
         metadata_dir = None
         for entry in entries:
             if os.path.basename(entry.path) == METADATA_DIR:
-                metadata_dir = _find_copy_target(Path(entry.path).resolve(), version_string)
+                metadata_dir = _find_copy_target(
+                    Path(entry.path).resolve(), version_string
+                )
             else:
-                proto_dir = _find_copy_target(Path(entry.path).resolve(), version_string)
+                proto_dir = _find_copy_target(
+                    Path(entry.path).resolve(), version_string
+                )
 
         # copy proto files
         if isinstance(proto_dir, Path):
@@ -131,7 +137,9 @@ def owlbot_copy_version(
         # copy metadata files
         if isinstance(metadata_dir, Path):
             logger.debug("metadata_dir detected: %s", metadata_dir)
-            s.move([metadata_dir], dest / "metadata", merge=_merge, excludes=copy_excludes)
+            s.move(
+                [metadata_dir], dest / "metadata", merge=_merge, excludes=copy_excludes
+            )
     else:
         logger.info("there is no proto generated src directory to copy: %s", proto_src)
 

--- a/synthtool/languages/php.py
+++ b/synthtool/languages/php.py
@@ -92,48 +92,48 @@ def owlbot_copy_version(
         copy_excludes = DEFAULT_COPY_EXCLUDES
     # detect the version string for later use
     src_dir = src / "src"
-    entries = os.scandir(src_dir)
-    snippet_dir = src / "samples"
-    if not entries:
+    if os.path.isdir(src_dir):
+        entries = os.scandir(src_dir)
+        if not version_string:
+            version_string = os.path.basename(os.path.basename(next(entries))).lower()
+            logger.debug("version_string detected: %s", version_string)
+
+        # copy all src including partial veneer classes
+        s.move([src / "src"], dest / "src", merge=_merge, excludes=copy_excludes)
+
+        # copy tests
+        s.move([src / "tests"], dest / "tests", merge=_merge, excludes=copy_excludes)
+
+        # copy snippets
+        snippet_dir = src / "samples"
+        if os.path.isdir(snippet_dir):
+            s.move([snippet_dir], dest / "samples", merge=_merge, excludes=copy_excludes)
+    else:
         logger.info("there is no src directory '%s' to copy", src_dir)
-        return
-    if not version_string:
-        version_string = os.path.basename(os.path.basename(next(entries))).lower()
-        logger.debug("version_string detected: %s", version_string)
-
-    # copy all src including partial veneer classes
-    s.move([src / "src"], dest / "src", merge=_merge, excludes=copy_excludes)
-
-    # copy tests
-    s.move([src / "tests"], dest / "tests", merge=_merge, excludes=copy_excludes)
-
-    # copy snippets
-    if os.path.isdir(snippet_dir):
-        s.move([snippet_dir], dest / "samples", merge=_merge, excludes=copy_excludes)
 
     # detect the directory containing proto generated PHP source and metadata.
     proto_src = src / "proto/src"
-    entries = os.scandir(proto_src)
-    proto_dir = None
-    metadata_dir = None
-    if not entries:
+    if os.path.isdir(proto_src):
+        entries = os.scandir(proto_src)
+        proto_dir = None
+        metadata_dir = None
+        for entry in entries:
+            if os.path.basename(entry.path) == METADATA_DIR:
+                metadata_dir = _find_copy_target(Path(entry.path).resolve(), version_string)
+            else:
+                proto_dir = _find_copy_target(Path(entry.path).resolve(), version_string)
+
+        # copy proto files
+        if isinstance(proto_dir, Path):
+            logger.debug("proto_dir detected: %s", proto_dir)
+            s.move([proto_dir], dest / "src", merge=_merge, excludes=copy_excludes)
+
+        # copy metadata files
+        if isinstance(metadata_dir, Path):
+            logger.debug("metadata_dir detected: %s", metadata_dir)
+            s.move([metadata_dir], dest / "metadata", merge=_merge, excludes=copy_excludes)
+    else:
         logger.info("there is no proto generated src directory to copy: %s", proto_src)
-        return
-    for entry in entries:
-        if os.path.basename(entry.path) == METADATA_DIR:
-            metadata_dir = _find_copy_target(Path(entry.path).resolve(), version_string)
-        else:
-            proto_dir = _find_copy_target(Path(entry.path).resolve(), version_string)
-
-    # copy proto files
-    if isinstance(proto_dir, Path):
-        logger.debug("proto_dir detected: %s", proto_dir)
-        s.move([proto_dir], dest / "src", merge=_merge, excludes=copy_excludes)
-
-    # copy metadata files
-    if isinstance(metadata_dir, Path):
-        logger.debug("metadata_dir detected: %s", metadata_dir)
-        s.move([metadata_dir], dest / "metadata", merge=_merge, excludes=copy_excludes)
 
 
 def owlbot_patch() -> None:

--- a/synthtool/languages/php.py
+++ b/synthtool/languages/php.py
@@ -117,7 +117,7 @@ def owlbot_copy_version(
     proto_src = src / "proto/src"
     if os.path.isdir(proto_src):
         if not version_string:
-            logger.info("cannot move protos without a version_string provided")
+            logger.info("cannot move protos without a version_string detected or provided")
             return
         entries = os.scandir(proto_src)
         proto_dir = None

--- a/synthtool/languages/php.py
+++ b/synthtool/languages/php.py
@@ -116,6 +116,9 @@ def owlbot_copy_version(
     # detect the directory containing proto generated PHP source and metadata.
     proto_src = src / "proto/src"
     if os.path.isdir(proto_src):
+        if not version_string:
+            logger.info("cannot move protos without a version_string provided")
+            return
         entries = os.scandir(proto_src)
         proto_dir = None
         metadata_dir = None


### PR DESCRIPTION
This looks like a bigger change than it is. I just wrapped the "copy gapics" and "copy protos" sections in a conditional to see if those expected directories exist. Without this, synthtool throws an exception (a `FileNotFoundError: [Errno 2] No such file or directory` error) when `src` or `proto/src` doesn't exist. 

Additionally, I added a log message if the required `version_string` doesn't exist, as this covers an edge case with proto-only copies (since the `version_string` is derived from the gapic path).

This is important for using OwlBot to generate our "Cloud Common Protos", which won't contain a GAPIC service, but for which we'd still like to use OwlBot (see https://github.com/googleapis/google-cloud-php/pull/5935).