### PR TITLE
fix: updates jinja template to control blank line whitespace

### DIFF
--- a/synthtool/gcp/templates/python_library/docs/conf.py.j2
+++ b/synthtool/gcp/templates/python_library/docs/conf.py.j2
@@ -369,9 +369,9 @@ intersphinx_mapping = {
     "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
     {%- if intersphinx_dependencies %}
-        {% for name, url in intersphinx_dependencies.items() %}
+        {%- for name, url in intersphinx_dependencies.items() %}
     "{{ name }}": ("{{ url }}", None),
-        {% endfor %}
+        {%- endfor -%}
     {% endif %}
 }
 


### PR DESCRIPTION
This edit adds control characters to the docs/conf.py.j2 jinja template to control the undesired insertion of blank lines in between the key-value pairs of additions to the intersphinx-dependency dictionary.