### PR TITLE
docs: update README's sample link

### DIFF
--- a/synthtool/gcp/templates/python_library/README.rst
+++ b/synthtool/gcp/templates/python_library/README.rst
@@ -51,7 +51,9 @@ dependencies.
 Code samples and snippets
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Code samples and snippets live in the `samples/` folder.
+Code samples and snippets live in the `samples/`_ folder.
+
+.. _samples/: https://github.com/{{ metadata['repo']['repo'] }}/tree/main/samples
 
 
 Supported Python Versions

--- a/synthtool/gcp/templates/python_mono_repo_library/README.rst
+++ b/synthtool/gcp/templates/python_mono_repo_library/README.rst
@@ -51,7 +51,9 @@ dependencies.
 Code samples and snippets
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Code samples and snippets live in the `samples/` folder.
+Code samples and snippets live in the `samples/`_ folder.
+
+.. _samples/: https://github.com/googleapis/google-cloud-python/tree/main/packages/{{ metadata['repo']['distribution_name'] }}/samples
 
 
 Supported Python Versions


### PR DESCRIPTION
Currently the sample section does not provide a direct link. Although this is not the hardest thing to probably figure out while you're on GitHub, it can be difficult outside of that context so we should provide a direct link. For example, https://cloud.google.com/python/docs/reference/storageinsights/latest#code-samples-and-snippets does not have a direct link. Still helps to provide a link on GitHub as well :)

Working example with the monorepo: https://github.com/googleapis/google-cloud-python/blob/readme_Test/packages/google-cloud-storageinsights/README.rst

Towards b/291087837.