### PR TITLE
chore: use includePaths instead of ignorePaths to follow opt-in strategy for renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,11 @@
   "extends": [
     "schedule:weekly"
   ],
-  "ignorePaths": ["*/**"],
+  "includePaths": [
+    "synthtool/gcp/templates/java-library/.kokoro/presubmit/graalvm-native.*.cfg",
+    "requirements.in",
+    "requirements.txt"
+  ],
   "internalChecksFilter": "strict",
   "stabilityDays": 30,
   "timezone": "America/Los_Angeles",


### PR DESCRIPTION
Fixes #1786 

Emulates https://github.com/googleapis/google-cloud-java/blob/bf842646a173781330b35915e8886ab929323bd0/renovate.json#L12
