### PR TITLE
chore: revert previous node-version template changes in ci.yaml

### DIFF
--- a/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
+++ b/synthtool/gcp/templates/node_library/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
       - run: node --version
       - run: npm install --engine-strict
         working-directory: .github/scripts
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
       - run: npm install --engine-strict
       - run: npm test
         env:
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
       - run: npm install
       - run: npm run lint
   docs:
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
       - run: npm install
       - run: npm run docs
       - uses: JustinBeckwith/linkinator-action@v1


### PR DESCRIPTION
Somehow when master got merged into #2114 it undid the changes to `ci.yaml` 🤦🏻 