### PR TITLE
fix(node): ignore staging folder get_destination_folder function

### DIFF
--- a/synthtool/languages/node_mono_repo.py
+++ b/synthtool/languages/node_mono_repo.py
@@ -397,7 +397,7 @@ def get_destination_folder(package_name: str, base_dir: Path) -> Optional[str]:
     It searches for a directory with the package name in all subdirectories of the current directory.
     """
     for path in base_dir.glob(f"*/{package_name}"):
-        if path.is_dir():
+        if path.is_dir() and path.parent.name != "owl-bot-staging":
             return path.parent.name
     return None
 

--- a/tests/test_node_mono_repo.py
+++ b/tests/test_node_mono_repo.py
@@ -468,16 +468,17 @@ def test_walk_through_owlbot_dirs_no_staging(mock_subproc_popen):
         (handwritten_dir / ".OwlBot.yaml").touch()
 
         owlbot_dirs = node_mono_repo.walk_through_owlbot_dirs(
-            workdir, search_for_changed_files=False, legacy_staging_dir=False
+            workdir, search_for_changed_files=False
         )
+        unique_owlbot_dirs = set(owlbot_dirs)
 
         assert not mock_subproc_popen.called
-        # dlp, my-package. Staging should be excluded.
-        assert len(owlbot_dirs) == 2
+        # dlp, my-package. Staging-sourced paths should be mapped to destination.
+        assert len(unique_owlbot_dirs) == 2
 
-        assert any(re.search("handwritten/my-package", d) for d in owlbot_dirs)
-        assert any(re.search("packages/dlp", d) for d in owlbot_dirs)
-        assert not any(re.search("owl-bot-staging", d) for d in owlbot_dirs)
+        assert any(re.search("handwritten/my-package", d) for d in unique_owlbot_dirs)
+        assert any(re.search("packages/dlp", d) for d in unique_owlbot_dirs)
+        assert not any(re.search("owl-bot-staging", d) for d in unique_owlbot_dirs)
 
 
 @patch("synthtool.languages.node_mono_repo.walk_through_owlbot_dirs")


### PR DESCRIPTION
Ignore staging folder in get_destionation_folder function. 

An error is occurring because the system is incorrectly scanning all subdirectories, including the staging folder, while looking for the destination folder. Refer to b/476524603 for additional details.
