### PR TITLE
fix(node): exclude test fixtures from post-processing

### DIFF
--- a/synthtool/languages/node_mono_repo.py
+++ b/synthtool/languages/node_mono_repo.py
@@ -482,6 +482,7 @@ def walk_through_owlbot_dirs(dir: Path, search_for_changed_files: bool):
     packages_to_exclude = [
         r"packages/gapic-node-processing/templates/bootstrap-templates",
         r"node_modules",
+        r"core/generator/gapic-generator-typescript/test-fixtures",
     ]
     if search_for_changed_files:
         try:

--- a/tests/test_node_mono_repo.py
+++ b/tests/test_node_mono_repo.py
@@ -519,12 +519,19 @@ def test_walk_through_owlbot_dirs_excluded(mock_subproc_popen):
     with util.copied_fixtures_dir(
         FIXTURES / "nodejs_mono_repo_with_staging"
     ) as workdir:
-        excluded_dir = workdir / "core" / "generator" / "gapic-generator-typescript" / "test-fixtures" / "speech"
+        excluded_dir = (
+            workdir
+            / "core"
+            / "generator"
+            / "gapic-generator-typescript"
+            / "test-fixtures"
+            / "speech"
+        )
         excluded_dir.mkdir(parents=True)
         (excluded_dir / ".OwlBot.yaml").touch()
 
         regular_dir = workdir / "core" / "generator" / "gapic-generator-typescript"
-        regular_dir.mkdir(parents=True)
+        regular_dir.mkdir(parents=True, exist_ok=True)
         (regular_dir / ".OwlBot.yaml").touch()
 
         owlbot_dirs = node_mono_repo.walk_through_owlbot_dirs(
@@ -532,8 +539,17 @@ def test_walk_through_owlbot_dirs_excluded(mock_subproc_popen):
         )
 
         assert not mock_subproc_popen.called
-        assert any(re.search("core/generator/gapic-generator-typescript$", d) for d in owlbot_dirs)
-        assert not any(re.search("core/generator/gapic-generator-typescript/test-fixtures/speech", d) for d in owlbot_dirs)
+        assert any(
+            re.search("core/generator/gapic-generator-typescript$", d)
+            for d in owlbot_dirs
+        )
+        assert not any(
+            re.search(
+                "core/generator/gapic-generator-typescript/test-fixtures/speech",
+                d,
+            )
+            for d in owlbot_dirs
+        )
 
 
 @patch("subprocess.run")

--- a/tests/test_node_mono_repo.py
+++ b/tests/test_node_mono_repo.py
@@ -510,6 +510,33 @@ def test_walk_through_owlbot_dirs_handwritten(mock_subproc_popen):
 
 
 @patch("subprocess.run")
+def test_walk_through_owlbot_dirs_excluded(mock_subproc_popen):
+    process_mock = Mock()
+    attrs = {"communicate.return_value": ("output", "error")}
+    process_mock.configure_mock(**attrs)
+    mock_subproc_popen.return_value = process_mock
+
+    with util.copied_fixtures_dir(
+        FIXTURES / "nodejs_mono_repo_with_staging"
+    ) as workdir:
+        excluded_dir = workdir / "core" / "generator" / "gapic-generator-typescript" / "test-fixtures" / "speech"
+        excluded_dir.mkdir(parents=True)
+        (excluded_dir / ".OwlBot.yaml").touch()
+
+        regular_dir = workdir / "core" / "generator" / "gapic-generator-typescript"
+        regular_dir.mkdir(parents=True)
+        (regular_dir / ".OwlBot.yaml").touch()
+
+        owlbot_dirs = node_mono_repo.walk_through_owlbot_dirs(
+            workdir, search_for_changed_files=False
+        )
+
+        assert not mock_subproc_popen.called
+        assert any(re.search("core/generator/gapic-generator-typescript$", d) for d in owlbot_dirs)
+        assert not any(re.search("core/generator/gapic-generator-typescript/test-fixtures/speech", d) for d in owlbot_dirs)
+
+
+@patch("subprocess.run")
 def test_walk_through_owlbot_dirs_no_staging(mock_subproc_popen):
     process_mock = Mock()
     attrs = {"communicate.return_value": ("output", "error")}


### PR DESCRIPTION
Excludes `core/generator/gapic-generator-typescript/test-fixtures` from directory traversal in `node_mono_repo.py` to prevent the post-processor from re-adding them to `release-please-config.json`.

See https://github.com/googleapis/google-cloud-node/pull/8171 for an example of the issue.