### PR TITLE
chore(python): Update renovate.json to exclude pyproject.toml

### DIFF
--- a/synthtool/gcp/templates/python_library/renovate.json
+++ b/synthtool/gcp/templates/python_library/renovate.json
@@ -5,7 +5,7 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
+  "ignorePaths": [".pre-commit-config.yaml", "pyproject.toml", "setup.py", ".github/workflows/unittest.yml"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }


### PR DESCRIPTION
See https://github.com/googleapis/python-bigquery/pull/2143 where renovate bot is proposing undesired changes to `pyproject.toml`. 

We're currently excluding `setup.py` but we also need to exclude `pyproject.toml`

https://github.com/googleapis/synthtool/blob/bb0a3506602525f63c7002f8d13345be3678effb/synthtool/gcp/templates/python_library/renovate.json#L8

This PR also includes the following fixes:
- exclude `.kokoro/requirements.txt`  which was removed in https://github.com/googleapis/synthtool/pull/2035
