### PR TITLE
fix: lint failures

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@
 
 import nox
 
-PYTHON_VERSIONS = ['3.8', '3.10']
+PYTHON_VERSIONS = ['3.10']
 
 # Error if a python version is missing
 nox.options.error_on_missing_interpreters = True

--- a/synthtool/gcp/templates/node_library/.kokoro/lint.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/lint.sh
@@ -17,6 +17,11 @@
 set -eo pipefail
 
 export NPM_CONFIG_PREFIX=${HOME}/.npm-global
+export PATH="${NPM_CONFIG_PREFIX}/bin:${PATH}"
+
+# Ensure the npm global directory is writable, otherwise rebuild `npm`
+mkdir -p ${NPM_CONFIG_PREFIX}
+npm config -g ls || npm i -g npm@`npm --version`
 
 cd $(dirname $0)/..
 


### PR DESCRIPTION
issue - kokoro pipeline for lint nightly is failing with the error
npm error enoent ENOENT: no such file or directory, lstat '/h/.npm-global'

fix is needed in synthtool to mirror the changes in all the clients
fix provided will create the directory /h/.npm-global. If the parent directory /h doesn't exist it will create it first, otherwise will do nothing.