### PR TITLE
chore(python): allow post processor to run without setup.py

### DIFF
--- a/synthtool/languages/python_mono_repo.py
+++ b/synthtool/languages/python_mono_repo.py
@@ -312,8 +312,9 @@ def owlbot_main(package_dir: str) -> None:
         # create CHANGELOG.md and symlink to docs/CHANGELOG.md if it doesn't exist
         create_changelog_and_symlink_to_docs_changelog(package_dir)
 
-        # update the url in setup.py to point to google-cloud-python
-        update_url_in_setup_py(package_dir)
+        if Path(f"packages/{package_name}/setup.py").exists():
+            # update the url in setup.py to point to google-cloud-python
+            update_url_in_setup_py(package_dir)
 
         # add license header to pb2.py and pb2.pyi files.
         fix_pb2_headers(package_dir)

--- a/synthtool/languages/python_mono_repo.py
+++ b/synthtool/languages/python_mono_repo.py
@@ -312,7 +312,7 @@ def owlbot_main(package_dir: str) -> None:
         # create CHANGELOG.md and symlink to docs/CHANGELOG.md if it doesn't exist
         create_changelog_and_symlink_to_docs_changelog(package_dir)
 
-        if Path(f"packages/{package_name}/setup.py").exists():
+        if Path(f"{package_dir}/setup.py").exists():
             # update the url in setup.py to point to google-cloud-python
             update_url_in_setup_py(package_dir)
 


### PR DESCRIPTION
This PR resolves the following issue when running the Python post processor in a directory without `setup.py`.

This happens with librarian when we run `librarian generate` for APIs which don't contain GAPICs such as common protos, since the generation only consists of Protobuf gencode with only these files : `*_pb.py` and `*_pb.pyi` 