### PR TITLE
chore: remove pinned Sphinx version [autoapprove]

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -372,10 +372,9 @@ def docfx(session):
 
     session.install("-e", ".")
     session.install(
-        "sphinx==4.0.1",
+        "gcp-sphinx-docfx-yaml",
         "alabaster",
         "recommonmark",
-        "gcp-sphinx-docfx-yaml",
     )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)


### PR DESCRIPTION
Use the default pinned version that's specified in the DocFX YAML plugin for `docfx` job. We shouldn't have redundancy / discrepancy in versions between the pinned Sphinx version specified and the plugin. This was necessary before, but shouldn't be necessary now that the plugin specifies the required Sphinx version.