### PR TITLE
chore(python): exclude .github/workflows/unittest.yml in renovate config

### DIFF
--- a/synthtool/gcp/templates/python_library/renovate.json
+++ b/synthtool/gcp/templates/python_library/renovate.json
@@ -5,7 +5,7 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py"],
+  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }


### PR DESCRIPTION
We pinned Ubuntu to 22.04 because the next version (24.02) dropped support for Python 3.7 (see https://github.com/googleapis/synthtool/pull/2047). Renovate bot has been trying to upgrade it (for [example](https://github.com/googleapis/python-bigquery-storage/pull/863/files#diff-066dfc7b476727cdc5ff6eca6e8191b2a6df2b53a0281182f6c9cf4de7268469)) so we are excluding this file from its updates.