### PR TITLE
fix(php): continue searching sibling directories in _find_copy_target

### DIFF
--- a/synthtool/languages/php.py
+++ b/synthtool/languages/php.py
@@ -68,14 +68,13 @@ def _merge(src: str, dest: str, path: Path):
 def _find_copy_target(src: Path, version_string: str) -> typing.Optional[Path]:
     """Returns a directory contains the version subdirectory."""
     logger.debug("_find_copy_target called with %s and %s", src, version_string)
-    entries = os.scandir(src)
-    if not entries:
-        return None
-    for entry in entries:
-        if Path(entry.path).resolve().stem.lower() == version_string:
+    for entry in src.iterdir():
+        if entry.name.lower() == version_string:
             return src
         if entry.is_dir():
-            return _find_copy_target(Path(entry.path).resolve(), version_string)
+            target = _fixed_find_copy_target(entry, version_string)
+            if target is not None:
+                return target
     return None
 
 

--- a/synthtool/languages/php.py
+++ b/synthtool/languages/php.py
@@ -72,7 +72,7 @@ def _find_copy_target(src: Path, version_string: str) -> typing.Optional[Path]:
         if entry.name.lower() == version_string:
             return src
         if entry.is_dir():
-            target = _fixed_find_copy_target(entry, version_string)
+            target = _find_copy_target(entry, version_string)
             if target is not None:
                 return target
     return None

--- a/tests/test_php.py
+++ b/tests/test_php.py
@@ -20,6 +20,8 @@ import tempfile
 
 import pytest
 
+from synthtool.languages import php
+
 
 FIXTURES = Path(__file__).parent / "fixtures" / "php"
 
@@ -57,3 +59,43 @@ def get_diff_string(dcmp, buf=""):
     for sub_dcmp in dcmp.subdirs.values():
         buf += get_diff_string(sub_dcmp)
     return buf
+
+
+def test_find_copy_target_direct(tmp_path: Path):
+    (tmp_path / "V1").mkdir()
+    assert php._find_copy_target(tmp_path, "v1") == tmp_path
+
+
+def test_find_copy_target_in_sibling(tmp_path: Path):
+    sibling_empty = tmp_path / "sibling_empty"
+    sibling_empty.mkdir()
+
+    sibling_other = tmp_path / "sibling_other"
+    sibling_other.mkdir()
+    (sibling_other / "v2").mkdir()
+
+    sibling_match = tmp_path / "sibling_match"
+    sibling_match.mkdir()
+    (sibling_match / "V1").mkdir()
+
+    assert php._find_copy_target(tmp_path, "v1") == sibling_match
+
+
+def test_find_copy_target_nested(tmp_path: Path):
+    nested_dir = tmp_path / "a" / "b"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "v1beta1").mkdir()
+
+    assert php._find_copy_target(tmp_path, "v1beta1") == nested_dir
+
+
+def test_find_copy_target_not_found(tmp_path: Path):
+    nested_dir = tmp_path / "a" / "b"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "v2").mkdir()
+
+    assert php._find_copy_target(tmp_path, "v1") is None
+
+
+def test_find_copy_target_empty_dir(tmp_path: Path):
+    assert php._find_copy_target(tmp_path, "v1") is None


### PR DESCRIPTION
Previously, `_find_copy_target` unconditionally returned the result of the recursive call on the first subdirectory encountered. If that branch did not contain the version subdirectory, the search terminated early with `None` instead of inspecting sibling directories.

Switch to `Path.iterdir()` and only return early from the recursive call when a matching target is found.
