### PR TITLE
chore(python): ignore workflows in renovate.json

### DIFF
--- a/synthtool/gcp/templates/python_library/renovate.json
+++ b/synthtool/gcp/templates/python_library/renovate.json
@@ -5,7 +5,7 @@
     ":preserveSemverRanges",
     ":disableDependencyDashboard"
   ],
-  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/unittest.yml"],
+  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt", "setup.py", ".github/workflows/*"],
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
   }


### PR DESCRIPTION
Fixes: https://github.com/googleapis/synthtool/issues/2090

> Renovate Bot PRs are currently failing on many repos, because it is trying to update the Python version used by our GitrHub Actions tests, when we often want to explicitly test against the lowest supported version (examples: https://github.com/googleapis/python-bigtable/pull/1129, [firestore](https://github.com/googleapis/python-firestore/pull/1007/files)).
>
> To address this, we should change the template renovate.json file to skip all GitHub Action workflow files, instead of the [default of just skiping unittest.yaml](https://github.com/googleapis/synthtool/blob/6318601ed44bb99ec965bae0d46b54eba42aeb24/synthtool/gcp/templates/python_library/renovate.json#L8)