### PR TITLE
docs: add deprecation notice for python 3.7

### DIFF
--- a/synthtool/gcp/templates/python_library/README.rst
+++ b/synthtool/gcp/templates/python_library/README.rst
@@ -66,6 +66,16 @@ Python >= 3.7
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
+**NOTE**:
+Python 3.7 was marked as `unsupported`_ by the python community in June 2023.
+We recommend that all developers upgrade to Python 3.8 and newer as soon as
+they can. Support for Python 3.7 will be removed from all client libraries after
+January 1 2024. Client libraries that support Python 3.7 will continue to be available
+for download, but releases after January 1 2024 will only target Python 3.8 and
+newer.
+
+.. _unsupported: https://devguide.python.org/versions/#unsupported-versions
+
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Python <= 3.6

--- a/synthtool/gcp/templates/python_mono_repo_library/README.rst
+++ b/synthtool/gcp/templates/python_mono_repo_library/README.rst
@@ -66,6 +66,16 @@ Python >= 3.7
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
+**NOTE**:
+Python 3.7 was marked as `unsupported`_ by the python community in June 2023.
+We recommend that all developers upgrade to Python 3.8 and newer as soon as
+they can. Support for Python 3.7 will be removed from all client libraries after
+January 1 2024. Client libraries that support Python 3.7 will continue to be available
+for download, but releases after January 1 2024 will only target Python 3.8 and
+newer.
+
+.. _unsupported: https://devguide.python.org/versions/#unsupported-versions
+
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Python <= 3.6


### PR DESCRIPTION
Towards https://github.com/googleapis/google-cloud-python/issues/11437

See example downstream change here: https://github.com/googleapis/python-optimization/commit/fd38bfd025b6de808035b747838c4c0f3ed5c549