### PR TITLE
chore(python): explicitly state that Python 3.14 is supported

### DIFF
--- a/synthtool/gcp/templates/python_mono_repo_library/README.rst
+++ b/synthtool/gcp/templates/python_mono_repo_library/README.rst
@@ -65,7 +65,7 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.7
+Python >= 3.7, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches


### PR DESCRIPTION
Towards b/375664027