### PR TITLE
build: update Node.js version and base Debian version

### DIFF
--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Version 0.2.0
+# Version 0.3.0
 
 # build from the root of this repo:
 # docker build -t gcr.io/repo-automation-bots/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .
-FROM python:3.10.6-buster
+FROM python:3.10.12-bookworm
 
 WORKDIR /
 
 ###################### Install nodejs.
-RUN curl -sL https://deb.nodesource.com/setup_15.x | bash -
-RUN apt-get install -y nodejs
+RUN curl https://nodejs.org/dist/v18.17.0/node-v18.17.0-linux-x64.tar.xz > /tmp/nodejs.tar.xz
+RUN tar -C /usr/local --strip-components=1 -xJf /tmp/nodejs.tar.xz
+RUN rm -f /tmp/nodejs.tar.xz
+ENV PATH "$PATH:/usr/local/bin"
 
 ###################### Install synthtool's requirements.
 COPY requirements.txt /synthtool/requirements.txt

--- a/docker/owlbot/nodejs/container_test.yaml
+++ b/docker/owlbot/nodejs/container_test.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0
 commandTests:
 - name: "node"
   command: ["node", "--version"]
-  expectedOutput: ["v15.14.0"]
+  expectedOutput: ["v18.17.0"]
 - name: "python"
   command: ["python", "--version"]
-  expectedOutput: ["Python 3.10.6"]
+  expectedOutput: ["Python 3.10.12"]

--- a/docker/owlbot/nodejs_mono_repo/Dockerfile
+++ b/docker/owlbot/nodejs_mono_repo/Dockerfile
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Version 0.2.0
+# Version 0.3.0
 
 # build from the root of this repo:
-# docker build -t gcr.io/repo-automation-bots/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .
-FROM python:3.10.6-buster
+# docker build -t gcr.io/repo-automation-bots/owlbot-nodejs-mono-repo -f docker/owlbot/nodejs_mono_repo/Dockerfile .
+FROM python:3.10.12-bookworm
 
 WORKDIR /
 
 ###################### Install nodejs.
-RUN curl -sL https://deb.nodesource.com/setup_15.x | bash -
-RUN apt-get install -y nodejs
+RUN curl https://nodejs.org/dist/v18.17.0/node-v18.17.0-linux-x64.tar.xz > /tmp/nodejs.tar.xz
+RUN tar -C /usr/local --strip-components=1 -xJf /tmp/nodejs.tar.xz
+RUN rm -f /tmp/nodejs.tar.xz
+ENV PATH "$PATH:/usr/local/bin"
 
 ###################### Install git.
 RUN apt-get update && apt-get install -y git

--- a/docker/owlbot/nodejs_mono_repo/container_test.yaml
+++ b/docker/owlbot/nodejs_mono_repo/container_test.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0.0
 commandTests:
 - name: "node"
   command: ["node", "--version"]
-  expectedOutput: ["v15.14.0"]
+  expectedOutput: ["v18.17.0"]
 - name: "python"
   command: ["python", "--version"]
-  expectedOutput: ["Python 3.10.6"]
+  expectedOutput: ["Python 3.10.12"]


### PR DESCRIPTION
Node.js v15 is EOL, and the newest version of `eslint` requires something newer since it uses new features (namely, `require("node:fs")` which does not work in Node 15.

While I'm here, I'm also updating the Debian base image to `bookworm` (`buster` is EOL), and fixing some typos in the comments.

Last but not least, let's not do `curl | bash` in Dockerfiles.