### PR TITLE
build: update actions/upload-artifact and actions/download-artifact

### DIFF
--- a/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Upload coverage results
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-artifacts
+        name: coverage-artifact-${{ '{{' }} matrix.python {{ '}}' }}
         path: .coverage-${{ '{{' }} matrix.python {{ '}}' }}
 
   cover:
@@ -49,9 +49,9 @@ jobs:
     - name: Download coverage results
       uses: actions/download-artifact@v4
       with:
-        name: coverage-artifacts
         path: .coverage-results/
     - name: Report coverage results
       run: |
-        coverage combine .coverage-results/.coverage*
+        find .coverage-results -type f -name '*.zip' -exec unzip {} \;
+        coverage combine .coverage-results/**/.coverage*
         coverage report --show-missing --fail-under={{ cov_level if cov_level != None else 100 }}

--- a/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         nox -s unit-${{ '{{' }} matrix.python {{ '}}' }}
     - name: Upload coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-artifacts
         path: .coverage-${{ '{{' }} matrix.python {{ '}}' }}
@@ -47,7 +47,7 @@ jobs:
         python -m pip install --upgrade setuptools pip wheel
         python -m pip install coverage
     - name: Download coverage results
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: coverage-artifacts
         path: .coverage-results/


### PR DESCRIPTION
https://github.com/actions/upload-artifact/releases/tag/v4.0.0
https://github.com/actions/download-artifact/releases/tag/v4.0.0

There are breaking changes in `upload-artifact` v4 where the artifact name must be different. See https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes

```
Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once.
```

I tested the changes in https://github.com/googleapis/python-pubsublite/pull/466