### PR TITLE
chore: fix syntax for graalvm job config in renovate bot settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,9 +16,9 @@
       "fileMatch": ["^synthtool/gcp/templates/java-library/.kokoro/presubmit/graalvm-native.*.cfg"],
       "matchStrings": ["value: \"gcr.io/cloud-devrel-kokoro-resources/graalvm:(?<currentValue>.*?)\"",
         "value: \"gcr.io/cloud-devrel-kokoro-resources/graalvm17:(?<currentValue>.*?)\""],
-      "depNameTemplate": "jdk",
-      "datasourceTemplate": "docker",
-      "packageNameTemplate": "ghcr.io/graalvm/jdk"
+      "depNameTemplate": "ghcr.io/graalvm/graalvm-ce",
+      "datasourceTemplate": "docker"
+
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "schedule:weekly"
   ],
   "includePaths": [
-    "synthtool/gcp/templates/java-library/.kokoro/presubmit/graalvm-native.*.cfg",
+    "synthtool/gcp/templates/java-library/.kokoro/presubmit/graalvm-native*.cfg",
     "requirements.in",
     "requirements.txt"
   ],


### PR DESCRIPTION
Renovate bot was enabled for graalvm native image job config files but they are still not getting updates. This PR fixes some syntax issues that previously existed in the settings. Verified with https://github.com/mpeddada1/renovate-bot-test/pull/24