### PR TITLE
chore(python): exclude *.tar.gz when copying generated code

### DIFF
--- a/synthtool/languages/python_mono_repo.py
+++ b/synthtool/languages/python_mono_repo.py
@@ -279,7 +279,7 @@ def owlbot_main(package_dir: str) -> None:
                     f"{package_dir}/samples/generated_samples", ignore_errors=True
                 )
                 clean_up_generated_samples = False
-            synthtool.move([library], package_dir, excludes=[])
+            synthtool.move([library], package_dir, excludes=["*.tar.gz"])
 
         templated_files = gcp.CommonTemplates().py_mono_repo_library(
             relative_dir=f"packages/{package_name}",


### PR DESCRIPTION
The output of python client library generation includes *.tar.gz files. These are not currently used, so we can exclude them when copying code from googleapis-gen.

As an example, see https://github.com/googleapis/googleapis-gen/blob/master/google/cloud/securitycenter/v1/securitycenter-v1-py/securitycenter-v1-py.tar.gz 

See related issue https://github.com/googleapis/gapic-generator-python/issues/1354
I have only seen this problem when using bazel. It doesn't appear when running protoc directly.