### PR TITLE
chore: for Java repos renovate bot to ignore GitHub Actions workflow file

### DIFF
--- a/synthtool/gcp/templates/java_library/renovate.json
+++ b/synthtool/gcp/templates/java_library/renovate.json
@@ -12,7 +12,10 @@
     ":maintainLockFilesDisabled",
     ":autodetectPinVersions"
   ],
-  "ignorePaths": [".kokoro/requirements.txt"],
+  "ignorePaths": [
+    ".kokoro/requirements.txt",
+    ".github/workflows/**"
+  ],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
The actions used in the GitHub Actions workflow files do not appear in libraries' dependencies and mostly maintained by Java postprocessor templates. This change will suppress the unnecessary pull requests like ttps://github.com/googleapis/java-firestore/pull/1412.

IgnorePath option document: https://docs.renovatebot.com/configuration-options/