### PR TITLE
chore: correct path to node_modules

### DIFF
--- a/synthtool/languages/node.py
+++ b/synthtool/languages/node.py
@@ -220,13 +220,13 @@ def fix_hermetic(hide_output=False):
     """
     logger.debug("Copy eslint config")
     shell.run(
-        ["cp", "-r", "/node_modules", "."],
+        ["cp", "-r", "node_modules", "."],
         check=True,
         hide_output=hide_output,
     )
     logger.debug("Running fix...")
     shell.run(
-        ["/node_modules/.bin/gts", "fix"],
+        ["node_modules/.bin/gts", "fix"],
         check=False,
         hide_output=hide_output,
     )
@@ -249,7 +249,7 @@ def compile_protos_hermetic(hide_output=False):
     """
     logger.debug("Compiling protos...")
     shell.run(
-        ["/node_modules/.bin/compileProtos", "src"],
+        ["node_modules/.bin/compileProtos", "src"],
         check=True,
         hide_output=hide_output,
     )


### PR DESCRIPTION
Should fix: https://github.com/googleapis/nodejs-bigquery-migration/pull/61