### PR TITLE
fix(node-mono-repo): execute non-ESM compileProtos command when not ESM

### DIFF
--- a/synthtool/languages/node_mono_repo.py
+++ b/synthtool/languages/node_mono_repo.py
@@ -357,7 +357,7 @@ def compile_protos_hermetic(relative_dir, is_esm=False, hide_output=False):
     """
     logger.debug("Compiling protos...")
     command = (
-        [f"{_TOOLS_DIRECTORY}/node_modules/.bin/compileProtos", "esm/src", "--esm"]
+        [f"{_TOOLS_DIRECTORY}/node_modules/.bin/compileProtos", "src"]
         if not is_esm
         else [f"{_TOOLS_DIRECTORY}/node_modules/.bin/compileProtos", "esm/src", "--esm"]
     )

--- a/tests/test_node_mono_repo.py
+++ b/tests/test_node_mono_repo.py
@@ -370,7 +370,7 @@ class TestPostprocess(TestCase):
                 for call in calls
             ]
         )
-    
+
     @patch("synthtool.shell.run")
     def test_compile_protos_hermetic(self, shell_run_mock):
         node_mono_repo.compile_protos_hermetic(relative_dir="any", is_esm=False)
@@ -413,6 +413,7 @@ class TestPostprocess(TestCase):
                 for call in calls
             ]
         )
+
 
 # postprocess_gapic_library_hermetic() must be mocked because it depends on node modules
 # present in the docker image but absent while running unit tests.

--- a/tests/test_node_mono_repo.py
+++ b/tests/test_node_mono_repo.py
@@ -370,6 +370,28 @@ class TestPostprocess(TestCase):
                 for call in calls
             ]
         )
+    
+    @patch("synthtool.shell.run")
+    def test_compile_protos_hermetic(self, shell_run_mock):
+        node_mono_repo.compile_protos_hermetic(relative_dir="any", is_esm=False)
+        calls = shell_run_mock.call_args_list
+        assert any(
+            [
+                "/node_modules/.bin/compileProtos src" in " ".join(call[0][0])
+                for call in calls
+            ]
+        )
+
+    @patch("synthtool.shell.run")
+    def test_compile_protos_hermetic_esm(self, shell_run_mock):
+        node_mono_repo.compile_protos_hermetic(relative_dir="any", is_esm=True)
+        calls = shell_run_mock.call_args_list
+        assert any(
+            [
+                "/node_modules/.bin/compileProtos esm/src --esm" in " ".join(call[0][0])
+                for call in calls
+            ]
+        )
 
     @patch("synthtool.shell.run")
     def test_postprocess_gapic_library(self, shell_run_mock):
@@ -391,7 +413,6 @@ class TestPostprocess(TestCase):
                 for call in calls
             ]
         )
-
 
 # postprocess_gapic_library_hermetic() must be mocked because it depends on node modules
 # present in the docker image but absent while running unit tests.


### PR DESCRIPTION
If the repo is ESM, it should execute the ESM command; if not, it should execute the normal compileProtos command. As it's written, it executes ESM either way. This fixes that.