### PR TITLE
chore(python): in .coveragerc, ignore branches that aren't really branches

### DIFF
--- a/synthtool/gcp/templates/python_library/.coveragerc
+++ b/synthtool/gcp/templates/python_library/.coveragerc
@@ -31,6 +31,8 @@ exclude_lines =
     def __repr__
     # Ignore abstract methods
     raise NotImplementedError
+    # Ignore branches that aren't really branches in tests
+    with pytest.raises
 omit =
   */gapic/*.py
   */proto/*.py


### PR DESCRIPTION
We don't expect `with pytest.raises...:` "branches" to fail in passing tests.