### PR TITLE
feat: (poc) create synthtool/synthtool only image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.10.6-buster
+
+COPY . /synthtool/
+
+WORKDIR /synthtool
+# remove postprocessor images
+RUN rm -rdf /synthtool/docker
+
+RUN python3 -m pip install --no-deps -e .
+ENV SYNTHTOOL_TEMPLATES="/synthtool/synthtool/gcp/templates"
+CMD [ "python", "/workspace/owlbot.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,9 @@ ENV SYNTHTOOL_TEMPLATES="/synthtool/synthtool/gcp/templates"
 # Put synthtool in the PYTHONPATH so owlbot.py scripts will find it.
 ENV PYTHONPATH="/synthtool"
 
+# Update permissions so non-root users won't see errors.
+RUN find /synthtool -exec chmod a+r {} \;
+RUN find /synthtool -type d -exec chmod a+x {} \;
+
+
 CMD [ "python3" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN rm -rdf /synthtool/docker
 RUN python3 -m pip install -e .
 RUN python3 -m pip install -r requirements.in
 
+# Allow non-root users to run python
+RUN chmod +rx /root/
+
 WORKDIR /workspace
 
 ENV SYNTHTOOL_TEMPLATES="/synthtool/synthtool/gcp/templates"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,8 @@ WORKDIR /synthtool
 RUN rm -rdf /synthtool/docker
 
 RUN python3 -m pip install --no-deps -e .
+
+WORKDIR /workspace
+
 ENV SYNTHTOOL_TEMPLATES="/synthtool/synthtool/gcp/templates"
-CMD [ "python", "/workspace/owlbot.py" ]
+CMD [ "python3", "/workspace/owlbot.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ WORKDIR /synthtool
 # remove postprocessor images
 RUN rm -rdf /synthtool/docker
 
-RUN python3 -m pip install --no-deps -e .
+RUN python3 -m pip install -e .
+RUN python3 -m pip install -r requirements.in
 
 WORKDIR /workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ RUN chmod +rx /root/
 WORKDIR /workspace
 
 ENV SYNTHTOOL_TEMPLATES="/synthtool/synthtool/gcp/templates"
-CMD [ "python3", "/workspace/owlbot.py" ]
+CMD [ "python3" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,7 @@ RUN chmod +rx /root/
 WORKDIR /workspace
 
 ENV SYNTHTOOL_TEMPLATES="/synthtool/synthtool/gcp/templates"
+# Put synthtool in the PYTHONPATH so owlbot.py scripts will find it.
+ENV PYTHONPATH="/synthtool"
+
 CMD [ "python3" ]


### PR DESCRIPTION
(WIP)
In regards of transferring the implementation of the owlbot java docker image to sdk-platform-java, we here consider the option of having synthool as a self-contained library that can be referenced as a docker image