### PR TITLE
feat: drop python 3.9 support in python mono-repo library template

### DIFF
--- a/synthtool/_tracked_paths.py
+++ b/synthtool/_tracked_paths.py
@@ -20,7 +20,7 @@ This is a bit of a hack.
 import pathlib
 
 
-_tracked_paths = []
+_tracked_paths: list[pathlib.Path] = []
 
 
 def add(path):

--- a/synthtool/gcp/templates/python_mono_repo_library/README.rst
+++ b/synthtool/gcp/templates/python_mono_repo_library/README.rst
@@ -65,14 +65,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.


### PR DESCRIPTION
Updates the README.rst template to match our currently supported runtimes:

supported: >= 3.10
unsupported: <=3.9

Also:

added a type annotation that was causing mypy CI/CD check to fail.