### PR TITLE
chore(python_mono_repo): update template to cater for grpc-google-iam-v1

### DIFF
--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -28,7 +28,7 @@ import nox
 
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
-{% if metadata['repo']['distribution_name'].startswith('google') %}
+{% if 'google' in metadata['repo']['distribution_name'] %}
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 {% else %}
 LINT_PATHS = ["docs", "{{ metadata['repo']['distribution_name'] }}", "tests", "noxfile.py", "setup.py"]
@@ -160,7 +160,7 @@ def lint(session):
         "--check",
         *LINT_PATHS,
     )
-    {% if metadata['repo']['distribution_name'].startswith('google') %}
+    {% if 'google' in metadata['repo']['distribution_name'] %}
     session.run("flake8", "google", "tests")
     {% else %}
     session.run("flake8", "{{ metadata['repo']['distribution_name'] }}", "tests")


### PR DESCRIPTION
Currently we have a check in an if statement for whether a package has `google` in the name to determine if we should lint the folder `google`. The specific check is `metadata['repo']['distribution_name'].startswith('google')`. This doesn't work for the [grpc-google-iam-v1](https://pypi.org/project/grpc-google-iam-v1/) package. We should use `'google' in metadata['repo']['distribution_name']` instead.