### PR TITLE
chore: fix directory name in renovate bot settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "schedule:weekly"
   ],
   "includePaths": [
-    "synthtool/gcp/templates/java-library/.kokoro/presubmit/graalvm-native*.cfg",
+    "synthtool/gcp/templates/java_library/.kokoro/presubmit/graalvm-native*.cfg",
     "requirements.in",
     "requirements.txt"
   ],
@@ -13,7 +13,7 @@
   "enabledManagers": ["regex"],
   "regexManagers": [
     {
-      "fileMatch": ["^synthtool/gcp/templates/java-library/.kokoro/presubmit/graalvm-native.*.cfg"],
+      "fileMatch": ["^synthtool/gcp/templates/java_library/.kokoro/presubmit/graalvm-native.*.cfg"],
       "matchStrings": ["value: \"gcr.io/cloud-devrel-kokoro-resources/graalvm:(?<currentValue>.*?)\"",
         "value: \"gcr.io/cloud-devrel-kokoro-resources/graalvm17:(?<currentValue>.*?)\""],
       "depNameTemplate": "ghcr.io/graalvm/graalvm-ce",


### PR DESCRIPTION
https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/java_library/.kokoro/presubmit/graalvm-native-17.cfg is still not receiving updates. This PR fixes the directory name specified in renovate bot. 