### PR TITLE
fix:  test fixture's .OwlBot.yaml

### DIFF
--- a/tests/fixtures/nodejs_mono_repo_with_staging/packages/gapic-node-templating/.OwlBot.yaml
+++ b/tests/fixtures/nodejs_mono_repo_with_staging/packages/gapic-node-templating/.OwlBot.yaml
@@ -1,1 +1,15 @@
-empty file
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+docker:
+  image: gcr.io/cloud-devrel-public-resources/647beb99368b47710b366419e0:latest


### PR DESCRIPTION
It wasn't parseable yaml.
Fixes https://github.com/googleapis/synthtool/issues/1783