### PR TITLE
chore(python): Use latest python runtime in prerelease_deps session

### DIFF
--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -436,7 +436,7 @@ def docfx(session):
     )
 
 
-@nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
+@nox.session(python="{{ unit_test_python_versions | last }}")
 @nox.parametrize(
     "protobuf_implementation",
     [ "python", "upb", "cpp" ],


### PR DESCRIPTION
This PR updates the `prerelease_deps` nox session in the `python_library` templates to match the `python_mono_repo_library` templates so that only the latest python runtime is used.

https://github.com/googleapis/synthtool/blob/8c5db447e092c91f728cb618cc1d249d88860f7d/synthtool/gcp/templates/python_library/noxfile.py.j2#L439-L444

https://github.com/googleapis/synthtool/blob/8c5db447e092c91f728cb618cc1d249d88860f7d/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2#L448-L453