### PR TITLE
feat: remove nox uninstall/reinstall from python build.sh template

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/build.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/build.sh
@@ -33,13 +33,6 @@ export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/service-account.json
 # Setup project id.
 export PROJECT_ID=$(cat "${KOKORO_GFILE_DIR}/project-id.json")
 
-# Remove old nox
-python3 -m pip uninstall --yes --quiet nox-automation
-
-# Install nox
-python3 -m pip install --upgrade --quiet nox
-python3 -m nox --version
-
 # If this is a continuous build, send the test log to the FlakyBot.
 # See https://github.com/googleapis/repo-automation-bots/tree/main/packages/flakybot.
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then


### PR DESCRIPTION
This PR removes the steps that uninstall/reinstall nox and report the version from build.sh, as nox should be included as part of the base python docker image used for testing.