### PR TITLE
chore: update cloud-rad version to ^0.4.0

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/release/docs-devsite.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/release/docs-devsite.sh
@@ -25,6 +25,6 @@ if [[ -z "$CREDENTIALS" ]]; then
 fi
 
 npm install
-npm install --no-save @google-cloud/cloud-rad@^0.3.7
+npm install --no-save @google-cloud/cloud-rad@^0.4.0
 # publish docs to devsite
 npx @google-cloud/cloud-rad . cloud-rad


### PR DESCRIPTION
This updates the cloud-rad version to 0.4.x for the Node.js template for libraries outside the the [Node.js monorepo](https://github.com/googleapis/google-cloud-node).