### PR TITLE
chore(python): fix docs build

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
+++ b/synthtool/gcp/templates/python_library/.kokoro/docker/docs/Dockerfile
@@ -72,19 +72,18 @@ RUN tar -xvf Python-3.10.14.tgz
 RUN ./Python-3.10.14/configure --enable-optimizations
 RUN make altinstall
 
-RUN python3.10 -m venv /venv
-ENV PATH /venv/bin:$PATH
+ENV PATH /usr/local/bin/python3.10:$PATH
 
 ###################### Install pip
 RUN wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-  && python3 /tmp/get-pip.py \
+  && python3.10 /tmp/get-pip.py \
   && rm /tmp/get-pip.py
 
 # Test pip
-RUN python3 -m pip
+RUN python3.10 -m pip
 
 # Install build requirements
 COPY requirements.txt /requirements.txt
-RUN python3 -m pip install --require-hashes -r requirements.txt
+RUN python3.10 -m pip install --require-hashes -r requirements.txt
 
 CMD ["python3.10"]

--- a/synthtool/gcp/templates/python_library/.kokoro/publish-docs.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/publish-docs.sh
@@ -21,18 +21,18 @@ export PYTHONUNBUFFERED=1
 export PATH="${HOME}/.local/bin:${PATH}"
 
 # Install nox
-python3 -m pip install --require-hashes -r .kokoro/requirements.txt
-python3 -m nox --version
+python3.10 -m pip install --require-hashes -r .kokoro/requirements.txt
+python3.10 -m nox --version
 
 # build docs
 nox -s docs
 
 # create metadata
-python3 -m docuploader create-metadata \
+python3.10 -m docuploader create-metadata \
   --name=$(jq --raw-output '.name // empty' .repo-metadata.json) \
-  --version=$(python3 setup.py --version) \
+  --version=$(python3.10 setup.py --version) \
   --language=$(jq --raw-output '.language // empty' .repo-metadata.json) \
-  --distribution-name=$(python3 setup.py --name) \
+  --distribution-name=$(python3.10 setup.py --name) \
   --product-page=$(jq --raw-output '.product_documentation // empty' .repo-metadata.json) \
   --github-repository=$(jq --raw-output '.repo // empty' .repo-metadata.json) \
   --issue-tracker=$(jq --raw-output '.issue_tracker // empty' .repo-metadata.json)
@@ -40,18 +40,18 @@ python3 -m docuploader create-metadata \
 cat docs.metadata
 
 # upload docs
-python3 -m docuploader upload docs/_build/html --metadata-file docs.metadata --staging-bucket "${STAGING_BUCKET}"
+python3.10 -m docuploader upload docs/_build/html --metadata-file docs.metadata --staging-bucket "${STAGING_BUCKET}"
 
 
 # docfx yaml files
 nox -s docfx
 
 # create metadata.
-python3 -m docuploader create-metadata \
+python3.10 -m docuploader create-metadata \
   --name=$(jq --raw-output '.name // empty' .repo-metadata.json) \
-  --version=$(python3 setup.py --version) \
+  --version=$(python3.10 setup.py --version) \
   --language=$(jq --raw-output '.language // empty' .repo-metadata.json) \
-  --distribution-name=$(python3 setup.py --name) \
+  --distribution-name=$(python3.10 setup.py --name) \
   --product-page=$(jq --raw-output '.product_documentation // empty' .repo-metadata.json) \
   --github-repository=$(jq --raw-output '.repo // empty' .repo-metadata.json) \
   --issue-tracker=$(jq --raw-output '.issue_tracker // empty' .repo-metadata.json)
@@ -59,4 +59,4 @@ python3 -m docuploader create-metadata \
 cat docs.metadata
 
 # upload docs
-python3 -m docuploader upload docs/_build/html/docfx_yaml --metadata-file docs.metadata --destination-prefix docfx --staging-bucket "${V2_STAGING_BUCKET}"
+python3.10 -m docuploader upload docs/_build/html/docfx_yaml --metadata-file docs.metadata --destination-prefix docfx --staging-bucket "${V2_STAGING_BUCKET}"


### PR DESCRIPTION
This PR fixes b/356444150, specifically the error below which started as of https://github.com/googleapis/synthtool/pull/1989:

`ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '/venv/lib/python3.10/site-packages/pyperclip'`

I tested this by running through these steps:

1. I ran `docker build -f docker/owlbot/python/Dockerfile -t docs .` in branch ` fix-docs-build-python` in the [synthtool](https://github.com/googleapis/synthtool) repository
2. I ran `docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo docs` in branch v3.11.0 in the [python-logging](https://github.com/googleapis/python-logging) repository
3. I triggered docs build manually with the changes from 2