### PR TITLE
chore(python_library): ignore venv/ folder in .gitignore

### DIFF
--- a/synthtool/gcp/templates/python_library/.gitignore
+++ b/synthtool/gcp/templates/python_library/.gitignore
@@ -50,6 +50,7 @@ docs.metadata
 
 # Virtual environment
 env/
+venv/
 
 # Test logs
 coverage.xml


### PR DESCRIPTION
venv is a common name for the venv/virtualenv folder.