### PR TITLE
ci: automatic kokoro label in and /gcbrun comment

### DIFF
--- a/synthtool/gcp/templates/java_library/.github/trusted-contribution.yml
+++ b/synthtool/gcp/templates/java_library/.github/trusted-contribution.yml
@@ -1,3 +1,9 @@
 trustedContributors:
 - renovate-bot
 - gcf-owl-bot[bot]
+
+annotations:
+- type: comment
+  text: "/gcbrun"
+- type: label
+  text: "kokoro:force-run"


### PR DESCRIPTION
From reading the configuration (https://github.com/googleapis/repo-automation-bots/pull/1682/files), it accepts multiple objects.