### PR TITLE
build(python_mono_repo): remove system tests from prerelease_deps nox session

### DIFF
--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -472,24 +472,3 @@ def prerelease_deps(session):
     session.run("python", "-c", "import google.auth; print(google.auth.__version__)")
 
     session.run("py.test", "tests/unit")
-
-    system_test_path = os.path.join("tests", "system.py")
-    system_test_folder_path = os.path.join("tests", "system")
-
-    # Only run system tests if found.
-    if os.path.exists(system_test_path):
-        session.run(
-            "py.test",
-            "--verbose",
-            f"--junitxml=system_{session.python}_sponge_log.xml",
-            system_test_path,
-            *session.posargs,
-        )
-    if os.path.exists(system_test_folder_path):
-        session.run(
-            "py.test",
-            "--verbose",
-            f"--junitxml=system_{session.python}_sponge_log.xml",
-            system_test_folder_path,
-            *session.posargs,
-        )


### PR DESCRIPTION
We currently run the `prerelease_deps` nox session in Github actions in the monorepo `google-cloud-python`. Currently this session includes running system tests. It is not possible for us to run the system tests in Github actions due to the requirement to have valid credentials. System tests should only be run using the `system` nox session via Kokoro.

https://github.com/googleapis/synthtool/blob/b9b4907fa59c31952c9b10be4abb0cf3d01f3159/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2#L287-L293

This change should not impact existing testing for client libraries in the monorepo as the monorepo does not currently contain any system tests.