### PR TITLE
chore: update docfx minimum Python version

### DIFF
--- a/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -370,7 +370,7 @@ def docs(session):
     )
 
 
-@nox.session(python="3.9")
+@nox.session(python="3.10")
 def docfx(session):
     """Build the docfx yaml files for this library."""
 

--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -359,7 +359,7 @@ def docs(session):
 
     session.install("-e", ".")
     session.install(
-        "sphinx==4.0.1",
+        "sphinx==4.5.0",
         "alabaster",
         "recommonmark",
     )

--- a/synthtool/languages/python_mono_repo.py
+++ b/synthtool/languages/python_mono_repo.py
@@ -226,7 +226,7 @@ def owlbot_main(package_dir: str) -> None:
             relative_dir=f"packages/{package_name}",
             microgenerator=True,
             default_python_version="3.10",
-            unit_test_python_versions=["3.8", "3.9", "3.10", "3.11"],
+            unit_test_python_versions=["3.7", "3.8", "3.9", "3.10", "3.11"],
             system_test_python_versions=["3.8", "3.9", "3.10", "3.11"],
             cov_level=100,
             versions=gcp.common.detect_versions(

--- a/synthtool/languages/python_mono_repo.py
+++ b/synthtool/languages/python_mono_repo.py
@@ -225,8 +225,8 @@ def owlbot_main(package_dir: str) -> None:
         templated_files = gcp.CommonTemplates().py_mono_repo_library(
             relative_dir=f"packages/{package_name}",
             microgenerator=True,
-            default_python_version="3.9",
-            unit_test_python_versions=["3.7", "3.8", "3.9", "3.10", "3.11"],
+            default_python_version="3.10",
+            unit_test_python_versions=["3.8", "3.9", "3.10", "3.11"],
             system_test_python_versions=["3.8", "3.9", "3.10", "3.11"],
             cov_level=100,
             versions=gcp.common.detect_versions(


### PR DESCRIPTION
Sphinx plugin now requires Python3.10 as the minimum version, which is run in `docfx` sessions. This change is required to accommodate for the breaking change for upgrade in the version. See https://github.com/googleapis/sphinx-docfx-yaml/pull/335.

For split repos, only the `docfx` session is updated to run in 3.10, and will respect what the split repo maintainer chooses to use as the default version.

For the monorepo, 3.10 will be used as the default version in general. Both split and monorepo uses Ubuntu22.04, which has Python3.10 as the built in Python version.

Unblocks major release for https://github.com/googleapis/sphinx-docfx-yaml/pull/335.