### PR TITLE
chore(python): Pin virtualenv for Python 3.7 compatibility

### DIFF
--- a/synthtool/gcp/templates/python_library/.kokoro/test-samples-impl.sh
+++ b/synthtool/gcp/templates/python_library/.kokoro/test-samples-impl.sh
@@ -33,7 +33,8 @@ export PYTHONUNBUFFERED=1
 env | grep KOKORO
 
 # Install nox
-python3.9 -m pip install --upgrade --quiet nox
+# `virtualenv==20.26.6` is added for Python 3.7 compatibility
+python3.9 -m pip install --upgrade --quiet nox virtualenv==20.26.6
 
 # Use secrets acessor service account to get secrets
 if [[ -f "${KOKORO_GFILE_DIR}/secrets_viewer_service_account.json" ]]; then


### PR DESCRIPTION
This will solve the issue in PR https://github.com/googleapis/google-api-python-client/pull/2507 where we see the following error in the build log for `Samples - Python 3.7`

```
******************** TESTING PROJECTS ********************
------------------------------------------------------------
- testing samples/compute
------------------------------------------------------------
No user noxfile_config found: detail: No module named 'noxfile_config'
nox > Running session py-3.7
nox > Creating virtual environment (virtualenv) using python3.7 in .nox/py-3-7
nox > python -m pip install -r requirements.txt
nox > Command python -m pip install -r requirements.txt failed with exit code 1:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/workspace/samples/compute/.nox/py-3-7/lib/python3.7/site-packages/pip/__main__.py", line 22, in 
    from pip._internal.cli.main import main as _main
  File "/workspace/samples/compute/.nox/py-3-7/lib/python3.7/site-packages/pip/_internal/cli/main.py", line 11, in 
    from pip._internal.cli.autocompletion import autocomplete
  File "/workspace/samples/compute/.nox/py-3-7/lib/python3.7/site-packages/pip/_internal/cli/autocompletion.py", line 10, in 
    from pip._internal.cli.main_parser import create_main_parser
  File "/workspace/samples/compute/.nox/py-3-7/lib/python3.7/site-packages/pip/_internal/cli/main_parser.py", line 9, in 
    from pip._internal.build_env import get_runnable_pip
  File "/workspace/samples/compute/.nox/py-3-7/lib/python3.7/site-packages/pip/_internal/build_env.py", line 18, in 
    from pip._internal.cli.spinners import open_spinner
  File "/workspace/samples/compute/.nox/py-3-7/lib/python3.7/site-packages/pip/_internal/cli/spinners.py", line 9, in 
    from pip._internal.utils.logging import get_indentation
  File "/workspace/samples/compute/.nox/py-3-7/lib/python3.7/site-packages/pip/_internal/utils/logging.py", line 13, in 
    from pip._vendor.rich.console import (
  File "/workspace/samples/compute/.nox/py-3-7/lib/python3.7/site-packages/pip/_vendor/rich/console.py", line 41, in 
    from pip._vendor.typing_extensions import (
  File "/workspace/samples/compute/.nox/py-3-7/lib/python3.7/site-packages/pip/_vendor/typing_extensions.py", line 1039
    def TypedDict(typename, fields=_marker, /, *, total=True, closed=False, **kwargs):
                                            ^
SyntaxError: invalid syntax
nox > Session py-3.7 failed.
```