### PR TITLE
fix: update npmjs.org to npmjs.com

### DIFF
--- a/synthtool/gcp/templates/node_esm_mono_repo_library/README.md
+++ b/synthtool/gcp/templates/node_esm_mono_repo_library/README.md
@@ -9,7 +9,7 @@
 {%- endif %}
 
 {{ metadata['repo']['release_level']|release_quality_badge }}
-[![npm version](https://img.shields.io/npm/v/{{ metadata['name'] }}.svg)](https://www.npmjs.org/package/{{ metadata['name'] }})
+[![npm version](https://img.shields.io/npm/v/{{ metadata['name'] }}.svg)](https://www.npmjs.com/package/{{ metadata['name'] }})
 
 {% if metadata['deprecated'] %}
 | :warning: Deprecated Module |

--- a/synthtool/gcp/templates/node_library/.kokoro/release/publish.cfg
+++ b/synthtool/gcp/templates/node_library/.kokoro/release/publish.cfg
@@ -38,7 +38,7 @@ env_vars: {
     value: "github/{{ metadata['repository_name'] }}/.kokoro/publish.sh"
 }
 
-# Store the packages we uploaded to npmjs.org and their corresponding
+# Store the packages we uploaded to npmjs.com and their corresponding
 # package-lock.jsons in Placer.  That way, we have a record of exactly
 # what we published, and which version of which tools we used to publish
 # it, which we can use to generate SBOMs and attestations.

--- a/synthtool/gcp/templates/node_library/README.md
+++ b/synthtool/gcp/templates/node_library/README.md
@@ -9,7 +9,7 @@
 {%- endif %}
 
 {{ metadata['repo']['release_level']|release_quality_badge }}
-[![npm version](https://img.shields.io/npm/v/{{ metadata['name'] }}.svg)](https://www.npmjs.org/package/{{ metadata['name'] }})
+[![npm version](https://img.shields.io/npm/v/{{ metadata['name'] }}.svg)](https://www.npmjs.com/package/{{ metadata['name'] }})
 
 {% if metadata['deprecated'] %}
 | :warning: Deprecated Module |

--- a/synthtool/gcp/templates/node_mono_repo_library/README.md
+++ b/synthtool/gcp/templates/node_mono_repo_library/README.md
@@ -9,7 +9,7 @@
 {%- endif %}
 
 {{ metadata['repo']['release_level']|release_quality_badge }}
-[![npm version](https://img.shields.io/npm/v/{{ metadata['name'] }}.svg)](https://www.npmjs.org/package/{{ metadata['name'] }})
+[![npm version](https://img.shields.io/npm/v/{{ metadata['name'] }}.svg)](https://www.npmjs.com/package/{{ metadata['name'] }})
 
 {% if metadata['deprecated'] %}
 | :warning: Deprecated Module |

--- a/tests/fixtures/node_templates/no_version/README.md
+++ b/tests/fixtures/node_templates/no_version/README.md
@@ -5,7 +5,7 @@
 # [Repo Automation Bots: Node.js Client](https://github.com/googleapis/repo-automation-bots)
 
 [![release level](https://img.shields.io/badge/release%20level-stable-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
-[![npm version](https://img.shields.io/npm/v/repo-automation-bots.svg)](https://www.npmjs.org/package/repo-automation-bots)
+[![npm version](https://img.shields.io/npm/v/repo-automation-bots.svg)](https://www.npmjs.com/package/repo-automation-bots)
 
 
 

--- a/tests/fixtures/nodejs-dlp-with-staging/README.md
+++ b/tests/fixtures/nodejs-dlp-with-staging/README.md
@@ -5,7 +5,7 @@
 # [Cloud Data Loss Prevention: Node.js Client](https://github.com/googleapis/nodejs-dlp)
 
 [![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
-[![npm version](https://img.shields.io/npm/v/@google-cloud/dlp.svg)](https://www.npmjs.org/package/@google-cloud/dlp)
+[![npm version](https://img.shields.io/npm/v/@google-cloud/dlp.svg)](https://www.npmjs.com/package/@google-cloud/dlp)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-dlp/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-dlp)
 
 

--- a/tests/fixtures/nodejs-dlp/README.md
+++ b/tests/fixtures/nodejs-dlp/README.md
@@ -5,7 +5,7 @@
 # [Cloud Data Loss Prevention: Node.js Client](https://github.com/googleapis/nodejs-dlp)
 
 [![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
-[![npm version](https://img.shields.io/npm/v/@google-cloud/dlp.svg)](https://www.npmjs.org/package/@google-cloud/dlp)
+[![npm version](https://img.shields.io/npm/v/@google-cloud/dlp.svg)](https://www.npmjs.com/package/@google-cloud/dlp)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-dlp/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-dlp)
 
 

--- a/tests/fixtures/nodejs_mono_repo_esm/packages/dlp/README.md
+++ b/tests/fixtures/nodejs_mono_repo_esm/packages/dlp/README.md
@@ -5,7 +5,7 @@
 # [Cloud Data Loss Prevention: Node.js Client](https://github.com/googleapis/nodejs-dlp)
 
 [![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
-[![npm version](https://img.shields.io/npm/v/@google-cloud/dlp.svg)](https://www.npmjs.org/package/@google-cloud/dlp)
+[![npm version](https://img.shields.io/npm/v/@google-cloud/dlp.svg)](https://www.npmjs.com/package/@google-cloud/dlp)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-dlp/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-dlp)
 
 

--- a/tests/fixtures/nodejs_mono_repo_with_staging/packages/dlp/README.md
+++ b/tests/fixtures/nodejs_mono_repo_with_staging/packages/dlp/README.md
@@ -5,7 +5,7 @@
 # [Cloud Data Loss Prevention: Node.js Client](https://github.com/googleapis/nodejs-dlp)
 
 [![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
-[![npm version](https://img.shields.io/npm/v/@google-cloud/dlp.svg)](https://www.npmjs.org/package/@google-cloud/dlp)
+[![npm version](https://img.shields.io/npm/v/@google-cloud/dlp.svg)](https://www.npmjs.com/package/@google-cloud/dlp)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-dlp/master.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-dlp)
 
 

--- a/tests/fixtures/nodejs_mono_repo_without_version/packages/no_version/README.md
+++ b/tests/fixtures/nodejs_mono_repo_without_version/packages/no_version/README.md
@@ -5,7 +5,7 @@
 # [Repo Automation Bots: Node.js Client](https://github.com/googleapis/repo-automation-bots)
 
 [![release level](https://img.shields.io/badge/release%20level-stable-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
-[![npm version](https://img.shields.io/npm/v/repo-automation-bots.svg)](https://www.npmjs.org/package/repo-automation-bots)
+[![npm version](https://img.shields.io/npm/v/repo-automation-bots.svg)](https://www.npmjs.com/package/repo-automation-bots)
 
 
 


### PR DESCRIPTION
Linkinator is fussy but one failure is right - npmjs.org is now npmjs.com - I think that this should fix that failure