### PR TITLE
fix(nodejs): Add `system-test/fixtures` to `.eslintignore`

### DIFF
--- a/synthtool/gcp/templates/node_library/.eslintignore
+++ b/synthtool/gcp/templates/node_library/.eslintignore
@@ -5,3 +5,4 @@ build/
 docs/
 protos/
 samples/generated/
+system-test/fixtures

--- a/synthtool/gcp/templates/node_library/.eslintignore
+++ b/synthtool/gcp/templates/node_library/.eslintignore
@@ -5,4 +5,4 @@ build/
 docs/
 protos/
 samples/generated/
-system-test/fixtures
+system-test/**/fixtures


### PR DESCRIPTION
We have some mismatches between the files `eslint` lints and `tsconfig` checks - which will cause some errors [in a future release](https://github.com/google/gts/issues/793) of `gts` and `eslint`.

We can prepare for this upgrade and remove this mismatch for many of our libraries, including:
- https://github.com/googleapis/nodejs-googleapis-common
- https://github.com/googleapis/google-auth-library-nodejs
- https://github.com/googleapis/gaxios
- and others with 'fixtures' in system-tests