### PR TITLE
chore(python_mono_repo): only add license headers to recently generated files

### DIFF
--- a/synthtool/languages/python_mono_repo.py
+++ b/synthtool/languages/python_mono_repo.py
@@ -39,21 +39,27 @@ LICENSE = """
 # limitations under the License."""
 
 
-def fix_pb2_headers() -> None:
+def fix_pb2_headers(package_dir: str) -> None:
     """
     Add / fix license headers in generated protobuf code. By default
     generated protobuf code does not include license header
     information. As an example, see the generated `*pb2.py` and
     `*.pb2.pyi` files in [googleapis-gen](https://github.com/googleapis/googleapis-gen/tree/master/google/api/api-py).
+
+    Args:
+        package_dir (str): path to the directory for a specific package. For example
+            '<path to>/packages/google-cloud-video-transcoder'
     """
+
+    package_name = package_dir.split("/")[-1]
     synthtool.replace(
-        "**/*_pb2.py",
+        f"packages/{package_name}/**/*_pb2.py",
         PB2_HEADER,
         rf"\g<1>{LICENSE}\n\n\g<2>",
         flags=re.DOTALL | re.MULTILINE,
     )
     synthtool.replace(
-        "**/*_pb2.pyi",
+        f"packages/{package_name}/**/*_pb2.pyi",
         r"^\A(.*)",
         rf"{LICENSE}\n\n\g<1>",
         flags=re.DOTALL | re.MULTILINE,
@@ -305,7 +311,7 @@ def owlbot_main(package_dir: str) -> None:
         update_url_in_setup_py(package_dir)
 
         # add license header to pb2.py and pb2.pyi files.
-        fix_pb2_headers()
+        fix_pb2_headers(package_dir)
 
         # run format nox session for all directories which have a noxfile
         for noxfile in Path(".").glob(f"packages/{package_name}/**/noxfile.py"):


### PR DESCRIPTION
https://github.com/googleapis/synthtool/pull/2058 was recently merged to add license headers to `*pb2.py*` files however the change had to be [reverted downstream](https://github.com/googleapis/google-cloud-python/pull/13493) because license headers were being stacked each time that the post processor ran. 

Using the fix from this PR, the issue no longer appears because we're only adding the license header for the specific package which exists in `owl-bot-staging`.

See the following steps used validate the fix:

In `googleapis/googleapis`, run
```
gbazelisk build //google/cloud/accessapproval/v1:accessapproval-v1-py 
```
In `googleapis/google-cloud-python`, run

```
docker run --rm --user $(id -u):$(id -g)   -v $(pwd):/repo   -v <path to bazel-bin>:/bazel-bin   gcr.io/cloud-devrel-public-resources/owlbot-cli:latest copy-bazel-bin   --source-dir /bazel-bin --dest /repo   --config-file=/packages/googleapis-common-protos/.OwlBot.yaml 
```

```
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo mono_repo_update
```

Confirm that license headers are no longer stacked.

I also repeated the tests in https://github.com/googleapis/synthtool/pull/2058#issue-2831201262 to ensure that we're still adding license headers as intended.