### PR TITLE
chore: Java 8 unit test to build code in Java 17 and run tests on Java 8

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/sync-repo-settings.yaml
+++ b/synthtool/gcp/templates/java_library/.github/sync-repo-settings.yaml
@@ -41,7 +41,7 @@ branchProtectionRules:
   requiresStrictStatusChecks: false
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
-  - "dependencies (11)"
+  - "dependencies (17)"
   - "lint"
   - "units (8)"
   - "units (11)"

--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -46,7 +46,10 @@ jobs:
         with:
           java-version: 8
           distribution: zulu
-      - run: echo "JAVA8_HOME=${JAVA_HOME}" >> $GITHUB_ENV
+      - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
+        # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
+        # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
+        run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
         shell: bash
       - uses: actions/setup-java@v3
         with:
@@ -73,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [17]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3

--- a/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/java_library/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17]
+        java: [11, 17]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
@@ -36,6 +36,25 @@ jobs:
     - run: .kokoro/build.sh
       env:
         JOB_TYPE: test
+  units-java8:
+    # Building using Java 17 and run the tests with Java 8 runtime
+    name: "units (8)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: zulu
+      - run: echo "JAVA8_HOME=${JAVA_HOME}" >> $GITHUB_ENV
+        shell: bash
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: zulu
+      - run: .kokoro/build.sh
+        env:
+          JOB_TYPE: test
   windows:
     runs-on: windows-latest
     steps:

--- a/synthtool/gcp/templates/java_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.sh
@@ -47,7 +47,17 @@ set +e
 
 case ${JOB_TYPE} in
 test)
-    mvn test -B -ntp -Dclirr.skip=true -Denforcer.skip=true
+    # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
+    # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
+    # If we rely on certain things only available in newer JVM than Java 8, this
+    # tests detect the usage.
+    SUREFIRE_JVM_OPT=""
+    if [ -n "${JAVA8_HOME}" ]; then
+      SUREFIRE_JVM_OPT="-Djvm=${JAVA8_HOME}/bin/java"
+      echo "To use ${SUREFIRE_JVM_OPT} for unit tests runtime"
+    fi
+
+    mvn test -B -ntp -Dclirr.skip=true -Denforcer.skip=true ${SUREFIRE_JVM_OPT}
     RETURN_CODE=$?
     ;;
 lint)

--- a/synthtool/gcp/templates/java_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/java_library/.kokoro/build.sh
@@ -47,16 +47,7 @@ set +e
 
 case ${JOB_TYPE} in
 test)
-    # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
-    # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
-    # If we rely on certain things only available in newer JVM than Java 8, this
-    # tests detect the usage.
-    SUREFIRE_JVM_OPT=""
-    if [ -n "${JAVA8_HOME}" ]; then
-      SUREFIRE_JVM_OPT="-Djvm=${JAVA8_HOME}/bin/java"
-      echo "To use ${SUREFIRE_JVM_OPT} for unit tests runtime"
-    fi
-
+    echo "SUREFIRE_JVM_OPT: ${SUREFIRE_JVM_OPT}"
     mvn test -B -ntp -Dclirr.skip=true -Denforcer.skip=true ${SUREFIRE_JVM_OPT}
     RETURN_CODE=$?
     ;;


### PR DESCRIPTION
It worked in https://github.com/googleapis/java-storage/pull/2081 (closed after confirming it works).

* Our Java projects are configured to produce Java 8-compatible bytecode via https://github.com/googleapis/java-shared-config/blob/main/pom.xml#L848. This change ensures this config is applied correctly.
* This change also switches the JDK distribution of GitHub Actions to temurin from zulu.
* For the repositories that mark "dependencies (8)" and "dependencies (11)" as required, they should point to only "dependencies (17)" via `.github/sync-repo-settings.yaml`. I'll create pull requests to the repositories, or add necessary commit to derived owl-bot-update-lock pull requests.
