### PR TITLE
chore(python): use python 3.10 for docs build

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
+++ b/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update \
   && rm -f /var/cache/apt/archives/*.deb
 
 
-###################### Install python 3.10.14 for docfx session
+###################### Install python 3.10.14 for docs/docfx session
 
 # Download python 3.10.14
 RUN wget https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz

--- a/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
+++ b/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update \
     libssl-dev \
     libsqlite3-dev \
     portaudio19-dev \
-    python3-distutils \
     redis-server \
     software-properties-common \
     ssh \
@@ -72,6 +71,10 @@ RUN tar -xvf Python-3.9.13.tgz
 RUN ./Python-3.9.13/configure --enable-optimizations
 RUN make altinstall
 
+# Use python 3.9 by default
+RUN python3.9 -m venv /venv
+ENV PATH /venv/bin:$PATH
+
 ###################### Install pip
 RUN wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
   && python3 /tmp/get-pip.py \
@@ -84,4 +87,4 @@ RUN python3 -m pip
 COPY requirements.txt /requirements.txt
 RUN python3 -m pip install --require-hashes -r requirements.txt
 
-CMD ["python3.8"]
+CMD ["python3.9"]

--- a/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
+++ b/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
@@ -60,18 +60,6 @@ RUN apt-get update \
   && rm -f /var/cache/apt/archives/*.deb
 
 
-###################### Install python 3.9.19
-
-# Download python 3.9.19
-RUN wget https://www.python.org/ftp/python/3.9.19/Python-3.9.19.tgz
-
-# Extract files
-RUN tar -xvf Python-3.9.19.tgz
-
-# Install python 3.9.19
-RUN ./Python-3.9.19/configure --enable-optimizations
-RUN make altinstall
-
 ###################### Install python 3.10.14 for docfx session
 
 # Download python 3.10.14
@@ -84,9 +72,9 @@ RUN tar -xvf Python-3.10.14.tgz
 RUN ./Python-3.10.14/configure --enable-optimizations
 RUN make altinstall
 
-###################### Use python 3.9 by default
+###################### Use python 3.10 by default
 
-RUN python3.9 -m venv /venv
+RUN python3.10 -m venv /venv
 ENV PATH /venv/bin:$PATH
 
 ###################### Install pip
@@ -101,4 +89,4 @@ RUN python3 -m pip
 COPY requirements.txt /requirements.txt
 RUN python3 -m pip install --require-hashes -r requirements.txt
 
-CMD ["python3.9"]
+CMD ["python3.10"]

--- a/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
+++ b/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
@@ -59,19 +59,33 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   && rm -f /var/cache/apt/archives/*.deb
 
-###################### Install python 3.9.13
 
-# Download python 3.9.13
-RUN wget https://www.python.org/ftp/python/3.9.13/Python-3.9.13.tgz
+###################### Install python 3.9.19
+
+# Download python 3.9.19
+RUN wget https://www.python.org/ftp/python/3.9.19/Python-3.9.19.tgz
 
 # Extract files
-RUN tar -xvf Python-3.9.13.tgz
+RUN tar -xvf Python-3.9.19.tgz
 
-# Install python 3.9.13
-RUN ./Python-3.9.13/configure --enable-optimizations
+# Install python 3.9.19
+RUN ./Python-3.9.19/configure --enable-optimizations
 RUN make altinstall
 
-# Use python 3.9 by default
+###################### Install python 3.10.14 for docfx session
+
+# Download python 3.10.14
+RUN wget https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz
+
+# Extract files
+RUN tar -xvf Python-3.10.14.tgz
+
+# Install python 3.10.14
+RUN ./Python-3.10.14/configure --enable-optimizations
+RUN make altinstall
+
+###################### Use python 3.9 by default
+
 RUN python3.9 -m venv /venv
 ENV PATH /venv/bin:$PATH
 

--- a/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
+++ b/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
@@ -72,8 +72,6 @@ RUN tar -xvf Python-3.10.14.tgz
 RUN ./Python-3.10.14/configure --enable-optimizations
 RUN make altinstall
 
-###################### Use python 3.10 by default
-
 RUN python3.10 -m venv /venv
 ENV PATH /venv/bin:$PATH
 

--- a/synthtool/gcp/templates/python_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_library/noxfile.py.j2
@@ -355,7 +355,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.9")
+@nox.session(python="3.10")
 def docs(session):
     """Build the docs for this library."""
 


### PR DESCRIPTION
This PR fixes the issue `E: Package 'python3-distutils' has no installation candidate` which can be seen in [this build log](https://btx.cloud.google.com/invocations/9768051b-00b0-430a-afa6-59dc7124566f/log) from PR https://github.com/googleapis/python-pubsub/pull/1220.

This PR also updates the default python version to be 3.10 for the `docs` session to match what we use for `docfx`.
https://github.com/googleapis/synthtool/blob/0142f3529bd44e1bd7297e72ac6d0c8228bf1489/synthtool/gcp/templates/python_library/noxfile.py.j2#L358-L359

https://github.com/googleapis/synthtool/blob/0142f3529bd44e1bd7297e72ac6d0c8228bf1489/synthtool/gcp/templates/python_library/noxfile.py.j2#L393-L394

I tested that this build successfully by running `docker build -t test_docs .` in the directory `synthtool/gcp/templates/python_library/.kokoro/docker/docs/`


I then ran the following nox sessions `docs` and `docfx`.

Note: The both the `docs` and `docfx` session now require Python 3.10.

```
docker run --rm -it --entrypoint /bin/bash test_docs
```

Then in the docker image, run the following commands
```
git clone https://github.com/googleapis/python-pubsub.git
cd python-pubsub
nox -s docs
nox -s docfx
```