### PR TITLE
chore(python): Update the python version in docs presubmit to use 3.10

### DIFF
--- a/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel


### PR DESCRIPTION
The docs `nox` session requires Python 3.10 but the Github action runs with Python 3.9

https://github.com/googleapis/synthtool/blob/e808c98e1ab7eec3df2a95a05331619f7001daef/synthtool/gcp/templates/python_library/noxfile.py.j2#L358-L359

https://github.com/googleapis/synthtool/blob/e808c98e1ab7eec3df2a95a05331619f7001daef/synthtool/gcp/templates/python_library/.github/workflows/docs.yml#L6-L15