### PR TITLE
chore(python): Use ubuntu 22.04 for Python 3.7 testing

### DIFF
--- a/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
+++ b/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml
@@ -5,7 +5,10 @@ on:
 name: unittest
 jobs:
   unit:
-    runs-on: ubuntu-latest
+    # TODO(https://github.com/googleapis/gapic-generator-python/issues/2303): use `ubuntu-latest` once this bug is fixed.
+    # Use ubuntu-22.04 until Python 3.7 is removed from the test matrix
+    # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python: {{unit_test_python_versions}}


### PR DESCRIPTION
This PR resolves the following issue [when running Python 3.7 tests](https://github.com/googleapis/python-bigquery-storage/actions/runs/12564329806/job/35077501902?pr=858) :

```
  Version 3.7 was not found in the local cache
  Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
```

