### PR TITLE
build: install dependencies directly from the repo

### DIFF
--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -49,7 +49,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax and gapic-tools are used for compiling protos.
-RUN cd /synthtool && mkdir node_modules
+RUN cd /synthtool && mkdir node_modules && cd ../
 RUN npm install --prefix synthtool/node_modules
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -45,12 +45,10 @@ COPY post-processor-changes.txt /post-processor-changes.txt
 RUN find /synthtool -exec chmod a+r {} \;
 RUN find /synthtool -type d -exec chmod a+x {} \;
 
-# Install dependencies used for post processing:
-# * gts/typescript are used for linting.
-# * google-gax and gapic-tools are used for compiling protos.
+# Install dependencies used for post processing
+# Since we're running in a clone of the library, we'll have access to it's package.json
 COPY package.json /package.json
 RUN npm install --ignore-scripts
-RUN cd /node_modules && echo $(ls -a)
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -54,7 +54,7 @@ COPY package.json /package.json
 RUN cd /synthtool && mkdir node_modules && cd ../
 RUN echo $(pwd)
 RUN echo $(ls -a)
-RUN npm install --ignore-scripts --prefix /synthtool/node_modules -g
+RUN npm install --ignore-scripts -g --prefix /synthtool
 RUN cd synthtool/node_modules && echo $(ls -a)
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -45,10 +45,6 @@ COPY post-processor-changes.txt /post-processor-changes.txt
 RUN find /synthtool -exec chmod a+r {} \;
 RUN find /synthtool -type d -exec chmod a+x {} \;
 
-# Install dependencies used for post processing
-# Since we're running in a clone of the library, we'll have access to it's package.json
-COPY package.json /package.json
-RUN npm install --ignore-scripts
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -45,7 +45,7 @@ COPY post-processor-changes.txt /post-processor-changes.txt
 RUN find /synthtool -exec chmod a+r {} \;
 RUN find /synthtool -type d -exec chmod a+x {} \;
 
-RUN npm i @google-cloud/typeless-sample-bot@1.3.3
+RUN npm install @google-cloud/typeless-sample-bot@1.3.3
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -17,8 +17,6 @@
 # build from the root of this repo:
 # docker build -t gcr.io/repo-automation-bots/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .
 FROM python:3.10.12-bookworm
-RUN echo $(pwd)
-RUN echo $(ls -a)
 WORKDIR /
 
 ###################### Install nodejs.

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -54,7 +54,8 @@ COPY package.json /package.json
 RUN cd /synthtool && mkdir node_modules && cd ../
 RUN echo $(pwd)
 RUN echo $(ls -a)
-RUN npm install --ignore-scripts
+RUN npm install --ignore-scripts --prefix /synthtool/node_modules
+RUN cd synthtool/node_modules && echo $(ls -a)
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -49,8 +49,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax and gapic-tools are used for compiling protos.
-RUN cd /synthtool && mkdir node_modules && npm i gts@5.0.0 google-gax@4.0.3 \
-    typescript@5.1.6 @google-cloud/typeless-sample-bot@1.3.3 gapic-tools@0.1.8
+RUN npm install
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -54,7 +54,7 @@ COPY package.json /package.json
 RUN cd /synthtool && mkdir node_modules && cd ../
 RUN echo $(pwd)
 RUN echo $(ls -a)
-RUN npm install --ignore-scripts --prefix synthtool/node_modules -g
+RUN npm install --prefix synthtool/node_modules -g --ignore-scripts
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -49,7 +49,6 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # * gts/typescript are used for linting.
 # * google-gax and gapic-tools are used for compiling protos.
 RUN cd /synthtool && mkdir node_modules && cd ../
-RUN curl -LJO https://raw.githubusercontent.com/googleapis/nodejs-bigtable/main/package.json
 RUN echo $(pwd)
 RUN echo $(ls -a)
 RUN npm install --prefix synthtool/node_modules

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -17,7 +17,8 @@
 # build from the root of this repo:
 # docker build -t gcr.io/repo-automation-bots/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .
 FROM python:3.10.12-bookworm
-
+RUN echo $(pwd)
+RUN echo $(ls -a)
 WORKDIR /
 
 ###################### Install nodejs.
@@ -52,6 +53,9 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 RUN echo $(pwd)
 RUN echo $(ls -a)
 RUN cd /synthtool && mkdir node_modules && cd ../
+RUN cd /workspace
+RUN echo $(pwd)
+RUN echo $(ls -a)
 RUN npm install --prefix synthtool/node_modules
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -50,7 +50,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # * google-gax and gapic-tools are used for compiling protos.
 COPY package.json /package.json
 RUN npm install --ignore-scripts
-RUN cd node_modules && echo $(ls -a)
+RUN cd /node_modules && echo $(ls -a)
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -54,7 +54,7 @@ COPY package.json /package.json
 RUN cd /synthtool && mkdir node_modules && cd ../
 RUN echo $(pwd)
 RUN echo $(ls -a)
-RUN npm install --prefix synthtool/node_modules  --ignore-scripts -g
+RUN npm install --ignore-scripts --prefix synthtool/node_modules -g
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -51,11 +51,8 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # * gts/typescript are used for linting.
 # * google-gax and gapic-tools are used for compiling protos.
 COPY package.json /package.json
-RUN cd /synthtool && mkdir node_modules && cd ../
-RUN echo $(pwd)
-RUN echo $(ls -a)
-RUN npm install --ignore-scripts --prefix /synthtool
-RUN cd /synthtool/node_modules && echo $(ls -a)
+RUN npm install --ignore-scripts
+RUN cd node_modules && echo $(ls -a)
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -49,7 +49,8 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax and gapic-tools are used for compiling protos.
-RUN npm install
+RUN cd /synthtool && mkdir node_modules
+RUN npm install --prefix synthtool/node_modules
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -54,7 +54,7 @@ COPY package.json /package.json
 RUN cd /synthtool && mkdir node_modules && cd ../
 RUN echo $(pwd)
 RUN echo $(ls -a)
-RUN npm install --prefix synthtool/node_modules
+RUN npm install --prefix synthtool/node_modules -g
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -45,7 +45,7 @@ COPY post-processor-changes.txt /post-processor-changes.txt
 RUN find /synthtool -exec chmod a+r {} \;
 RUN find /synthtool -type d -exec chmod a+x {} \;
 
-RUN npm install @google-cloud/typeless-sample-bot@1.3.3
+RUN cd /synthtool && mkdir node_modules && npm install @google-cloud/typeless-sample-bot@1.3.3
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -54,7 +54,7 @@ COPY package.json /package.json
 RUN cd /synthtool && mkdir node_modules && cd ../
 RUN echo $(pwd)
 RUN echo $(ls -a)
-RUN npm install --ignore-scripts --prefix /synthtool/node_modules
+RUN npm install --ignore-scripts --prefix /synthtool/node_modules -g
 RUN cd synthtool/node_modules && echo $(ls -a)
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -17,8 +17,6 @@
 # build from the root of this repo:
 # docker build -t gcr.io/repo-automation-bots/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .
 FROM python:3.10.12-bookworm
-RUN echo $(pwd)
-RUN echo $(ls -a)
 WORKDIR /
 
 ###################### Install nodejs.
@@ -50,10 +48,8 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax and gapic-tools are used for compiling protos.
-RUN echo $(pwd)
-RUN echo $(ls -a)
 RUN cd /synthtool && mkdir node_modules && cd ../
-RUN cd /workspace
+RUN curl -LJO https://raw.githubusercontent.com/googleapis/nodejs-bigtable/main/package.json
 RUN echo $(pwd)
 RUN echo $(ls -a)
 RUN npm install --prefix synthtool/node_modules

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -50,6 +50,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # * gts/typescript are used for linting.
 # * google-gax and gapic-tools are used for compiling protos.
 RUN echo $(pwd)
+RUN echo $(ls -a)
 RUN cd /synthtool && mkdir node_modules && cd ../
 RUN npm install --prefix synthtool/node_modules
 

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -55,7 +55,7 @@ RUN cd /synthtool && mkdir node_modules && cd ../
 RUN echo $(pwd)
 RUN echo $(ls -a)
 RUN npm install --ignore-scripts --prefix /synthtool
-RUN cd synthtool/node_modules && echo $(ls -a)
+RUN cd /synthtool/node_modules && echo $(ls -a)
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -54,7 +54,7 @@ COPY package.json /package.json
 RUN cd /synthtool && mkdir node_modules && cd ../
 RUN echo $(pwd)
 RUN echo $(ls -a)
-RUN npm install --ignore-scripts -g --prefix /synthtool
+RUN npm install --ignore-scripts --prefix /synthtool
 RUN cd synthtool/node_modules && echo $(ls -a)
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -49,6 +49,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax and gapic-tools are used for compiling protos.
+RUN echo $(pwd)
 RUN cd /synthtool && mkdir node_modules && cd ../
 RUN npm install --prefix synthtool/node_modules
 

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -17,6 +17,8 @@
 # build from the root of this repo:
 # docker build -t gcr.io/repo-automation-bots/owlbot-nodejs -f docker/owlbot/nodejs/Dockerfile .
 FROM python:3.10.12-bookworm
+RUN echo $(pwd)
+RUN echo $(ls -a)
 WORKDIR /
 
 ###################### Install nodejs.

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -54,7 +54,7 @@ COPY package.json /package.json
 RUN cd /synthtool && mkdir node_modules && cd ../
 RUN echo $(pwd)
 RUN echo $(ls -a)
-RUN npm install --prefix synthtool/node_modules -g
+RUN npm install --prefix synthtool/node_modules  --ignore-scripts -g
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -45,6 +45,7 @@ COPY post-processor-changes.txt /post-processor-changes.txt
 RUN find /synthtool -exec chmod a+r {} \;
 RUN find /synthtool -type d -exec chmod a+x {} \;
 
+RUN npm i @google-cloud/typeless-sample-bot@1.3.3
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -54,7 +54,7 @@ COPY package.json /package.json
 RUN cd /synthtool && mkdir node_modules && cd ../
 RUN echo $(pwd)
 RUN echo $(ls -a)
-RUN npm install --prefix synthtool/node_modules -g --ignore-scripts
+RUN npm install --ignore-scripts
 
 ENTRYPOINT [ "/bin/bash" ]
 CMD [ "/synthtool/docker/owlbot/nodejs/entrypoint.sh" ]

--- a/docker/owlbot/nodejs/Dockerfile
+++ b/docker/owlbot/nodejs/Dockerfile
@@ -50,6 +50,7 @@ RUN find /synthtool -type d -exec chmod a+x {} \;
 # Install dependencies used for post processing:
 # * gts/typescript are used for linting.
 # * google-gax and gapic-tools are used for compiling protos.
+COPY package.json /package.json
 RUN cd /synthtool && mkdir node_modules && cd ../
 RUN echo $(pwd)
 RUN echo $(ls -a)

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -13,6 +13,7 @@ steps:
           sed -i "s/([^()]*)$//g" post-processor-changes.txt &&
           sed -i "s/^\(feat\|fix\)/chore/g" post-processor-changes.txt &&
           sed -i "s/\!:/:/g" post-processor-changes.txt
+  # Copy any package.json to mimic the container running in a clone of a given repo
   - name: 'gcr.io/cloud-builders/git'
     entrypoint: '/bin/sh'
     args:

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -23,15 +23,9 @@ steps:
       - --no-single-branch
       - https://github.com/googleapis/nodejs-bigtable.git
       - /library
-  - name: 'gcr.io/cloud-builders/git'
-    entrypoint: '/bin/sh'
-    args:
-      - echo
-      - ($pwd)
-      - echo
-      - ($ls)
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
+    dir: '/library/nodejs-bigtable'
     id: 'build'
     args: [ 'build',
       '-t', 'gcr.io/repo-automation-bots/owlbot-nodejs:$SHORT_SHA',

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -22,6 +22,7 @@ steps:
       - '100'
       - --no-single-branch
       - https://github.com/googleapis/nodejs-bigtable.git
+      - /workspace/
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build'

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -23,9 +23,13 @@ steps:
       - --no-single-branch
       - https://github.com/googleapis/nodejs-bigtable.git
       - /library
-    volumes:
-    - name: 'myvolume'
-      path: '/library'
+  - name: 'gcr.io/cloud-builders/git'
+    entrypoint: '/bin/sh'
+    args:
+      - echo
+      - ($pwd)
+      - echo
+      - ($ls)
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build'

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -33,6 +33,8 @@ steps:
       '-t', 'gcr.io/cloud-devrel-public-resources/owlbot-nodejs:$SHORT_SHA',
       '-t', 'gcr.io/cloud-devrel-public-resources/owlbot-nodejs:latest',
       '-f', 'docker/owlbot/nodejs/Dockerfile', '.' ]
+    env:
+      - 'HOME=/workspace'
   # Run container tests
   - name: gcr.io/gcp-runtimes/container-structure-test
     args:

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -22,7 +22,7 @@ steps:
       - '100'
       - --no-single-branch
       - https://github.com/googleapis/nodejs-bigtable.git
-      - /workspace/
+      - /workspace/library
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build'

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -22,6 +22,8 @@ steps:
       - '100'
       - --no-single-branch
       - https://github.com/googleapis/nodejs-bigtable.git
+    env:
+      - 'HOME=/workspace'
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build'

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -39,9 +39,6 @@ steps:
       '-t', 'gcr.io/cloud-devrel-public-resources/owlbot-nodejs:$SHORT_SHA',
       '-t', 'gcr.io/cloud-devrel-public-resources/owlbot-nodejs:latest',
       '-f', 'docker/owlbot/nodejs/Dockerfile', '.' ]
-    volumes:
-    - name: 'myvolume'
-      path: '/library'
   # Run container tests
   - name: gcr.io/gcp-runtimes/container-structure-test
     args:

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -14,15 +14,11 @@ steps:
           sed -i "s/^\(feat\|fix\)/chore/g" post-processor-changes.txt &&
           sed -i "s/\!:/:/g" post-processor-changes.txt
   - name: 'gcr.io/cloud-builders/git'
+    entrypoint: '/bin/sh'
     args:
-      - clone
-      - -b
-      - main
-      - --depth
-      - '100'
-      - --no-single-branch
-      - https://github.com/googleapis/nodejs-bigtable.git
-      - /library
+      - '-c'
+        - |
+          curl -LJO https://raw.githubusercontent.com/googleapis/nodejs-bigtable/main/package.json
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
     dir: '/library/nodejs-bigtable'

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -13,6 +13,15 @@ steps:
           sed -i "s/([^()]*)$//g" post-processor-changes.txt &&
           sed -i "s/^\(feat\|fix\)/chore/g" post-processor-changes.txt &&
           sed -i "s/\!:/:/g" post-processor-changes.txt
+  - name: 'gcr.io/cloud-builders/git'
+    args:
+      - clone
+      - -b
+      - main
+      - --depth
+      - '100'
+      - --no-single-branch
+      - https://github.com/googleapis/nodejs-bigtable.git
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build'

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -17,8 +17,8 @@ steps:
     entrypoint: '/bin/sh'
     args:
       - '-c'
-        - |
-          curl -LJO https://raw.githubusercontent.com/googleapis/nodejs-bigtable/main/package.json
+      - |
+        curl -LJO https://raw.githubusercontent.com/googleapis/nodejs-bigtable/main/package.json
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
     dir: '/library/nodejs-bigtable'

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -22,8 +22,10 @@ steps:
       - '100'
       - --no-single-branch
       - https://github.com/googleapis/nodejs-bigtable.git
-    env:
-      - 'HOME=/workspace'
+      - /workspace
+    volumes:
+    - name: 'myvolume'
+      path: '/workspace'
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build'
@@ -33,8 +35,9 @@ steps:
       '-t', 'gcr.io/cloud-devrel-public-resources/owlbot-nodejs:$SHORT_SHA',
       '-t', 'gcr.io/cloud-devrel-public-resources/owlbot-nodejs:latest',
       '-f', 'docker/owlbot/nodejs/Dockerfile', '.' ]
-    env:
-      - 'HOME=/workspace'
+    volumes:
+    - name: 'myvolume'
+      path: '/workspace'
   # Run container tests
   - name: gcr.io/gcp-runtimes/container-structure-test
     args:

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -22,10 +22,10 @@ steps:
       - '100'
       - --no-single-branch
       - https://github.com/googleapis/nodejs-bigtable.git
-      - /workspace
+      - /library
     volumes:
     - name: 'myvolume'
-      path: '/workspace'
+      path: '/library'
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build'
@@ -37,7 +37,7 @@ steps:
       '-f', 'docker/owlbot/nodejs/Dockerfile', '.' ]
     volumes:
     - name: 'myvolume'
-      path: '/workspace'
+      path: '/library'
   # Run container tests
   - name: gcr.io/gcp-runtimes/container-structure-test
     args:

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -13,13 +13,6 @@ steps:
           sed -i "s/([^()]*)$//g" post-processor-changes.txt &&
           sed -i "s/^\(feat\|fix\)/chore/g" post-processor-changes.txt &&
           sed -i "s/\!:/:/g" post-processor-changes.txt
-  # Copy any package.json to mimic the container running in a clone of a given repo
-  - name: 'gcr.io/cloud-builders/git'
-    entrypoint: '/bin/sh'
-    args:
-      - '-c'
-      - |
-        curl -LJO https://raw.githubusercontent.com/googleapis/nodejs-bigtable/main/package.json
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build'

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -21,7 +21,6 @@ steps:
         curl -LJO https://raw.githubusercontent.com/googleapis/nodejs-bigtable/main/package.json
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
-    dir: '/library/nodejs-bigtable'
     id: 'build'
     args: [ 'build',
       '-t', 'gcr.io/repo-automation-bots/owlbot-nodejs:$SHORT_SHA',

--- a/docker/owlbot/nodejs/cloudbuild_test.yaml
+++ b/docker/owlbot/nodejs/cloudbuild_test.yaml
@@ -22,7 +22,6 @@ steps:
       - '100'
       - --no-single-branch
       - https://github.com/googleapis/nodejs-bigtable.git
-      - /workspace/library
   # Build the docker image.
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build'

--- a/docker/owlbot/nodejs/entrypoint.sh
+++ b/docker/owlbot/nodejs/entrypoint.sh
@@ -15,7 +15,7 @@
 
 set -ex
 
-npm i --ignore-scripts
+npm i --only=dev --ignore-scripts
 
 if [ -f owlbot.py ]; then
     python owlbot.py

--- a/docker/owlbot/nodejs/entrypoint.sh
+++ b/docker/owlbot/nodejs/entrypoint.sh
@@ -15,6 +15,8 @@
 
 set -ex
 
+npm i --ignore-scripts
+
 if [ -f owlbot.py ]; then
     python owlbot.py
 else

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -188,7 +188,7 @@ def typeless_samples_hermetic(hide_output=False):
     logger.debug("Run typeless sample bot")
     shell.run(
         [
-            "node_modules/.bin/typeless-sample-bot",
+            "/node_modules/.bin/typeless-sample-bot",
             "--outputpath",
             "samples",
             "--targets",
@@ -219,13 +219,13 @@ def fix_hermetic(hide_output=False):
     """
     logger.debug("Copy eslint config")
     shell.run(
-        ["cp", "-r", "node_modules", "."],
+        ["cp", "-r", "/node_modules", "."],
         check=True,
         hide_output=hide_output,
     )
     logger.debug("Running fix...")
     shell.run(
-        ["node_modules/.bin/gts", "fix"],
+        ["/node_modules/.bin/gts", "fix"],
         check=False,
         hide_output=hide_output,
     )
@@ -248,7 +248,7 @@ def compile_protos_hermetic(hide_output=False):
     """
     logger.debug("Compiling protos...")
     shell.run(
-        ["node_modules/.bin/compileProtos", "src"],
+        ["/node_modules/.bin/compileProtos", "src"],
         check=True,
         hide_output=hide_output,
     )

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -26,7 +26,6 @@ import shutil
 from synthtool.languages import common
 
 _REQUIRED_FIELDS = ["name", "repository", "engines"]
-_TOOLS_DIRECTORY = "/synthtool"
 _GENERATED_SAMPLES_DIRECTORY = "./samples/generated"
 
 
@@ -189,7 +188,7 @@ def typeless_samples_hermetic(hide_output=False):
     logger.debug("Run typeless sample bot")
     shell.run(
         [
-            f"{_TOOLS_DIRECTORY}/node_modules/.bin/typeless-sample-bot",
+            "node_modules/.bin/typeless-sample-bot",
             "--outputpath",
             "samples",
             "--targets",
@@ -220,13 +219,13 @@ def fix_hermetic(hide_output=False):
     """
     logger.debug("Copy eslint config")
     shell.run(
-        ["cp", "-r", f"{_TOOLS_DIRECTORY}/node_modules", "."],
+        ["cp", "-r", "node_modules", "."],
         check=True,
         hide_output=hide_output,
     )
     logger.debug("Running fix...")
     shell.run(
-        [f"{_TOOLS_DIRECTORY}/node_modules/.bin/gts", "fix"],
+        ["node_modules/.bin/gts", "fix"],
         check=False,
         hide_output=hide_output,
     )
@@ -249,7 +248,7 @@ def compile_protos_hermetic(hide_output=False):
     """
     logger.debug("Compiling protos...")
     shell.run(
-        [f"{_TOOLS_DIRECTORY}/node_modules/.bin/compileProtos", "src"],
+        ["node_modules/.bin/compileProtos", "src"],
         check=True,
         hide_output=hide_output,
     )

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -188,7 +188,7 @@ def typeless_samples_hermetic(hide_output=False):
     logger.debug("Run typeless sample bot")
     shell.run(
         [
-            "/node_modules/.bin/typeless-sample-bot",
+            f"{_TOOLS_DIRECTORY}/node_modules/.bin/typeless-sample-bot",
             "--outputpath",
             "samples",
             "--targets",

--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -26,6 +26,7 @@ import shutil
 from synthtool.languages import common
 
 _REQUIRED_FIELDS = ["name", "repository", "engines"]
+_TOOLS_DIRECTORY = "/synthtool"
 _GENERATED_SAMPLES_DIRECTORY = "./samples/generated"
 
 


### PR DESCRIPTION
Node keeps running into an issue where the linter fails because it has a slightly different dependency tree than the linter owlbot runs. Ideally, they'd just run the same linting.