### PR TITLE
chore(python): update unittest workflow template

### DIFF
--- a/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
@@ -30,7 +30,6 @@ jobs:
       with:
         name: coverage-artifact-${{ '{{' }} matrix.python {{ '}}' }}
         path: .coverage-${{ '{{' }} matrix.python {{ '}}' }}
-        if-no-files-found: error
         include-hidden-files: true
 
   cover:

--- a/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
@@ -30,6 +30,8 @@ jobs:
       with:
         name: coverage-artifact-${{ '{{' }} matrix.python {{ '}}' }}
         path: .coverage-${{ '{{' }} matrix.python {{ '}}' }}
+        if-no-files-found: error
+        include-hidden-files: true
 
   cover:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change is adding `include-hidden-files` to the `upload-artifact` step. The `upload-artifact` excludes hidden files by default [here](https://github.com/actions/upload-artifact/commit/50769540e7f4bd5e21e526ee35c689e35e0d6874) so that `.coverage-*` files would be excluded to be uploaded. 