### PR TITLE
chore(python_mono_repo): add core_deps_from_source nox session

### DIFF
--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -451,20 +451,29 @@ def docfx(session):
     ["python", "upb", "cpp"],
 )
 def prerelease_deps(session, protobuf_implementation):
-    """Run all tests with prerelease versions of dependencies installed."""
+    """
+    Run all tests with pre-release versions of dependencies installed
+    rather than the standard non pre-release versions.
+    Pre-releases versions can be installed using
+    `pip install --pre <package>`.
+    """
 
     if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
     session.install("-e", ".")
+
     unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
+    # Install dependencies for the unit test environment
     session.install(*unit_deps_all)
+
     system_deps_all = (
         SYSTEM_TEST_STANDARD_DEPENDENCIES
         + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
         + SYSTEM_TEST_EXTRAS
     )
+    # Install dependencies for the system test environment
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -486,6 +495,7 @@ def prerelease_deps(session, protobuf_implementation):
         )
     ]
 
+    # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
 
     prerel_deps = [
@@ -535,12 +545,18 @@ def prerelease_deps(session, protobuf_implementation):
     ["python", "upb"],
 )
 def core_deps_from_source(session, protobuf_implementation):
-    """Run all tests with local versions of core dependencies installed."""
+    """Run all tests with local versions of core dependencies installed,
+    rather than pulling core dependencies from PyPI.
+    """
 
     # Install all dependencies
     session.install(".")
+
+    # Install dependencies for the unit test environment
     unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
     session.install(*unit_deps_all)
+
+    # Install dependencies for the system test environment
     system_deps_all = (
         SYSTEM_TEST_STANDARD_DEPENDENCIES
         + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
@@ -567,6 +583,7 @@ def core_deps_from_source(session, protobuf_implementation):
         )
     ]
 
+    # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
 
     core_dependencies_from_source = [

--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -527,3 +527,64 @@ def prerelease_deps(session, protobuf_implementation):
             "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
         },
     )
+
+
+@nox.session(python="{{ unit_test_python_versions | last }}")
+@nox.parametrize(
+    "protobuf_implementation",
+    ["python", "upb"],
+)
+def core_deps_from_source(session, protobuf_implementation):
+    """Run all tests with local versions of core dependencies installed."""
+
+    # Install all dependencies
+    session.install(".[all, tests, tracing]")
+    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
+    session.install(*unit_deps_all)
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
+    session.install(*system_deps_all)
+
+    # Because we test minimum dependency versions on the minimum Python
+    # version, the first version we test with in the unit tests sessions has a
+    # constraints file containing all dependencies and extras that should be installed.
+    with open(
+        CURRENT_DIRECTORY
+        / "testing"
+        / f"constraints-{UNIT_TEST_PYTHON_VERSIONS[0]}.txt",
+        encoding="utf-8",
+    ) as constraints_file:
+        constraints_text = constraints_file.read()
+
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
+
+    session.install(*constraints_deps)
+
+    core_dependencies_from_source = [
+        "google-api-core @ git+https://github.com/googleapis/python-api-core.git",
+        "google-auth @ git+https://github.com/googleapis/google-auth-library-python.git",
+        CURRENT_DIRECTORY / ".." / "googleapis-common-protos",
+        CURRENT_DIRECTORY / ".." / "grpc-google-iam-v1",
+        "proto-plus @ git+https://github.com/googleapis/proto-plus-python.git",
+        
+    ]
+
+    for dep in core_dependencies_from_source:
+        session.install(dep, "--ignore-installed", "--no-deps")
+
+    session.run(
+        "py.test",
+        "tests/unit",
+        env={
+            "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
+        },
+    )

--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -572,8 +572,8 @@ def core_deps_from_source(session, protobuf_implementation):
     core_dependencies_from_source = [
         "google-api-core @ git+https://github.com/googleapis/python-api-core.git",
         "google-auth @ git+https://github.com/googleapis/google-auth-library-python.git",
-        CURRENT_DIRECTORY / ".." / "googleapis-common-protos",
-        CURRENT_DIRECTORY / ".." / "grpc-google-iam-v1",
+        f"{CURRENT_DIRECTORY}/../googleapis-common-protos",
+        f"{CURRENT_DIRECTORY}/../grpc-google-iam-v1",
         "proto-plus @ git+https://github.com/googleapis/proto-plus-python.git",
         
     ]

--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -457,7 +457,7 @@ def prerelease_deps(session, protobuf_implementation):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
-    session.install("-e", ".[all, tests, tracing]")
+    session.install("-e", ".")
     unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
     session.install(*unit_deps_all)
     system_deps_all = (
@@ -538,7 +538,7 @@ def core_deps_from_source(session, protobuf_implementation):
     """Run all tests with local versions of core dependencies installed."""
 
     # Install all dependencies
-    session.install(".[all, tests, tracing]")
+    session.install(".")
     unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
     session.install(*unit_deps_all)
     system_deps_all = (


### PR DESCRIPTION
This PR adds a new nox session for generated clients called `core_deps_from_source` that installs core dependencies from source.

`google-api-core` `google-auth` and `proto-plus` are installed from the corresponding GitHub repositories, however `googleapis-common-protos` and `grpc-google-iam-v1` are installed from within the monorepo

```
        "google-api-core @ git+https://github.com/googleapis/python-api-core.git",
        "google-auth @ git+https://github.com/googleapis/google-auth-library-python.git",
        CURRENT_DIRECTORY / ".." / "googleapis-common-protos",
        CURRENT_DIRECTORY / ".." / "grpc-google-iam-v1",
        "proto-plus @ git+https://github.com/googleapis/proto-plus-python.git",
```

To test these changes,

In a clone of this repository, run the following:
```
docker build -f docker/owlbot/python_mono_repo/Dockerfile -t mono_repo_update .
```

Then in `googleapis/google-cloud-python`, run the following:
```
mkdir -p owl-bot-staging/<package name>
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo mono_repo_update
```

See the result in https://github.com/googleapis/google-cloud-python/pull/13509 