### PR TITLE
chore: README template fix in google-cloud-java

### DIFF
--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -272,7 +272,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [developer-console]: https://console.developers.google.com/
 [create-project]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
 [cloud-cli]: https://cloud.google.com/cli
-[troubleshooting]: https://github.com/googleapis/google-cloud-common/blob/main/troubleshooting/readme.md#troubleshooting
+[troubleshooting]: https://github.com/googleapis/google-cloud-java/blob/main/TROUBLESHOOTING.md
 [contributing]: https://github.com/{{metadata['repo']['repo']}}/blob/main/CONTRIBUTING.md
 [code-of-conduct]: https://github.com/{{metadata['repo']['repo']}}/blob/main/CODE_OF_CONDUCT.md#contributor-code-of-conduct
 [license]: https://github.com/{{metadata['repo']['repo']}}/blob/main/LICENSE

--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -36,8 +36,7 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
 
 If you are using Maven without the BOM, add this to your dependencies:
 {% elif monorepo %}
-If you are using Maven with [BOM][libraries-bom], add the following elements to
-your pom.xml file:
+If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
 
 ```xml
 <dependencyManagement>

--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -34,8 +34,8 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
 {{ metadata['snippets'][metadata['repo']['api_shortname'] + '_install_with_bom'] }}
 ```
 
-If you are using Maven without BOM, add this to your dependencies:
-{% elif monorepo is defined and monorepo %}
+If you are using Maven without the BOM, add this to your dependencies:
+{% elif monorepo %}
 If you are using Maven with [BOM][libraries-bom], add the following elements to
 your pom.xml file:
 
@@ -58,10 +58,12 @@ your pom.xml file:
     <artifactId>{{ artifact_id }}</artifactId>
   </dependency>
 ```
+
+If you are using Maven without the BOM, add this to your dependencies:
 {% else %}
 If you are using Maven, add this to your pom.xml file:
-<!-- {x-version-update-start:{{ artifact_id }}:released} -->
 {% endif %}
+<!-- {x-version-update-start:{{ artifact_id }}:released} -->
 
 ```xml
 {% if 'snippets' in metadata and metadata['snippets'][metadata['repo']['api_shortname'] + '_install_without_bom'] -%}

--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -35,6 +35,29 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
 ```
 
 If you are using Maven without BOM, add this to your dependencies:
+{% elif monorepo is defined and monorepo %}
+If you are using Maven with [BOM][libraries-bom], add the following elements to
+your pom.xml file:
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>libraries-bom</artifactId>
+      <version>{{ metadata['latest_bom_version'] }}</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>{{ group_id }}</groupId>
+    <artifactId>{{ artifact_id }}</artifactId>
+  </dependency>
+```
 {% else %}
 If you are using Maven, add this to your pom.xml file:
 <!-- {x-version-update-start:{{ artifact_id }}:released} -->

--- a/synthtool/languages/java.py
+++ b/synthtool/languages/java.py
@@ -490,6 +490,7 @@ def common_templates(
     # Generate flat to tell this repository is a split repo that have migrated
     # to monorepo. The owlbot.py in the monorepo sets monorepo=True.
     monorepo = kwargs.get("monorepo", False)
+    kwargs["monorepo"] = monorepo
     split_repo = not monorepo
     repo_metadata = metadata["repo"]
     repo_short = repo_metadata["repo_short"]


### PR DESCRIPTION
The README.md files in the google-cloud-java monorepo to have instructions about how to use the Libraries BOM. This is part of b/274518727.

# How I confirmed the change


I built the Docker image:

```
suztomo@suztomo:~/synthtool$  docker build -f docker/owlbot/java/Dockerfile .
...
Successfully built d50554d0e398
```

## Checked with google-cloud-java repository

In google-cloud-java clone, I touched different Java files in java-api-gateway, java-language and java-notification.

```
for M in java-api-gateway java-language java-notification; do
   echo "" >> $(find $M -name '*.java' |head -1)
done

git commit -a -m 'chore: touch files to invoke OwlBot post processor'

```


Then I ran the code with google-cloud-java repository:

```
suztomo@suztomo:~/google-cloud-java$ docker run --rm -v $(pwd):/workspace  fd14d77283ae
```

The three modules got the channge in their README files https://github.com/googleapis/google-cloud-java/pull/9299. Notice the README files have Libraries BOM instruction now.

## Checked with java-storage repository

The change worked as expected for java-storage module:

```
suztomo@suztomo:~/java-storage$ docker run --rm -v $(pwd):/workspace d50554d0e398
...
```

![image](https://user-images.githubusercontent.com/28604/229186682-daa44281-4076-4c08-87e6-9cf2702e3b30.png)


This actually fixes an existing bug where it wasn't adding `<!-- {x-version-update-start:google-cloud-storage:released} -->` when a repository has snippet for Libraries BOM usage.
