### PR TITLE
docs: fix docs session

### DIFF
--- a/synthtool/gcp/templates/python_library/docs/index.rst
+++ b/synthtool/gcp/templates/python_library/docs/index.rst
@@ -35,3 +35,10 @@ For a list of all ``{{ metadata['repo']['distribution_name'] }}`` releases:
     :maxdepth: 2
 
     changelog
+
+{% if is_google_cloud_api %}
+.. toctree::
+  :hidden:
+
+  summary_overview.md
+{% endif %}

--- a/synthtool/gcp/templates/python_library/docs/index.rst
+++ b/synthtool/gcp/templates/python_library/docs/index.rst
@@ -35,10 +35,9 @@ For a list of all ``{{ metadata['repo']['distribution_name'] }}`` releases:
     :maxdepth: 2
 
     changelog
-
 {% if is_google_cloud_api %}
 .. toctree::
   :hidden:
 
   summary_overview.md
-{% endif %}
+{% endif -%}

--- a/synthtool/gcp/templates/python_mono_repo_library/docs/index.rst
+++ b/synthtool/gcp/templates/python_mono_repo_library/docs/index.rst
@@ -35,10 +35,9 @@ For a list of all ``{{ metadata['repo']['distribution_name'] }}`` releases:
     :maxdepth: 2
 
     CHANGELOG
-
 {% if is_google_cloud_api %}
 .. toctree::
   :hidden:
 
   summary_overview.md
-{% endif %}
+{% endif -%}

--- a/synthtool/gcp/templates/python_mono_repo_library/docs/index.rst
+++ b/synthtool/gcp/templates/python_mono_repo_library/docs/index.rst
@@ -35,3 +35,10 @@ For a list of all ``{{ metadata['repo']['distribution_name'] }}`` releases:
     :maxdepth: 2
 
     CHANGELOG
+
+{% if is_google_cloud_api %}
+.. toctree::
+  :hidden:
+
+  summary_overview.md
+{% endif %}


### PR DESCRIPTION
When the `summary_overview.md` file was added, various `nox -s docs` sessions were complaining as it's not included in any of the toc trees. Since warnings are treated as errors, it fails the builds.

Adding this as a hidden toctree allows the warning to be suppressed, as well as have no effect to the current documentation. Verified that the docs session passes with https://github.com/googleapis/python-storage/pull/1252, and then verified locally that docfx sessions are not affected with this change.