### PR TITLE
chore(python_mono_repo): clean up prerelease_deps and core_deps_from_source

### DIFF
--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -596,7 +596,7 @@ def core_deps_from_source(session, protobuf_implementation):
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
 
-    # TODO(hhttps://github.com/googleapis/gapic-generator-python/issues/2358): `grpcio` and
+    # TODO(https://github.com/googleapis/gapic-generator-python/issues/2358): `grpcio` and
     # `grpcio-status` should be added to the list below so that it is installed from source, rather than PyPI
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2357): `protobuf` should be
     # added to the list below so that it is installed from source, rather than PyPI

--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -597,7 +597,8 @@ def core_deps_from_source(session, protobuf_implementation):
     session.install(*constraints_deps)
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2358): `grpcio` and
-    # `grpcio-status` should be added to the list below so that it is installed from source, rather than PyPI
+    # `grpcio-status` should be added to the list below so that they are installed from source,
+    # rather than PyPI.
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2357): `protobuf` should be
     # added to the list below so that it is installed from source, rather than PyPI
     # Note: If a dependency is added to the `core_dependencies_from_source` list,

--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -527,10 +527,7 @@ def prerelease_deps(session, protobuf_implementation):
             "proto-plus": "proto",
         }
 
-        try:
-            version_namespace = package_namespaces[dep]
-        except KeyError:
-            version_namespace = None
+        version_namespace = package_namespaces.get(dep)
 
         print(f"Installed {dep}")
         if version_namespace:

--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -454,7 +454,7 @@ def prerelease_deps(session, protobuf_implementation):
     """
     Run all tests with pre-release versions of dependencies installed
     rather than the standard non pre-release versions.
-    Pre-releases versions can be installed using
+    Pre-release versions can be installed using
     `pip install --pre <package>`.
     """
 
@@ -464,16 +464,16 @@ def prerelease_deps(session, protobuf_implementation):
     # Install all dependencies
     session.install("-e", ".")
 
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
     # Install dependencies for the unit test environment
+    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
     session.install(*unit_deps_all)
 
+    # Install dependencies for the system test environment
     system_deps_all = (
         SYSTEM_TEST_STANDARD_DEPENDENCIES
         + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
         + SYSTEM_TEST_EXTRAS
     )
-    # Install dependencies for the system test environment
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -498,37 +498,47 @@ def prerelease_deps(session, protobuf_implementation):
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
 
+    # Note: If a dependency is added to the `prerel_deps` list,
+    # the `core_dependencies_from_source` list in the `core_deps_from_source`
+    # nox session should also be updated.
     prerel_deps = [
-        "protobuf",
-        # dependency of grpc
-        "six",
-        "grpc-google-iam-v1",
         "googleapis-common-protos",
-        "grpcio",
-        "grpcio-status",
         "google-api-core",
         "google-auth",
+        "grpc-google-iam-v1",
+        "grpcio",
+        "grpcio-status",
+        "protobuf",
         "proto-plus",
-        "google-cloud-testutils",
-        # dependencies of google-cloud-testutils"
-        "click",
     ]
 
     for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--upgrade", dep)
+        session.install("--pre", "--no-deps", "--ignore-installed", dep)
+        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+        # to the dictionary below once this bug is fixed.
+        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+        # once this bug is fixed.
+        package_namespaces = {
+            "google-api-core": "google.api_core",
+            "google-auth": "google.auth",
+            "grpcio": "grpc",
+            "protobuf": "google.protobuf",
+            "proto-plus": "proto",
+        }
 
-    # Remaining dependencies
-    other_deps = [
-        "requests",
-    ]
-    session.install(*other_deps)
+        try:
+            version_namespace = package_namespaces[dep]
+        except KeyError:
+            version_namespace = None
 
-    # Print out prerelease package versions
-    session.run(
-        "python", "-c", "import google.protobuf; print(google.protobuf.__version__)"
-    )
-    session.run("python", "-c", "import grpc; print(grpc.__version__)")
-    session.run("python", "-c", "import google.auth; print(google.auth.__version__)")
+        print(f"Installed {dep}")
+        if version_namespace:
+            session.run(
+                "python",
+                "-c",
+                f"import {version_namespace}; print({version_namespace}.__version__)",
+            )
 
     session.run(
         "py.test",
@@ -545,12 +555,12 @@ def prerelease_deps(session, protobuf_implementation):
     ["python", "upb"],
 )
 def core_deps_from_source(session, protobuf_implementation):
-    """Run all tests with local versions of core dependencies installed,
-    rather than pulling core dependencies from PyPI.
+    """Run all tests with core dependencies installed from source
+    rather than pulling the dependencies from PyPI.
     """
 
     # Install all dependencies
-    session.install(".")
+    session.install("-e", ".")
 
     # Install dependencies for the unit test environment
     unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
@@ -566,7 +576,7 @@ def core_deps_from_source(session, protobuf_implementation):
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a
-    # constraints file containing all dependencies and extras that should be installed.
+    # constraints file containing all dependencies and extras.
     with open(
         CURRENT_DIRECTORY
         / "testing"
@@ -586,17 +596,23 @@ def core_deps_from_source(session, protobuf_implementation):
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
 
+    # TODO(hhttps://github.com/googleapis/gapic-generator-python/issues/2358): `grpcio` and
+    # `grpcio-status` should be added to the list below so that it is installed from source, rather than PyPI
+    # TODO(https://github.com/googleapis/gapic-generator-python/issues/2357): `protobuf` should be
+    # added to the list below so that it is installed from source, rather than PyPI
+    # Note: If a dependency is added to the `core_dependencies_from_source` list,
+    # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
+        "proto-plus @ git+https://github.com/googleapis/proto-plus-python.git",
+        f"{CURRENT_DIRECTORY}/../googleapis-common-protos",
         "google-api-core @ git+https://github.com/googleapis/python-api-core.git",
         "google-auth @ git+https://github.com/googleapis/google-auth-library-python.git",
-        f"{CURRENT_DIRECTORY}/../googleapis-common-protos",
         f"{CURRENT_DIRECTORY}/../grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/proto-plus-python.git",
-        
     ]
 
     for dep in core_dependencies_from_source:
-        session.install(dep, "--ignore-installed", "--no-deps")
+        session.install(dep, "--no-deps", "--ignore-installed")
+        print(f"Installed {dep}")
 
     session.run(
         "py.test",

--- a/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
+++ b/synthtool/gcp/templates/python_mono_repo_library/noxfile.py.j2
@@ -603,11 +603,11 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "proto-plus @ git+https://github.com/googleapis/proto-plus-python.git",
         f"{CURRENT_DIRECTORY}/../googleapis-common-protos",
         "google-api-core @ git+https://github.com/googleapis/python-api-core.git",
         "google-auth @ git+https://github.com/googleapis/google-auth-library-python.git",
         f"{CURRENT_DIRECTORY}/../grpc-google-iam-v1",
+        "proto-plus @ git+https://github.com/googleapis/proto-plus-python.git",
     ]
 
     for dep in core_dependencies_from_source:


### PR DESCRIPTION
This PR will address feedback from code review in https://github.com/googleapis/google-cloud-python/pull/13637. The following fixes are included:

- Clean up of comments
- Print out installed versions in `prerelease_deps` and `core_deps_from_source`
- Sync dependencies in `prerelease_deps` and `core_deps_from_source`
