### PR TITLE
chore: fix link to noxfile in monorepo

### DIFF
--- a/synthtool/gcp/templates/python_mono_repo_library/CONTRIBUTING.rst
+++ b/synthtool/gcp/templates/python_mono_repo_library/CONTRIBUTING.rst
@@ -240,7 +240,7 @@ We support:
 
 Supported versions can be found in our ``noxfile.py`` `config`_.
 
-.. _config: https://github.com/{{ metadata['repo']['repo'] }}/blob/main/noxfile.py
+.. _config: https://github.com/{{ metadata['repo']['repo'] }}/blob/main/packages/{{ metadata['repo']['distribution_name'] }}/noxfile.py
 
 
 **********


### PR DESCRIPTION
Addresses https://github.com/googleapis/google-cloud-python/pull/11463#discussion_r1254894988