### PR TITLE
chore: fix old links

### DIFF
--- a/synthtool/gcp/templates/node_esm_mono_repo_library/CONTRIBUTING.md
+++ b/synthtool/gcp/templates/node_esm_mono_repo_library/CONTRIBUTING.md
@@ -70,7 +70,7 @@ accept your pull requests.
         npm run fix
 
 [setup]: https://cloud.google.com/nodejs/docs/setup
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}{% endif %}
+{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid={{ metadata['repo']['api_id'] }}{% endif %}
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/synthtool/gcp/templates/node_esm_mono_repo_library/README.md
+++ b/synthtool/gcp/templates/node_esm_mono_repo_library/README.md
@@ -168,7 +168,7 @@ See [LICENSE](https://github.com/{{ metadata['repo']['repo'] }}/blob/{{ metadata
 {% if metadata['repo']['client_documentation'] %}[client-docs]: {{ metadata['repo']['client_documentation'] }}{% endif %}
 {% if metadata['repo']['product_documentation'] %}[product-docs]: {{ metadata['repo']['product_documentation'] }}{% endif %}
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}{% endif %}
+{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid={{ metadata['repo']['api_id'] }}{% endif %}
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/synthtool/gcp/templates/node_library/CONTRIBUTING.md
+++ b/synthtool/gcp/templates/node_library/CONTRIBUTING.md
@@ -70,7 +70,7 @@ accept your pull requests.
         npm run fix
 
 [setup]: https://cloud.google.com/nodejs/docs/setup
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}{% endif %}
+{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid={{ metadata['repo']['api_id'] }}{% endif %}
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -168,7 +168,7 @@ See [LICENSE](https://github.com/{{ metadata['repo']['repo'] }}/blob/{{ metadata
 {% if metadata['repo']['client_documentation'] %}[client-docs]: {{ metadata['repo']['client_documentation'] }}{% endif %}
 {% if metadata['repo']['product_documentation'] %}[product-docs]: {{ metadata['repo']['product_documentation'] }}{% endif %}
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}{% endif %}
+{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid={{ metadata['repo']['api_id'] }}{% endif %}
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local

--- a/synthtool/gcp/templates/node_mono_repo_library/CONTRIBUTING.md
+++ b/synthtool/gcp/templates/node_mono_repo_library/CONTRIBUTING.md
@@ -70,7 +70,7 @@ accept your pull requests.
         npm run fix
 
 [setup]: https://cloud.google.com/nodejs/docs/setup
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}{% endif %}
+{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid={{ metadata['repo']['api_id'] }}{% endif %}
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/synthtool/gcp/templates/node_mono_repo_library/README.md
+++ b/synthtool/gcp/templates/node_mono_repo_library/README.md
@@ -168,7 +168,7 @@ See [LICENSE](https://github.com/{{ metadata['repo']['repo'] }}/blob/{{ metadata
 {% if metadata['repo']['client_documentation'] %}[client-docs]: {{ metadata['repo']['client_documentation'] }}{% endif %}
 {% if metadata['repo']['product_documentation'] %}[product-docs]: {{ metadata['repo']['product_documentation'] }}{% endif %}
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid={{ metadata['repo']['api_id'] }}{% endif %}
+{% if metadata['repo']['api_id'] %}[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid={{ metadata['repo']['api_id'] }}{% endif %}
 [auth]: https://cloud.google.com/docs/authentication/external/set-up-adc-local

--- a/synthtool/gcp/templates/python_library/README.rst
+++ b/synthtool/gcp/templates/python_library/README.rst
@@ -32,7 +32,7 @@ In order to use this library, you first need to go through the following steps:
 3. `Enable the {{ metadata['repo']['name_pretty'] }} API.`_
 4. `Set up Authentication.`_
 
-.. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
+.. _Select or create a Cloud Platform project.: https://console.cloud.google.com/cloud-resource-manager
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
 .. _Enable the {{ metadata['repo']['name_pretty'] }} API.:  {{ metadata['repo']['product_documentation'] }}
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html

--- a/synthtool/gcp/templates/python_library/scripts/readme-gen/templates/auth_api_key.tmpl.rst
+++ b/synthtool/gcp/templates/python_library/scripts/readme-gen/templates/auth_api_key.tmpl.rst
@@ -11,4 +11,4 @@ Key:
 
 .. _API Key:
     https://developers.google.com/api-client-library/python/guide/aaa_apikeys
-.. _Cloud Console: https://console.cloud.google.com/project?_
+.. _Cloud Console: https://console.cloud.google.com/cloud-resource-manager?_

--- a/synthtool/gcp/templates/python_mono_repo_library/README.rst
+++ b/synthtool/gcp/templates/python_mono_repo_library/README.rst
@@ -32,7 +32,7 @@ In order to use this library, you first need to go through the following steps:
 3. `Enable the {{ metadata['repo']['name_pretty'] }}.`_
 4. `Set up Authentication.`_
 
-.. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
+.. _Select or create a Cloud Platform project.: https://console.cloud.google.com/cloud-resource-manager
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
 .. _Enable the {{ metadata['repo']['name_pretty'] }}.:  {{ metadata['repo']['product_documentation'] }}
 .. _Set up Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html

--- a/synthtool/gcp/templates/python_samples/auth_api_key.tmpl.rst
+++ b/synthtool/gcp/templates/python_samples/auth_api_key.tmpl.rst
@@ -11,4 +11,4 @@ Key:
 
 .. _API Key:
     https://developers.google.com/api-client-library/python/guide/aaa_apikeys
-.. _Cloud Console: https://console.cloud.google.com/project?_
+.. _Cloud Console: https://console.cloud.google.com/cloud-resource-manager?_

--- a/tests/fixtures/node_templates/no_version/CONTRIBUTING.md
+++ b/tests/fixtures/node_templates/no_version/CONTRIBUTING.md
@@ -68,7 +68,7 @@ accept your pull requests.
         npm run fix
 
 [setup]: https://cloud.google.com/nodejs/docs/setup
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/tests/fixtures/node_templates/no_version/README.md
+++ b/tests/fixtures/node_templates/no_version/README.md
@@ -112,7 +112,7 @@ See [LICENSE](https://github.com/googleapis/repo-automation-bots/blob/master/LIC
 [client-docs]: https://cloud.google.com/nodejs/docs/reference/repo-automation-bots/latest
 
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/tests/fixtures/nodejs-dlp-with-staging/CONTRIBUTING.md
+++ b/tests/fixtures/nodejs-dlp-with-staging/CONTRIBUTING.md
@@ -70,7 +70,7 @@ accept your pull requests.
         npm run fix
 
 [setup]: https://cloud.google.com/nodejs/docs/setup
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=dlp.googleapis.com
+[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid=dlp.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/tests/fixtures/nodejs-dlp-with-staging/README.md
+++ b/tests/fixtures/nodejs-dlp-with-staging/README.md
@@ -220,7 +220,7 @@ See [LICENSE](https://github.com/googleapis/nodejs-dlp/blob/master/LICENSE)
 [client-docs]: https://googleapis.dev/nodejs/dlp/latest
 [product-docs]: https://cloud.google.com/dlp/docs/
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=dlp.googleapis.com
+[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid=dlp.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/tests/fixtures/nodejs-dlp/CONTRIBUTING.md
+++ b/tests/fixtures/nodejs-dlp/CONTRIBUTING.md
@@ -70,7 +70,7 @@ accept your pull requests.
         npm run fix
 
 [setup]: https://cloud.google.com/nodejs/docs/setup
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=dlp.googleapis.com
+[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid=dlp.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/tests/fixtures/nodejs-dlp/README.md
+++ b/tests/fixtures/nodejs-dlp/README.md
@@ -220,7 +220,7 @@ See [LICENSE](https://github.com/googleapis/nodejs-dlp/blob/master/LICENSE)
 [client-docs]: https://googleapis.dev/nodejs/dlp/latest
 [product-docs]: https://cloud.google.com/dlp/docs/
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=dlp.googleapis.com
+[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid=dlp.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/tests/fixtures/nodejs_mono_repo_esm/packages/dlp/CONTRIBUTING.md
+++ b/tests/fixtures/nodejs_mono_repo_esm/packages/dlp/CONTRIBUTING.md
@@ -70,7 +70,7 @@ accept your pull requests.
         npm run fix
 
 [setup]: https://cloud.google.com/nodejs/docs/setup
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=dlp.googleapis.com
+[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid=dlp.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/tests/fixtures/nodejs_mono_repo_esm/packages/dlp/README.md
+++ b/tests/fixtures/nodejs_mono_repo_esm/packages/dlp/README.md
@@ -220,7 +220,7 @@ See [LICENSE](https://github.com/googleapis/nodejs-dlp/blob/master/LICENSE)
 [client-docs]: https://googleapis.dev/nodejs/dlp/latest
 [product-docs]: https://cloud.google.com/dlp/docs/
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=dlp.googleapis.com
+[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid=dlp.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/tests/fixtures/nodejs_mono_repo_with_staging/packages/dlp/CONTRIBUTING.md
+++ b/tests/fixtures/nodejs_mono_repo_with_staging/packages/dlp/CONTRIBUTING.md
@@ -70,7 +70,7 @@ accept your pull requests.
         npm run fix
 
 [setup]: https://cloud.google.com/nodejs/docs/setup
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=dlp.googleapis.com
+[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid=dlp.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/tests/fixtures/nodejs_mono_repo_with_staging/packages/dlp/README.md
+++ b/tests/fixtures/nodejs_mono_repo_with_staging/packages/dlp/README.md
@@ -220,7 +220,7 @@ See [LICENSE](https://github.com/googleapis/nodejs-dlp/blob/master/LICENSE)
 [client-docs]: https://googleapis.dev/nodejs/dlp/latest
 [product-docs]: https://cloud.google.com/dlp/docs/
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
-[enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=dlp.googleapis.com
+[enable_api]: https://console.cloud.google.com/apis/enableflow?apiid=dlp.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/tests/fixtures/nodejs_mono_repo_without_version/packages/no_version/CONTRIBUTING.md
+++ b/tests/fixtures/nodejs_mono_repo_without_version/packages/no_version/CONTRIBUTING.md
@@ -68,7 +68,7 @@ accept your pull requests.
         npm run fix
 
 [setup]: https://cloud.google.com/nodejs/docs/setup
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 
 [auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/tests/fixtures/nodejs_mono_repo_without_version/packages/no_version/README.md
+++ b/tests/fixtures/nodejs_mono_repo_without_version/packages/no_version/README.md
@@ -112,7 +112,7 @@ See [LICENSE](https://github.com/googleapis/repo-automation-bots/blob/master/LIC
 [client-docs]: https://cloud.google.com/nodejs/docs/reference/repo-automation-bots/latest
 
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
-[projects]: https://console.cloud.google.com/project
+[projects]: https://console.cloud.google.com/cloud-resource-manager
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 
 [auth]: https://cloud.google.com/docs/authentication/getting-started


### PR DESCRIPTION
Linkinator failed on the initial generation of the node bigquery GAPIC because these links redirect. I've updated them to the current versions of them for all templates. Should fix https://github.com/googleapis/nodejs-bigquery/pull/1446