### PR TITLE
chore: testing python test

### DIFF
--- a/synthtool/gcp/templates/python_library/docs/index.rst
+++ b/synthtool/gcp/templates/python_library/docs/index.rst
@@ -35,3 +35,5 @@ For a list of all ``{{ metadata['repo']['distribution_name'] }}`` releases:
     :maxdepth: 2
 
     changelog
+
+This is a test


### PR DESCRIPTION
Do not merge. This pull request is Just to see the validity of the test failures in https://github.com/googleapis/synthtool/pull/1856

There Kokoro CI failed: https://source.cloud.google.com/results/invocations/a1603b4f-1b4d-4a21-9cfc-afdff613edd9/targets/cloud-devrel%2Fclient-libraries%2Fsynthtool%2Fpresubmit/log

```
=================================== FAILURES ===================================
___________________________ test_walk_through_apiary ___________________________

mock_subproc_popen = <MagicMock name='run' id='139646549292848'>

    @patch("subprocess.run")
    def test_walk_through_apiary(mock_subproc_popen):
        process_mock = Mock()
        attrs = {"communicate.return_value": ("output", "error")}
        process_mock.configure_mock(**attrs)
        mock_subproc_popen.return_value = process_mock
        dirs = node.walk_through_apiary(FIXTURES / "node_apiary", "src/apis/**/*")
        assert not mock_subproc_popen.called
>       assert re.search("src/apis/admin", dirs[0])
E       AssertionError: assert None
E        +  where None = <function search at 0x7f020127b760>('src/apis/admin', '/tmpfs/src/github/synthtool/tests/fixtures/node_apiary/src/apis/docs')
E        +    where <function search at 0x7f020127b760> = re.search
```