### PR TITLE
feat: add git concurrency patch

### DIFF
--- a/synthtool/sources/git.py
+++ b/synthtool/sources/git.py
@@ -105,15 +105,16 @@ def clone(
 
         dest = dest / pathlib.Path(url).stem
 
-        if force and dest.exists():
-            shutil.rmtree(dest)
+    import fcntl
+    lock_file = dest.parent / (dest.name + ".lock")
+    with open(lock_file, "w") as lock_f:
+        fcntl.flock(lock_f, fcntl.LOCK_EX)
+        try:
+            if not preclone:
+                if force and dest.exists():
+                    shutil.rmtree(dest)
 
-        default_branch = None
-        import fcntl
-        lock_file = dest.parent / (dest.name + ".lock")
-        with open(lock_file, "w") as lock_f:
-            fcntl.flock(lock_f, fcntl.LOCK_EX)
-            try:
+                default_branch = None
                 if not dest.exists():
                     cmd = ["git", "clone", "--recurse-submodules", "--single-branch", url, dest]
                     shell.run(cmd, check=True)
@@ -121,12 +122,12 @@ def clone(
                     default_branch = _local_default_branch(dest)
                     shell.run(["git", "checkout", default_branch], cwd=str(dest), check=True)
                     shell.run(["git", "pull"], cwd=str(dest), check=True)
-            finally:
-                fcntl.flock(lock_f, fcntl.LOCK_UN)
-        committish = committish or default_branch
+                committish = committish or default_branch
 
-    if committish:
-        shell.run(["git", "reset", "--hard", committish], cwd=str(dest))
+            if committish:
+                shell.run(["git", "reset", "--hard", committish], cwd=str(dest))
+        finally:
+            fcntl.flock(lock_f, fcntl.LOCK_UN)
 
     # track all git repositories
     _tracked_paths.add(dest)

--- a/synthtool/sources/git.py
+++ b/synthtool/sources/git.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import fcntl
 import os
 import pathlib
@@ -43,6 +44,16 @@ def make_repo_clone_url(repo: str) -> str:
         return f"git@github.com:{repo}.git"
     else:
         return f"https://github.com/{repo}.git"
+
+
+@contextlib.contextmanager
+def file_lock(lock_path: pathlib.Path):
+    with open(lock_path, "w") as lock_f:
+        fcntl.flock(lock_f, fcntl.LOCK_EX)
+        try:
+            yield lock_f
+        finally:
+            fcntl.flock(lock_f, fcntl.LOCK_UN)
 
 
 def _local_default_branch(path: pathlib.Path) -> Union[str, None]:
@@ -107,36 +118,32 @@ def clone(
         dest = dest / pathlib.Path(url).stem
 
     lock_file = dest.parent / (dest.name + ".lock")
-    with open(lock_file, "w") as lock_f:
-        fcntl.flock(lock_f, fcntl.LOCK_EX)
-        try:
-            if not preclone:
-                if force and dest.exists():
-                    shutil.rmtree(dest)
+    with file_lock(lock_file):
+        if not preclone:
+            if force and dest.exists():
+                shutil.rmtree(dest)
 
-                default_branch = None
-                if not dest.exists():
-                    cmd = [
-                        "git",
-                        "clone",
-                        "--recurse-submodules",
-                        "--single-branch",
-                        url,
-                        dest,
-                    ]
-                    shell.run(cmd, check=True)
-                else:
-                    default_branch = _local_default_branch(dest)
-                    shell.run(
-                        ["git", "checkout", default_branch], cwd=str(dest), check=True
-                    )
-                    shell.run(["git", "pull"], cwd=str(dest), check=True)
-                committish = committish or default_branch
+            default_branch = None
+            if not dest.exists():
+                cmd = [
+                    "git",
+                    "clone",
+                    "--recurse-submodules",
+                    "--single-branch",
+                    url,
+                    dest,
+                ]
+                shell.run(cmd, check=True)
+            else:
+                default_branch = _local_default_branch(dest)
+                shell.run(
+                    ["git", "checkout", default_branch], cwd=str(dest), check=True
+                )
+                shell.run(["git", "pull"], cwd=str(dest), check=True)
+            committish = committish or default_branch
 
-            if committish:
-                shell.run(["git", "reset", "--hard", committish], cwd=str(dest))
-        finally:
-            fcntl.flock(lock_f, fcntl.LOCK_UN)
+        if committish:
+            shell.run(["git", "reset", "--hard", committish], cwd=str(dest))
 
     # track all git repositories
     _tracked_paths.add(dest)

--- a/synthtool/sources/git.py
+++ b/synthtool/sources/git.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import fcntl
 import os
 import pathlib
 import re
@@ -104,8 +105,6 @@ def clone(
             dest = cache.get_cache_dir()
 
         dest = dest / pathlib.Path(url).stem
-
-    import fcntl
 
     lock_file = dest.parent / (dest.name + ".lock")
     with open(lock_file, "w") as lock_f:

--- a/synthtool/sources/git.py
+++ b/synthtool/sources/git.py
@@ -109,13 +109,20 @@ def clone(
             shutil.rmtree(dest)
 
         default_branch = None
-        if not dest.exists():
-            cmd = ["git", "clone", "--recurse-submodules", "--single-branch", url, dest]
-            shell.run(cmd, check=True)
-        else:
-            default_branch = _local_default_branch(dest)
-            shell.run(["git", "checkout", default_branch], cwd=str(dest), check=True)
-            shell.run(["git", "pull"], cwd=str(dest), check=True)
+        import fcntl
+        lock_file = dest.parent / (dest.name + ".lock")
+        with open(lock_file, "w") as lock_f:
+            fcntl.flock(lock_f, fcntl.LOCK_EX)
+            try:
+                if not dest.exists():
+                    cmd = ["git", "clone", "--recurse-submodules", "--single-branch", url, dest]
+                    shell.run(cmd, check=True)
+                else:
+                    default_branch = _local_default_branch(dest)
+                    shell.run(["git", "checkout", default_branch], cwd=str(dest), check=True)
+                    shell.run(["git", "pull"], cwd=str(dest), check=True)
+            finally:
+                fcntl.flock(lock_f, fcntl.LOCK_UN)
         committish = committish or default_branch
 
     if committish:

--- a/synthtool/sources/git.py
+++ b/synthtool/sources/git.py
@@ -106,6 +106,7 @@ def clone(
         dest = dest / pathlib.Path(url).stem
 
     import fcntl
+
     lock_file = dest.parent / (dest.name + ".lock")
     with open(lock_file, "w") as lock_f:
         fcntl.flock(lock_f, fcntl.LOCK_EX)
@@ -116,11 +117,20 @@ def clone(
 
                 default_branch = None
                 if not dest.exists():
-                    cmd = ["git", "clone", "--recurse-submodules", "--single-branch", url, dest]
+                    cmd = [
+                        "git",
+                        "clone",
+                        "--recurse-submodules",
+                        "--single-branch",
+                        url,
+                        dest,
+                    ]
                     shell.run(cmd, check=True)
                 else:
                     default_branch = _local_default_branch(dest)
-                    shell.run(["git", "checkout", default_branch], cwd=str(dest), check=True)
+                    shell.run(
+                        ["git", "checkout", default_branch], cwd=str(dest), check=True
+                    )
                     shell.run(["git", "pull"], cwd=str(dest), check=True)
                 committish = committish or default_branch
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -87,6 +87,16 @@ class TestClone(unittest.TestCase):
         os.environ = self.env
         return super().tearDown()
 
+    @mock.patch("fcntl.flock")
+    def testCloneConcurrencyPatch(self, mock_flock):
+        import fcntl
+        metadata.reset()
+        local_directory = git.clone("https://github.com/googleapis/nodejs-vision.git")
+        self.assertTrue(mock_flock.called)
+        # Should be called with LOCK_EX then LOCK_UN
+        mock_flock.assert_any_call(mock.ANY, fcntl.LOCK_EX)
+        mock_flock.assert_any_call(mock.ANY, fcntl.LOCK_UN)
+
     def testClone(self):
         # clear out metadata before creating new metadata and asserting on it
         metadata.reset()

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -90,8 +90,10 @@ class TestClone(unittest.TestCase):
     @mock.patch("fcntl.flock")
     def testCloneConcurrencyPatch(self, mock_flock):
         import fcntl
+
         metadata.reset()
         local_directory = git.clone("https://github.com/googleapis/nodejs-vision.git")
+        self.assertEqual("nodejs-vision", local_directory.name)
         self.assertTrue(mock_flock.called)
         # Should be called with LOCK_EX then LOCK_UN
         mock_flock.assert_any_call(mock.ANY, fcntl.LOCK_EX)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -14,6 +14,7 @@
 
 import copy
 import importlib
+import fcntl
 import os
 import unittest
 from unittest import mock
@@ -89,8 +90,6 @@ class TestClone(unittest.TestCase):
 
     @mock.patch("fcntl.flock")
     def testCloneConcurrencyPatch(self, mock_flock):
-        import fcntl
-
         metadata.reset()
         local_directory = git.clone("https://github.com/googleapis/nodejs-vision.git")
         self.assertEqual("nodejs-vision", local_directory.name)


### PR DESCRIPTION
## Description
This PR introduces an fcntl.flock file lock around the git clone, git checkout, and git pull operations within synthtool.sources.git.clone.

Context & Motivation: As part of the transition away from using Docker for librarian generate on Python packages (via the removal of librarian.yaml), client library generation is now executed locally on the host machine.

When running librarian generate -v --all, generation tasks are executed concurrently across multiple packages. This concurrency introduces a race condition where multiple processes attempt to clone or pull the same shared repository in the synthtool cache simultaneously, resulting in git index.lock collision errors that fail the generation.

By applying an exclusive file lock (.lock) over the specific cache repository before manipulating it, we guarantee that concurrent librarian processes serialize their git operations safely and avoid index.lock collisions.

## Changes Made
Added an fcntl.flock block in synthtool/sources/git.py that surrounds the git clone, git checkout, and git pull subprocess calls.
Added testCloneConcurrencyPatch to tests/test_git.py using mock.patch to verify that the LOCK_EX and LOCK_UN calls are correctly executed during cloning.
Corrected the indentation block for the try/finally block to ensure synthtool parses it properly.