### PR TITLE
chore(python): support multiple codeowners in blunderbuss

### DIFF
--- a/synthtool/gcp/templates/python_library/.github/blunderbuss.yml
+++ b/synthtool/gcp/templates/python_library/.github/blunderbuss.yml
@@ -5,17 +5,23 @@
 # team, please update `codeowner_team` in `.repo-metadata.json`.
 {% if metadata['repo']['codeowner_team']|length -%}
 assign_issues:
-  - {{ metadata['repo']['codeowner_team'].replace("@","") }}
+  {%- for codeowner in metadata['repo']['codeowner_team'].replace("@","").split(" ") %}
+  - {{ codeowner }}
+  {%- endfor %}
 
 assign_issues_by:
   - labels:
       - "samples"
     to:
       - googleapis/python-samples-reviewers
-      - {{ metadata['repo']['codeowner_team'].replace("@","") }}
+      {%- for codeowner in metadata['repo']['codeowner_team'].replace("@","").split(" ") %}
+      - {{ codeowner }}
+      {%- endfor %}
 
 assign_prs:
-  - {{ metadata['repo']['codeowner_team'].replace("@","") }}
+  {%- for codeowner in metadata['repo']['codeowner_team'].replace("@","").split(" ") %}
+  - {{ codeowner }}
+  {%- endfor %}
 {% else %}
 assign_issues:
   - googleapis/python-core-client-libraries

--- a/tests/test_python_library.py
+++ b/tests/test_python_library.py
@@ -178,7 +178,7 @@ def assert_valid_yaml(file):
             pytest.fail(f"unable to parse YAML: {file}")
 
 
-def test_library_blunderbuss():
+def test_library_blunderbuss_single_codeowner():
     t = templates.Templates(PYTHON_LIBRARY / ".github")
     result = t.render(
         "blunderbuss.yml",
@@ -188,10 +188,33 @@ def test_library_blunderbuss():
         config = yaml.safe_load(result)
         assert "googleapis/python-core-client-libraries" not in config["assign_issues"]
         assert "googleapis/foo" in config["assign_issues"]
+        assert "googleapis/foo" in config["assign_prs"]
         assert (
             "googleapis/python-samples-reviewers" in config["assign_issues_by"][0]["to"]
         )
         assert "googleapis/foo" in config["assign_issues_by"][0]["to"]
+    except yaml.YAMLError:
+        pytest.fail(f"unable to parse YAML: {result}")
+
+
+def test_library_blunderbuss_multiple_codeowner():
+    t = templates.Templates(PYTHON_LIBRARY / ".github")
+    result = t.render(
+        "blunderbuss.yml",
+        metadata={"repo": {"codeowner_team": "googleapis/foo googleapis/bar"}},
+    ).read_text()
+    try:
+        config = yaml.safe_load(result)
+        assert "googleapis/python-core-client-libraries" not in config["assign_issues"]
+        assert "googleapis/foo" in config["assign_issues"]
+        assert "googleapis/bar" in config["assign_issues"]
+        assert "googleapis/foo" in config["assign_prs"]
+        assert "googleapis/bar" in config["assign_prs"]
+        assert (
+            "googleapis/python-samples-reviewers" in config["assign_issues_by"][0]["to"]
+        )
+        assert "googleapis/foo" in config["assign_issues_by"][0]["to"]
+        assert "googleapis/bar" in config["assign_issues_by"][0]["to"]
     except yaml.YAMLError:
         pytest.fail(f"unable to parse YAML: {result}")
 


### PR DESCRIPTION
Fixes #946

I tested the changes by running the following commands

- Ran `docker build -f docker/owlbot/python/Dockerfile -t testmultiplecodeowners .` in this branch
- Ran `docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo testmultiplecodeowners` in the branch from PR https://github.com/googleapis/python-bigquery-magics/pull/6 which has multiple codeowners