### PR TITLE
fix: disable renovate for Node github action YAML configs

### DIFF
--- a/synthtool/gcp/templates/node_library/renovate.json
+++ b/synthtool/gcp/templates/node_library/renovate.json
@@ -15,6 +15,10 @@
     {
       "extends": "packages:linters",
       "groupName": "linters"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "enabled": false
     }
   ],
   "ignoreDeps": ["typescript"]


### PR DESCRIPTION
We have templated GitHub action configs and renovate opens PRs to update them, which then get clobbered by owlbot shortly after - this I think fixes b/444433904