### PR TITLE
feat: change transport value in template

### DIFF
--- a/synthtool/gcp/templates/java_library/README.md
+++ b/synthtool/gcp/templates/java_library/README.md
@@ -157,9 +157,9 @@ To get help, follow the instructions in the [shared Troubleshooting document][tr
 
 {% if metadata['repo']['transport'] == 'grpc' -%}
 {{metadata['repo']['name_pretty']}} uses gRPC for the transport layer.
-{% elif metadata['repo']['transport'] == 'http' -%}
+{% elif metadata['repo']['transport'] == 'rest' -%}
 {{metadata['repo']['name_pretty']}} uses HTTP/JSON for the transport layer.
-{% elif metadata['repo']['transport'] == 'both' -%}
+{% elif metadata['repo']['transport'] == 'grpc+rest' -%}
 {{metadata['repo']['name_pretty']}} uses both gRPC and HTTP/JSON for the transport layer.
 {% endif %}
 {% endif -%}


### PR DESCRIPTION
In this PR:
- In Java library, change the transport value in README.md template to `grpc+rest` and `rest`.

This change doesn't affect handwritten libraries because `.repo-metadata.json` in these libraries either has no `transport` or the value is `grpc`.