### PR TITLE
chore(python): add repository_name to metadata

### DIFF
--- a/synthtool/gcp/common.py
+++ b/synthtool/gcp/common.py
@@ -426,6 +426,11 @@ class CommonTemplates:
         if "repo" not in metadata:
             metadata["repo"] = _load_repo_metadata(relative_dir=relative_dir)
 
+            if "repo" in metadata["repo"]:
+                repo = git.parse_repo_url(metadata["repo"]["repo"])
+
+                metadata["repository_name"] = repo["name"]
+
 
 def detect_versions(
     path: str = "./src",


### PR DESCRIPTION
This PR is a follow up to https://github.com/googleapis/synthtool/pull/2033. PR https://github.com/googleapis/synthtool/pull/2033 expected `metadata['repository_name']` which doesn't exist. This fixes the issue.