### PR TITLE
chore(python_mono_repo): add support for grafeas

### DIFF
--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -28,7 +28,11 @@ import nox
 
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
+{% if metadata['repo']['distribution_name'].startswith('google') %}
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
+{% else %}
+LINT_PATHS = ["docs", "{{ metadata['repo']['distribution_name'] }}", "tests", "noxfile.py", "setup.py"]
+{% endif %}
 
 DEFAULT_PYTHON_VERSION = "{{ default_python_version }}"
 
@@ -156,7 +160,11 @@ def lint(session):
         "--check",
         *LINT_PATHS,
     )
+    {% if metadata['repo']['distribution_name'].startswith('google') %}
     session.run("flake8", "google", "tests")
+    {% else %}
+    session.run("flake8", "{{ metadata['repo']['distribution_name'] }}", "tests")
+    {% endif %}
 
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)
@@ -237,7 +245,11 @@ def default(session):
         "py.test",
         "--quiet",
         f"--junitxml=unit_{session.python}_sponge_log.xml",
+    {% if metadata['repo']['distribution_name'].startswith('google') %}
         "--cov=google",
+    {% else %}
+        "--cov={{ metadata['repo']['distribution_name'] }}",
+    {% endif %}
         "--cov=tests/unit",
         "--cov-append",
         "--cov-config=.coveragerc",

--- a/synthtool/languages/python_mono_repo.py
+++ b/synthtool/languages/python_mono_repo.py
@@ -230,7 +230,9 @@ def owlbot_main(package_dir: str) -> None:
             system_test_python_versions=["3.8", "3.9", "3.10", "3.11"],
             cov_level=100,
             versions=gcp.common.detect_versions(
-                path=f"{package_dir}/google" if package_name.startswith("google") else f"{package_dir}/{package_name}",
+                path=f"{package_dir}/google"
+                if package_name.startswith("google")
+                else f"{package_dir}/{package_name}",
                 default_version=default_version,
                 default_first=True,
             ),

--- a/synthtool/languages/python_mono_repo.py
+++ b/synthtool/languages/python_mono_repo.py
@@ -230,7 +230,7 @@ def owlbot_main(package_dir: str) -> None:
             system_test_python_versions=["3.8", "3.9", "3.10", "3.11"],
             cov_level=100,
             versions=gcp.common.detect_versions(
-                path=f"{package_dir}/google",
+                path=f"{package_dir}/google" if package_name.startswith("google") else f"{package_dir}/{package_name}",
                 default_version=default_version,
                 default_first=True,
             ),


### PR DESCRIPTION
This PR fixes the issue where the owlbot post processor fails for grafeas because it runs a nox session which expects a directory `google` in the package root. See build log [here](https://pantheon.corp.google.com/cloud-build/builds;region=global/f306c689-51c7-491d-a732-35e5a7de9536;step=5?project=repo-automation-bots). See the failure [here](https://github.com/googleapis/google-cloud-python/runs/18160870912).

See stack trace below
```
nox > black docs google tests noxfile.py setup.py
Usage: black [OPTIONS] SRC ...
Try 'black -h' for help.

Error: Invalid value for 'SRC ...': Path 'google' does not exist.
nox > Command black docs google tests noxfile.py setup.py failed with exit code 2
nox > Session format failed.
2023-10-29 14:42:48,408 synthtool [ERROR] > Failed executing nox -s format:

None
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/synthtool/synthtool/languages/python_mono_repo.py", line 263, in <module>
    owlbot_main(package_dir)
  File "/synthtool/synthtool/languages/python_mono_repo.py", line 251, in owlbot_main
    synthtool.shell.run(
  File "/synthtool/synthtool/shell.py", line 39, in run
    raise exc
  File "/synthtool/synthtool/shell.py", line 27, in run
    return subprocess.run(
  File "/usr/local/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['nox', '-s', 'format']' returned non-zero exit status 1.
```