### PR TITLE
chore: fix `npm` for Node v18 samples tests

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/samples-test.sh
@@ -16,7 +16,9 @@
 
 set -eo pipefail
 
-export NPM_CONFIG_PREFIX=${HOME}/.npm-global
+# Ensure the npm global directory is writable, otherwise rebuild `npm`
+mkdir -p $NPM_CONFIG_PREFIX
+npm config -g ls || npm i -g npm@`npm --version`
 
 # Setup service account credentials.
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secret_manager/long-door-651-kokoro-system-test-service-account

--- a/tests/fixtures/nodejs_mono_repo_esm/.kokoro/samples-test.sh
+++ b/tests/fixtures/nodejs_mono_repo_esm/.kokoro/samples-test.sh
@@ -16,7 +16,9 @@
 
 set -eo pipefail
 
-export NPM_CONFIG_PREFIX=${HOME}/.npm-global
+# Ensure the npm global directory is writable, otherwise rebuild `npm`
+mkdir -p $NPM_CONFIG_PREFIX
+npm config -g ls || npm i -g npm@`npm --version`
 
 # Setup service account credentials.
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/service-account.json


### PR DESCRIPTION
Tested with a working example here:
- https://github.com/googleapis/gaxios/pull/669/commits/3e2761f9b66360aae76680ed15a1c81a3480a5ae
- log: https://btx.cloud.google.com/invocations/d0fee0c1-dbb6-4eec-a5bf-6edf046fa715/targets/cloud-devrel%2Fclient-libraries%2Fnodejs%2Fpresubmit%2Fgoogleapis%2Fgaxios%2Fnode18%2Fsamples-test/log

Uses the inherited `npm` config to preserve shared settings, like `update-notifier: false`