### PR TITLE
chore: update ignore paths in renovate config

### DIFF
--- a/synthtool/gcp/templates/java_library/renovate.json
+++ b/synthtool/gcp/templates/java_library/renovate.json
@@ -14,7 +14,10 @@
   ],
   "ignorePaths": [
     ".kokoro/requirements.txt",
-    ".github/workflows/**"
+    ".github/workflows/approve-readme.yaml",
+    ".github/workflows/ci.yaml",
+    ".github/workflows/renovate_config_check.yaml",
+    ".github/workflows/samples.yaml"
   ],
   "customManagers": [
     {


### PR DESCRIPTION
In this PR:
- Update renovate config to explicitly ignore workflow files in `.github/workflows`.

Context: we want to use renovateBot to update the version of unmanaged dependency check in `.github/workflows/unmanaged_dependency_check.yaml`. However, the directory is ignored in renovate config (#1855). Explicitly list files in this directory can make renovate include `.github/workflows/unmanaged_dependency_check.yaml`.