### PR TITLE
chore(python): update release script

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/release/common.cfg
+++ b/synthtool/gcp/templates/python_library/.kokoro/release/common.cfg
@@ -33,12 +33,6 @@ before_action {
   }
 }
 
-# Tokens needed to report release status back to GitHub
-env_vars: {
-  key: "SECRET_MANAGER_KEYS"
-  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
-}
-
 # Store the packages we uploaded to PyPI.  That way, we have a record of exactly
 # what we published, which we can use to generate SBOMs and attestations.
 action {


### PR DESCRIPTION
This change to the release script is needed to resolve the error
```
2024-10-23 07:40:29 Retrieving secret releasetool-publish-reporter-app
ERROR: (gcloud.secrets.versions.access) FAILED_PRECONDITION: Secret Version [<REDACTED>] is in DISABLED state.
```